### PR TITLE
feat: add OpenCode Go and custom OpenAI-compatible AI providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to **Neon Vision Editor** are documented in this file.
 
 The format follows *Keep a Changelog*. Versions use semantic versioning with prerelease tags.
 
+## [v0.7.9] - 2026-06-16
+
+### Why Upgrade
+- Adds OpenCode Go as a selectable AI provider for code completion.
+- Adds a custom OpenAI-compatible provider so any compatible endpoint, including local servers, can be used for completion.
+
+### Highlights
+- Added OpenCode Go (OpenCode Zen) as an AI provider using its OpenAI-compatible chat completions endpoint and the deepseek-v4-flash model.
+- Added a custom OpenAI-compatible provider with user-configured base URL, model, and optional API key, grouped in its own Settings section.
+- Added a shared OpenAI-compatible client used by both providers, with the API key stored in the system Keychain alongside the existing provider keys.
+- Added AI Activity Log diagnostics for failed or empty provider responses, including HTTP status and finish reason, so silent fallbacks are now visible.
+- OpenCode Go models perform reasoning before answering, so they respond slower than the other providers and suit on-demand Suggest Code more than inline completion.
+
+### Breaking changes
+- None.
+
+### Migration
+- None. Existing provider selection and stored API keys are unchanged.
+
+### Issues
+- [#151](https://github.com/h3pdesign/Neon-Vision-Editor/issues/151) `[Feature]: Support OpenCode Go for an AI Provider`
+
 ## [v0.7.8] - 2026-06-11
 
 ### Why Upgrade

--- a/Neon Vision Editor/AI/AIClient.swift
+++ b/Neon Vision Editor/AI/AIClient.swift
@@ -290,12 +290,121 @@ final class GrokAIClientStreaming: AIClient {
     }
 }
 
+// OpenAI-compatible client for endpoints that speak the v1 chat-completions
+// API (POST /v1/chat/completions, Bearer auth, choices[].message.content).
+// Used for OpenCode Go and user-configured custom providers. The base URL and
+// model are supplied per provider; an empty key sends no Authorization header
+// so local/keyless servers work.
+final class OpenAICompatibleAIClient: AIClient {
+    private let apiKey: String
+    private let baseURL: String
+    private let model: String
+
+    init(apiKey: String, baseURL: String, model: String) {
+        self.apiKey = apiKey
+        self.baseURL = baseURL
+        self.model = model
+    }
+
+    func streamSuggestions(prompt: String) -> AsyncStream<String> {
+        return AsyncStream { continuation in
+            let apiKey = self.apiKey
+            let model = self.model
+            let endpoint = OpenAICompatibleAIClient.chatCompletionsURL(from: self.baseURL)
+            Task {
+                do {
+                    guard let url = endpoint else {
+                        AIActivityLog.record("OpenAI-compatible: invalid base URL", level: .error, source: "Completion")
+                        continuation.finish()
+                        return
+                    }
+                    var request = URLRequest(url: url)
+                    request.httpMethod = "POST"
+                    if !apiKey.isEmpty {
+                        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+                    }
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    // OpenCode Zen models are reasoning models: they spend tokens
+                    // on reasoning_content before writing the answer to content.
+                    // The budget must cover reasoning AND the completion, or content
+                    // comes back empty with finish_reason "length".
+                    let body: [String: Any] = [
+                        "model": model,
+                        "messages": [["role": "user", "content": prompt]],
+                        "max_tokens": 1024
+                    ]
+                    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+                    let (data, response) = try await URLSession.shared.data(for: request)
+                    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+                        let bodyText = String(data: data, encoding: .utf8) ?? ""
+                        AIActivityLog.record("OpenAI-compatible request failed: HTTP \(status) (model \(model)) \(bodyText.prefix(300))", level: .error, source: "Completion")
+                        continuation.finish()
+                        return
+                    }
+                    if let text = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let choices = text["choices"] as? [[String: Any]],
+                       let first = choices.first,
+                       let msg = first["message"] as? [String: Any],
+                       let content = msg["content"] as? String, !content.isEmpty {
+                        continuation.yield(content)
+                    } else {
+                        // Empty content usually means the token budget was consumed by
+                        // reasoning before any answer was produced (finish_reason "length").
+                        let finishReason = ((try? JSONSerialization.jsonObject(with: data) as? [String: Any])?["choices"] as? [[String: Any]])?.first?["finish_reason"] as? String ?? "unknown"
+                        AIActivityLog.record("OpenAI-compatible: empty content (model \(model), finish_reason \(finishReason)); raise max_tokens or use a non-reasoning model", level: .warning, source: "Completion")
+                    }
+                } catch {
+                    AIActivityLog.record("OpenAI-compatible request error: \(error.localizedDescription)", level: .error, source: "Completion")
+                }
+                continuation.finish()
+            }
+        }
+    }
+
+    // Accepts either a full chat-completions URL or a base URL and normalizes to
+    // the v1 chat-completions endpoint.
+    static func chatCompletionsURL(from raw: String) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.hasSuffix("/chat/completions") {
+            return URL(string: trimmed)
+        }
+        let base = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
+        return URL(string: base + "/chat/completions")
+    }
+}
+
+// Fixed configuration for the hosted OpenCode Go (OpenCode Zen) endpoint. Like
+// the other providers, the model is fixed in code rather than user-selectable.
+// deepseek-v4-flash is chosen for the highest rate limits among the supported
+// models. Note: only the OpenAI-compatible models (GLM, DeepSeek, Kimi) work via
+// this /chat/completions client; MiniMax and Qwen use OpenCode's Anthropic-style
+// /v1/messages endpoint, so the default must stay an OpenAI-compatible model.
+// These are reasoning models (they spend a large token budget on reasoning before
+// the answer), so completion latency is high — best used on demand, not inline.
+// Available models: https://opencode.ai/zen/go/v1/models
+enum OpenCodeGoConfig {
+    static let baseURL = "https://opencode.ai/zen/go/v1"
+    static let defaultModel = "deepseek-v4-flash"
+}
+
+// UserDefaults keys for the user-configured custom OpenAI-compatible provider.
+enum CustomProviderConfig {
+    static let baseURLDefaultsKey = "CustomProviderBaseURL"
+    static let modelDefaultsKey = "CustomProviderModel"
+}
+
 struct AIClientFactory {
     static func makeClient(for model: AIModel,
                            grokAPITokenProvider: () -> String? = { nil },
                            openAIKeyProvider: () -> String? = { nil },
                            geminiKeyProvider: () -> String? = { nil },
-                           anthropicKeyProvider: () -> String? = { nil }) -> AIClient? {
+                           anthropicKeyProvider: () -> String? = { nil },
+                           openCodeGoKeyProvider: () -> String? = { nil },
+                           customKeyProvider: () -> String? = { nil },
+                           customBaseURLProvider: () -> String? = { nil },
+                           customModelProvider: () -> String? = { nil }) -> AIClient? {
         switch model {
         case .appleIntelligence:
             // Default to Apple Intelligence client
@@ -322,6 +431,21 @@ struct AIClientFactory {
             if let key = anthropicKeyProvider()?.trimmingCharacters(in: .whitespacesAndNewlines), !key.isEmpty {
                 return AnthropicAIClient(apiKey: key)
             }
+            return AppleIntelligenceAIClient()
+        case .openCodeGo:
+            if let key = openCodeGoKeyProvider()?.trimmingCharacters(in: .whitespacesAndNewlines), !key.isEmpty {
+                return OpenAICompatibleAIClient(apiKey: key, baseURL: OpenCodeGoConfig.baseURL, model: OpenCodeGoConfig.defaultModel)
+            }
+            // Fallback to Apple Intelligence when no OpenCode Go key.
+            return AppleIntelligenceAIClient()
+        case .customProvider:
+            let key = customKeyProvider()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let baseURL = customBaseURLProvider()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let model = customModelProvider()?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !baseURL.isEmpty, !model.isEmpty {
+                return OpenAICompatibleAIClient(apiKey: key, baseURL: baseURL, model: model)
+            }
+            // Fallback to Apple Intelligence until a base URL and model are configured.
             return AppleIntelligenceAIClient()
         }
     }

--- a/Neon Vision Editor/App/AppMenus.swift
+++ b/Neon Vision Editor/App/AppMenus.swift
@@ -468,6 +468,10 @@ struct NeonVisionMacAppCommands: Commands {
             let openAIToken = SecureTokenStore.token(for: .openAI)
             let geminiToken = SecureTokenStore.token(for: .gemini)
             let anthropicToken = SecureTokenStore.token(for: .anthropic)
+            let openCodeGoToken = SecureTokenStore.token(for: .openCodeGo)
+            let customToken = SecureTokenStore.token(for: .customProvider)
+            let customBaseURL = UserDefaults.standard.string(forKey: CustomProviderConfig.baseURLDefaultsKey) ?? ""
+            let customModel = UserDefaults.standard.string(forKey: CustomProviderConfig.modelDefaultsKey) ?? ""
 
             var providerLabel = "Unknown"
             let client: AIClient? = {
@@ -492,6 +496,18 @@ struct NeonVisionMacAppCommands: Commands {
                 if !anthropicToken.isEmpty {
                     providerLabel = "Anthropic"
                     return AIClientFactory.makeClient(for: .anthropic, anthropicKeyProvider: { anthropicToken })
+                }
+                if !openCodeGoToken.isEmpty {
+                    providerLabel = "OpenCode Go"
+                    return AIClientFactory.makeClient(for: .openCodeGo,
+                                                      openCodeGoKeyProvider: { openCodeGoToken })
+                }
+                if !customBaseURL.isEmpty && !customModel.isEmpty {
+                    providerLabel = "Custom Provider"
+                    return AIClientFactory.makeClient(for: .customProvider,
+                                                      customKeyProvider: { customToken },
+                                                      customBaseURLProvider: { customBaseURL },
+                                                      customModelProvider: { customModel })
                 }
                 #if USE_FOUNDATION_MODELS && canImport(FoundationModels)
                 providerLabel = "Apple Intelligence (fallback)"

--- a/Neon Vision Editor/Data/SecureTokenStore.swift
+++ b/Neon Vision Editor/Data/SecureTokenStore.swift
@@ -8,6 +8,8 @@ enum APITokenKey: String, CaseIterable {
     case openAI
     case gemini
     case anthropic
+    case openCodeGo
+    case customProvider
 
     var account: String {
         switch self {
@@ -15,6 +17,8 @@ enum APITokenKey: String, CaseIterable {
         case .openAI: return "OpenAIAPIToken"
         case .gemini: return "GeminiAPIToken"
         case .anthropic: return "AnthropicAPIToken"
+        case .openCodeGo: return "OpenCodeGoAPIToken"
+        case .customProvider: return "CustomProviderAPIToken"
         }
     }
 }

--- a/Neon Vision Editor/Models/AIModel.swift
+++ b/Neon Vision Editor/Models/AIModel.swift
@@ -15,6 +15,8 @@ public enum AIModel: String, CaseIterable, Identifiable {
     case openAI
     case gemini
     case anthropic
+    case openCodeGo
+    case customProvider
 
     public var id: String { rawValue }
 
@@ -25,6 +27,8 @@ public enum AIModel: String, CaseIterable, Identifiable {
         case .openAI: return "OpenAI"
         case .gemini: return "Gemini"
         case .anthropic: return "Anthropic"
+        case .openCodeGo: return "OpenCode Go"
+        case .customProvider: return "Custom (OpenAI-compatible)"
         }
     }
 }

--- a/Neon Vision Editor/UI/ContentView+AICompletion.swift
+++ b/Neon Vision Editor/UI/ContentView+AICompletion.swift
@@ -381,7 +381,11 @@ extension ContentView {
             grokAPITokenProvider: { grokAPIToken },
             openAIKeyProvider: { openAIAPIToken },
             geminiKeyProvider: { geminiAPIToken },
-            anthropicKeyProvider: { anthropicAPIToken }
+            anthropicKeyProvider: { anthropicAPIToken },
+            openCodeGoKeyProvider: { SecureTokenStore.token(for: .openCodeGo) },
+            customKeyProvider: { SecureTokenStore.token(for: .customProvider) },
+            customBaseURLProvider: { UserDefaults.standard.string(forKey: CustomProviderConfig.baseURLDefaultsKey) },
+            customModelProvider: { UserDefaults.standard.string(forKey: CustomProviderConfig.modelDefaultsKey) }
         ) ?? AppleIntelligenceAIClient()
 
         let providerLabel: String
@@ -402,6 +406,14 @@ extension ContentView {
         case .anthropic:
             providerLabel = "Anthropic"
             isUsingConfiguredProvider = !anthropicAPIToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .openCodeGo:
+            providerLabel = "OpenCode Go"
+            isUsingConfiguredProvider = !SecureTokenStore.token(for: .openCodeGo).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .customProvider:
+            providerLabel = "Custom Provider"
+            let baseURL = (UserDefaults.standard.string(forKey: CustomProviderConfig.baseURLDefaultsKey) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            let model = (UserDefaults.standard.string(forKey: CustomProviderConfig.modelDefaultsKey) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            isUsingConfiguredProvider = !baseURL.isEmpty && !model.isEmpty
         }
 
         let candidate = await completionFromClient(client, prompt: prompt)

--- a/Neon Vision Editor/UI/NeonSettingsView.swift
+++ b/Neon Vision Editor/UI/NeonSettingsView.swift
@@ -235,6 +235,10 @@ struct NeonSettingsView: View {
     @State private var openAIAPIToken: String = ""
     @State private var geminiAPIToken: String = ""
     @State private var anthropicAPIToken: String = ""
+    @State private var openCodeGoAPIToken: String = ""
+    @State private var customProviderAPIToken: String = ""
+    @AppStorage(CustomProviderConfig.baseURLDefaultsKey) private var customProviderBaseURL: String = ""
+    @AppStorage(CustomProviderConfig.modelDefaultsKey) private var customProviderModel: String = ""
     @State private var showSupportPurchaseDialog: Bool = false
     @State private var showDataDisclosureDialog: Bool = false
     @State private var showRemoteConnectSheet: Bool = false
@@ -1025,6 +1029,8 @@ struct NeonSettingsView: View {
         if openAIAPIToken.isEmpty { openAIAPIToken = SecureTokenStore.token(for: .openAI) }
         if geminiAPIToken.isEmpty { geminiAPIToken = SecureTokenStore.token(for: .gemini) }
         if anthropicAPIToken.isEmpty { anthropicAPIToken = SecureTokenStore.token(for: .anthropic) }
+        if openCodeGoAPIToken.isEmpty { openCodeGoAPIToken = SecureTokenStore.token(for: .openCodeGo) }
+        if customProviderAPIToken.isEmpty { customProviderAPIToken = SecureTokenStore.token(for: .customProvider) }
     }
 
     private var preferredColorSchemeOverride: ColorScheme? {
@@ -4088,6 +4094,8 @@ struct NeonSettingsView: View {
                     Text("OpenAI").tag(AIModel.openAI)
                     Text("Gemini").tag(AIModel.gemini)
                     Text("Anthropic").tag(AIModel.anthropic)
+                    Text("OpenCode Go").tag(AIModel.openCodeGo)
+                    Text("Custom (OpenAI-compatible)").tag(AIModel.customProvider)
                 }
                 .neonSettingsDropdown(maxWidth: .infinity)
                 .accessibilityLabel("Model")
@@ -4114,6 +4122,22 @@ struct NeonSettingsView: View {
                     aiKeyRow(title: "OpenAI", placeholder: "sk-…", value: $openAIAPIToken, provider: .openAI)
                     aiKeyRow(title: "Gemini", placeholder: "AIza…", value: $geminiAPIToken, provider: .gemini)
                     aiKeyRow(title: "Anthropic", placeholder: "sk-ant-…", value: $anthropicAPIToken, provider: .anthropic)
+                    aiKeyRow(title: "OpenCode Go", placeholder: "sk-…", value: $openCodeGoAPIToken, provider: .openCodeGo)
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            settingsCardSection(
+                title: "Custom Provider",
+                icon: "network",
+                emphasis: .secondary,
+                tip: "Any OpenAI-compatible endpoint (v1 chat completions). The key is optional and stored in the system Keychain."
+            ) {
+                VStack(alignment: .center, spacing: UI.space12) {
+                    aiTextRow(title: "Base URL", placeholder: "https://host/v1", value: $customProviderBaseURL)
+                    aiTextRow(title: "Model", placeholder: "model-id", value: $customProviderModel)
+                    aiKeyRow(title: "API Key", placeholder: "optional", value: $customProviderAPIToken, provider: .customProvider)
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
             }
@@ -4127,6 +4151,8 @@ struct NeonSettingsView: View {
                         Text("OpenAI").tag(AIModel.openAI)
                         Text("Gemini").tag(AIModel.gemini)
                         Text("Anthropic").tag(AIModel.anthropic)
+                        Text("OpenCode Go").tag(AIModel.openCodeGo)
+                        Text("Custom (OpenAI-compatible)").tag(AIModel.customProvider)
                     }
                     .neonSettingsDropdown(maxWidth: 260)
                     .accessibilityLabel("Model")
@@ -4150,6 +4176,22 @@ struct NeonSettingsView: View {
                     aiKeyRow(title: "OpenAI", placeholder: "sk-…", value: $openAIAPIToken, provider: .openAI)
                     aiKeyRow(title: "Gemini", placeholder: "AIza…", value: $geminiAPIToken, provider: .gemini)
                     aiKeyRow(title: "Anthropic", placeholder: "sk-ant-…", value: $anthropicAPIToken, provider: .anthropic)
+                    aiKeyRow(title: "OpenCode Go", placeholder: "sk-…", value: $openCodeGoAPIToken, provider: .openCodeGo)
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(UI.groupPadding)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            GroupBox("Custom Provider") {
+                VStack(alignment: .center, spacing: UI.space12) {
+                    Text("Any OpenAI-compatible endpoint (v1 chat completions). The key is optional and stored in the system Keychain.")
+                        .font(Typography.footnote)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    aiTextRow(title: "Base URL", placeholder: "https://host/v1", value: $customProviderBaseURL)
+                    aiTextRow(title: "Model", placeholder: "model-id", value: $customProviderModel)
+                    aiKeyRow(title: "API Key", placeholder: "optional", value: $customProviderAPIToken, provider: .customProvider)
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(UI.groupPadding)
@@ -5076,6 +5118,53 @@ struct NeonSettingsView: View {
                         .onChange(of: value.wrappedValue) { _, new in
                             SecureTokenStore.setToken(new, for: provider)
                         }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: isCompactSettingsLayout ? .leading : .center)
+    }
+
+    // Plain-text settings row for non-secret provider config (base URL, model).
+    // The binding is persisted by its @AppStorage source, so no extra write here.
+    private func aiTextRow(title: String, placeholder: String, value: Binding<String>) -> some View {
+        Group {
+            if isCompactSettingsLayout {
+                VStack(alignment: .leading, spacing: UI.space8) {
+                    Text(title)
+                    TextField(placeholder, text: value)
+                        .textFieldStyle(.plain)
+                        .padding(.vertical, UI.space6)
+                        .padding(.horizontal, UI.space8)
+                        .background(inputFieldBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: UI.fieldCorner)
+                                .stroke(Color.secondary.opacity(0.35), lineWidth: 1)
+                        )
+                        .cornerRadius(UI.fieldCorner)
+#if os(iOS) || os(visionOS)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+#endif
+                }
+            } else {
+                HStack(spacing: UI.space12) {
+                    Text(title)
+                        .frame(width: standardLabelWidth, alignment: .leading)
+                    TextField(placeholder, text: value)
+                        .textFieldStyle(.plain)
+                        .padding(.vertical, UI.space6)
+                        .padding(.horizontal, UI.space8)
+                        .background(inputFieldBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: UI.fieldCorner)
+                                .stroke(Color.secondary.opacity(0.35), lineWidth: 1)
+                        )
+                        .cornerRadius(UI.fieldCorner)
+                        .frame(maxWidth: 360)
+#if os(iOS) || os(visionOS)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+#endif
                 }
             }
         }


### PR DESCRIPTION
## Summary

- What changed: Added OpenCode Go (OpenCode Zen) and a custom OpenAI-compatible provider as selectable AI providers for code completion.
- Why: Requested in #151. Enables OpenCode Go and any OpenAI-compatible or local endpoint for completion.
- Scope: Feature
- Linked issue/milestone: #151

## Validation

- [x] Built on macOS (macOS 27 beta, Xcode 27 beta)
- [x] Built on iOS simulator
- [x] Built on iPad simulator
- [x] Tested key flow manually (OpenCode Go endpoint verified working on macOS)
- [ ] Repro steps included (for bug/regression fixes)
- [ ] Expected vs actual behavior documented (for bug/regression fixes)

## Checklist

- [x] Accessibility checked (new rows reuse existing key/text row patterns; picker keeps its accessibility label)
- [x] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [x] VoiceOver impact evaluated (Settings picker and rows only)
- [x] Changelog updated (if user-facing change)
- [x] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

## Risk

- Risk level: Low
- User-facing risk: New optional providers. Default behavior is unchanged and unconfigured providers fall back to Apple Intelligence as before.
- Rollback plan: Revert this commit.

## Notes

- OpenCode Go uses the OpenAI-compatible chat completions endpoint with the deepseek-v4-flash model, chosen for the highest rate limits among the supported models. Only OpenAI-compatible models (GLM, DeepSeek, Kimi) work through this client; MiniMax and Qwen use OpenCode's Anthropic-style endpoint, so the default stays an OpenAI-compatible model.
- OpenCode Go models perform reasoning before answering, so they respond slower than the other providers and suit on-demand Suggest Code more than inline completion. The token budget accounts for reasoning output.
- AI completion remains a macOS feature in this app. This change does not add iOS completion, matching the existing behavior.
- The changelog entry is filed under v0.7.9. Renumber at release time if preferred.

## Summary by Sourcery

Add new AI providers for code completion and expose configuration in settings.

New Features:
- Introduce an OpenAI-compatible AI client used by multiple providers for chat-completion based code suggestions.
- Add OpenCode Go as a selectable AI provider for code completion, with its token stored securely.
- Add a configurable custom OpenAI-compatible provider that can target arbitrary or local endpoints via user-specified base URL and model.

Enhancements:
- Extend AI model selection and completion plumbing to recognize the new providers and fall back to Apple Intelligence when they are unconfigured.
- Persist custom provider connection details in user defaults and integrate them into macOS menus and completion flows.

Documentation:
- Document the new OpenCode Go and custom OpenAI-compatible providers in the changelog, including motivation and behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCode Go as a selectable AI provider for code suggestions
  * Added support for custom OpenAI-compatible endpoints with configurable base URL, model, and API key
  * Added diagnostics logging to track AI provider response issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->