### PR TITLE
Fix iOS status overlay type checking

### DIFF
--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -4047,11 +4047,7 @@ struct ContentView: View {
         }
 #if os(iOS) || os(visionOS)
         .overlay(alignment: .bottomTrailing) {
-            if !brainDumpLayoutEnabled && !shouldPinFloatingStatusToTop {
-                floatingStatusPill
-                    .padding(.trailing, 12)
-                    .padding(.bottom, 12)
-            }
+            mobileFloatingStatusOverlay
         }
 #endif
         .onChange(of: currentLanguage) { _, newLanguage in
@@ -4075,6 +4071,17 @@ struct ContentView: View {
         )
 #endif
     }
+
+#if os(iOS) || os(visionOS)
+    @ViewBuilder
+    private var mobileFloatingStatusOverlay: some View {
+        if !brainDumpLayoutEnabled && !shouldPinFloatingStatusToTop {
+            floatingStatusPill
+                .padding(.trailing, 12)
+                .padding(.bottom, 12)
+        }
+    }
+#endif
 
     private var largeFileLoadingPlaceholder: some View {
         VStack(spacing: 14) {


### PR DESCRIPTION
Fixes the Xcode 26.5 iOS Simulator compiler timeout in ContentView by extracting the mobile floating status overlay from the main editor view expression.

## Summary by Sourcery

Enhancements:
- Introduce a reusable mobileFloatingStatusOverlay view for conditional display of the floating status pill on iOS and visionOS.