### PR TITLE
Fix duplicate File menu in menu bar

### DIFF
--- a/Neon Vision Editor/NeonVisionEditorApp.swift
+++ b/Neon Vision Editor/NeonVisionEditorApp.swift
@@ -94,23 +94,21 @@ struct NeonVisionEditorApp: App {
                     openWindow(id: "blank-window")
                 }
                 .keyboardShortcut("n", modifiers: .command)
-            }
-
-            CommandMenu("File") {
-                Button("New Window") {
-                    openWindow(id: "blank-window")
-                }
 
                 Button("New Tab") {
                     viewModel.addNewTab()
                 }
                 .keyboardShortcut("t", modifiers: .command)
+            }
 
+            CommandGroup(after: .newItem) {
                 Button("Open File...") {
                     viewModel.openFile()
                 }
                 .keyboardShortcut("o", modifiers: .command)
+            }
 
+            CommandGroup(replacing: .saveItem) {
                 Button("Save") {
                     if let tab = viewModel.selectedTab {
                         viewModel.saveFile(tab: tab)
@@ -131,6 +129,8 @@ struct NeonVisionEditorApp: App {
                     viewModel.renameText = viewModel.selectedTab?.name ?? "Untitled"
                 }
                 .disabled(viewModel.selectedTab == nil)
+
+                Divider()
 
                 Button("Close Tab") {
                     if let tab = viewModel.selectedTab {


### PR DESCRIPTION
## Summary
- Removed the separate `CommandMenu("File")` that created a second File menu alongside the default macOS one
- Injected all custom items (New Tab, Open, Save, Save As, Rename, Close Tab) into the built-in File menu using `CommandGroup` placements (`replacing: .newItem`, `after: .newItem`, `replacing: .saveItem`)
- Eliminated the duplicate "New Window" button that existed in both menus

## Test plan
- [ ] Verify only a single File menu appears in the menu bar
- [ ] Verify New Window, New Tab, Open, Save, Save As, Rename, and Close Tab all appear in the File menu
- [ ] Verify keyboard shortcuts (Cmd+N, Cmd+T, Cmd+O, Cmd+S, Cmd+W) work correctly

## Summary by Sourcery

Update the macOS app menu structure to rely on the built-in File menu while integrating the editor’s file-related commands.

Bug Fixes:
- Remove the duplicate File menu and redundant New Window entry from the macOS menu bar.

Enhancements:
- Integrate New Tab, Open, Save, Save As, Rename, and Close Tab actions into the standard macOS File menu using command groups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized the application menu structure to improve command organization and accessibility
  * Consolidated file operations into streamlined command groups with enhanced visual separation
  * Repositioned menu items to provide better navigation flow and improved command discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->