### PR TITLE
Add common scientific text formats (.vasp, .xyz, .upf, .xsf, .isoviz) to supported extensions

### DIFF
--- a/Neon Vision Editor/Data/EditorViewModel.swift
+++ b/Neon Vision Editor/Data/EditorViewModel.swift
@@ -1658,7 +1658,7 @@ class EditorViewModel {
             "html", "htm", "ee", "exp", "tmpl", "css", "c", "cpp", "cc", "hpp", "hh", "h",
             "m", "mm", "cs", "json", "jsonc", "json5", "md", "markdown", "env", "proto",
             "graphql", "gql", "rst", "conf", "nginx", "cob", "cbl", "cobol", "sh", "bash", "zsh",
-            "tex", "latex", "bib", "sty", "cls"
+            "tex", "latex", "bib", "sty", "cls", "vasp", "isoviz", "upf", "xyz", "xsf"
         ]
         if knownSupportedExtensions.contains(ext) {
             return true


### PR DESCRIPTION
### What
Adds five plain-text file extensions used in computational physics / materials science to `knownSupportedExtensions` in `EditorViewModel.isSupportedEditorFileURL`:

- `.vasp` — VASP structure / input files
- `.isoviz` — ISOTROPY / ISODISTORT visualizer output
- `.upf` — Quantum ESPRESSO Unified Pseudopotential Format
- `.xyz` — XYZ molecular geometry format
- `.xsf` — XCrySDen Structure File

### Why
These are all human-readable text files but have no registered macOS UTI, so they fall through to the `UTType(filenameExtension:)` guard at line 1667 and trigger the "is not supported" alert. Users in computational science routinely edit these by hand and currently can't open them in Neon Vision Editor.

Follows the same pattern as the existing `.cif` / `.mcif` entries.

### Scope
Pure addition to a whitelist. No behavior change for any other file type. No new dependencies. Fits the project goal of "fast file opening" without expanding into IDE territory.

## Validation

Tested
Built locally with Xcode 26.4.1 on macOS 26 (Sign to Run Locally). Confirmed .vasp files now open as plain text in the editor instead of triggering the unsupported-file alert.

Refs # 82

## Summary by Sourcery

Enhancements:
- Add support for opening .vasp, .isoviz, .upf, .xyz, and .xsf files as plain-text in the editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editor now supports five additional file formats: VASP, ISOVIZ, UPF, XYZ, and XSF files can be opened directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->