### PR TITLE
docs: add release checklist links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - Contributing guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Privacy: [`PRIVACY.md`](PRIVACY.md)
 - Security policy: [`SECURITY.md`](SECURITY.md)
+- Release checklists: [`release/`](release/) — TestFlight & App Store preflight docs
 
 ## What's New Since v0.4.32
 


### PR DESCRIPTION
## Summary
- add a README link to the release folder for TestFlight/App Store checklists

## Rationale
- makes release preflight docs discoverable from the main README (issue #17)

## Changes
- README: new bullet pointing to  checklists

## Tests
- not run (docs-only)

Fixes #17

## Summary by Sourcery

Documentation:
- Document the location of TestFlight and App Store release checklists in the main README for easier discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference to release checklists for TestFlight and App Store preflight procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->