### PR TITLE
Highlight critical crash report details

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,8 @@
 name: CodeQL
 
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   schedule:

--- a/Neon Vision Editor/Core/AppleCrashReportParser.swift
+++ b/Neon Vision Editor/Core/AppleCrashReportParser.swift
@@ -73,7 +73,11 @@ enum AppleCrashReportParser {
             if summaryKeys.contains(normalizedKey) {
                 summary.append(entry(key: key, value: value, severity: .info, index: index))
             } else if failureKeys.contains(normalizedKey) {
-                let severity: AppleCrashReportSeverity = normalizedKey == "exception type" || normalizedKey == "termination reason" ? .critical : .warning
+                let criticalFailureKeys: Set<String> = [
+                    "exception type", "exception codes", "exception subtype",
+                    "termination reason", "termination signal", "crashed thread"
+                ]
+                let severity: AppleCrashReportSeverity = criticalFailureKeys.contains(normalizedKey) ? .critical : .warning
                 failure.append(entry(key: key, value: value, severity: severity, index: index))
             }
         }
@@ -156,10 +160,10 @@ enum AppleCrashReportParser {
 
         var failure: [AppleCrashReportEntry] = []
         appendJSONValue(report, path: ["exception", "type"], label: "Exception Type", to: &failure, severity: .critical)
-        appendJSONValue(report, path: ["exception", "codes"], label: "Exception Codes", to: &failure, severity: .warning)
+        appendJSONValue(report, path: ["exception", "codes"], label: "Exception Codes", to: &failure, severity: .critical)
         appendJSONValue(report, path: ["termination", "namespace"], label: "Termination Namespace", to: &failure, severity: .critical)
         appendJSONValue(report, path: ["termination", "reason"], label: "Termination Reason", to: &failure, severity: .critical)
-        appendJSONValue(report, path: ["faultingThread"], label: "Crashed Thread", to: &failure, severity: .warning)
+        appendJSONValue(report, path: ["faultingThread"], label: "Crashed Thread", to: &failure, severity: .critical)
 
         var sections: [AppleCrashReportSection] = []
         if !summary.isEmpty {

--- a/Neon Vision Editor/UI/ContentView+StructuredData.swift
+++ b/Neon Vision Editor/UI/ContentView+StructuredData.swift
@@ -323,27 +323,7 @@ extension ContentView {
                     ForEach(crashReportSections) { section in
                         Section(section.title) {
                             ForEach(section.entries) { entry in
-                                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                                    Text(entry.key)
-                                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                                        .frame(minWidth: 110, alignment: .leading)
-                                    Text(entry.value)
-                                        .font(.system(size: 12, design: .monospaced))
-                                        .lineLimit(3)
-                                        .foregroundStyle(.secondary)
-                                    Spacer(minLength: 0)
-                                    Text(entry.severity.rawValue.uppercased())
-                                        .font(.system(size: 9, weight: .bold, design: .monospaced))
-                                        .foregroundStyle(crashReportSeverityColor(entry.severity))
-                                        .padding(.horizontal, 5)
-                                        .padding(.vertical, 2)
-                                        .background(
-                                            Capsule(style: .continuous)
-                                                .fill(crashReportSeverityColor(entry.severity).opacity(0.16))
-                                        )
-                                }
-                                .accessibilityLabel("\(entry.key), \(entry.severity.rawValue)")
-                                .accessibilityValue(entry.value)
+                                crashReportEntryView(entry)
                             }
                         }
                     }
@@ -379,6 +359,47 @@ extension ContentView {
         case .warning: return .orange
         case .info: return .blue
         }
+    }
+
+    private func crashReportEntryView(_ entry: AppleCrashReportEntry) -> some View {
+        let severityColor = crashReportSeverityColor(entry.severity)
+        let isCrashCause = entry.severity == .critical
+        return HStack(alignment: .firstTextBaseline, spacing: 8) {
+            if isCrashCause {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(severityColor)
+                    .accessibilityHidden(true)
+            }
+            Text(entry.key)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundStyle(isCrashCause ? severityColor : .primary)
+                .frame(minWidth: isCrashCause ? 86 : 110, alignment: .leading)
+            Text(entry.value)
+                .font(.system(size: 12, design: .monospaced))
+                .lineLimit(3)
+                .foregroundStyle(isCrashCause ? severityColor : .secondary)
+            Spacer(minLength: 0)
+            Text(entry.severity.rawValue.uppercased())
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .foregroundStyle(severityColor)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(severityColor.opacity(0.16))
+                )
+        }
+        .padding(.vertical, isCrashCause ? 3 : 0)
+        .padding(.horizontal, isCrashCause ? 5 : 0)
+        .background {
+            if isCrashCause {
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(severityColor.opacity(0.10))
+            }
+        }
+        .accessibilityLabel("\(entry.key), \(entry.severity.rawValue)")
+        .accessibilityValue(entry.value)
     }
 
     private func plistKindColor(_ kind: String) -> Color {

--- a/Neon Vision EditorTests/LanguageDetectorTests.swift
+++ b/Neon Vision EditorTests/LanguageDetectorTests.swift
@@ -129,7 +129,10 @@ final class LanguageDetectorTests: XCTestCase {
         let result = Neon_Vision_Editor.LanguageDetector.shared.detect(text: report, name: "report.txt", fileURL: URL(fileURLWithPath: "/tmp/report.txt"))
         XCTAssertEqual(result.lang, "crashlog")
         XCTAssertTrue(Neon_Vision_Editor.AppleCrashReportParser.looksLikeAppleCrashReport(report))
-        XCTAssertEqual(Neon_Vision_Editor.AppleCrashReportParser.sections(from: report).map(\.title), ["Summary", "Crash Cause", "Threads", "Binary Images"])
+        let sections = Neon_Vision_Editor.AppleCrashReportParser.sections(from: report)
+        XCTAssertEqual(sections.map(\.title), ["Summary", "Crash Cause", "Threads", "Binary Images"])
+        let causeEntries = sections.first(where: { $0.title == "Crash Cause" })?.entries ?? []
+        XCTAssertTrue(causeEntries.allSatisfy { $0.severity == .critical })
     }
 
     func testDetectsTimestampedTextLogsWithoutMisclassifyingProse() {


### PR DESCRIPTION
Highlights causal crash-report fields in the structured summary and runs CodeQL on pushes to main.

## Summary by Sourcery

Emphasize critical crash cause information in Apple crash report summaries and tighten CI security analysis coverage on the main branch.

Enhancements:
- Highlight critical crash-report fields in the structured summary with distinct styling and iconography to emphasize crash causes.
- Adjust crash report parsing to classify additional failure fields as critical severity for clearer root-cause identification.

CI:
- Run CodeQL analysis on pushes to the main branch in addition to pull requests.

Tests:
- Extend crash report detection tests to assert that all entries in the "Crash Cause" section are marked as critical severity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Apple crash reports now identify more crash-cause fields as critical.
  - Critical crash details are displayed with clearer visual emphasis in the report summary.

- **Bug Fixes**
  - Corrected the severity classification for exception codes and related crash information.

- **Quality**
  - Expanded validation to ensure crash-cause entries receive the correct severity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->