### PR TITLE
Fix potential AppKit layout crash during markdown preview updates

### DIFF
--- a/Neon Vision Editor/UI/MarkdownPreviewWebView.swift
+++ b/Neon Vision Editor/UI/MarkdownPreviewWebView.swift
@@ -22,12 +22,23 @@ struct MarkdownPreviewWebView: NSViewRepresentable {
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         guard context.coordinator.lastHTML != html else { return }
-        context.coordinator.reloadPreservingScroll(webView: webView, html: html)
+        context.coordinator.scheduleReloadPreservingScroll(webView: webView, html: html)
         context.coordinator.lastHTML = html
     }
 
     final class Coordinator {
         var lastHTML: String = ""
+        private var pendingReload: DispatchWorkItem?
+
+        func scheduleReloadPreservingScroll(webView: WKWebView, html: String) {
+            pendingReload?.cancel()
+            let workItem = DispatchWorkItem { [weak webView] in
+                guard let webView else { return }
+                self.reloadPreservingScroll(webView: webView, html: html)
+            }
+            pendingReload = workItem
+            DispatchQueue.main.async(execute: workItem)
+        }
 
         func reloadPreservingScroll(webView: WKWebView, html: String) {
             let capture = "(() => { const max = Math.max(1, document.documentElement.scrollHeight - window.innerHeight); return window.scrollY / max; })();"


### PR DESCRIPTION
## Summary

Defers `WKWebView.loadHTMLString(...)` updates on macOS out of the immediate SwiftUI/AppKit update cycle.

This is a defensive fix targeting the crash reported in #101:

- `+[NSApplication _crashOnException:]`
- `___NSViewLayout_block_invoke`
- `_NSViewLayout`

## Changes

- Added deferred reload scheduling in `MarkdownPreviewWebView.Coordinator`
- Avoid immediate `WKWebView` reloads during `updateNSView`
- Added cancellation for pending reload work items to prevent stacked updates

## Why

`WKWebView.loadHTMLString(...)` during `updateNSView` can trigger nested layout/view updates while AppKit is already performing a layout pass.

macOS 26.5 Beta appears stricter about these mutations and may raise internal AppKit exceptions.

This patch moves the actual reload to the next main-thread cycle.

## Notes

This is intentionally a minimal, low-risk stabilization patch while further investigation continues around other `NSViewRepresentable` update paths.

Closes #101.

## Summary by Sourcery

Defer markdown preview WKWebView HTML reloads on macOS to avoid layout-related crashes during SwiftUI/AppKit update cycles.

Bug Fixes:
- Prevent potential AppKit layout crashes by scheduling WKWebView HTML reloads asynchronously instead of during updateNSView.
- Avoid stacked markdown preview reloads by cancelling any previously scheduled reload before enqueueing a new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance of markdown preview on macOS by optimizing how content updates are processed, reducing unnecessary reloads and providing a smoother viewing experience with maintained scroll position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->