### PR TITLE
Revise next release target and update version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 > Status: **active release**  
 > Latest release: **v1.0.2**
-> Next release target: **v1.0.3**
+> Next release target: **v1.1**
 > Platform target: **macOS 26 (Tahoe)** compatible with **macOS Sequoia**
 > Apple Silicon: tested / Intel: not tested
 > Direct GitHub release: **v1.0.2** / App Store and TestFlight availability varies by platform and review status
@@ -220,8 +220,8 @@ The direct GitHub release is currently ahead of the App Store version. The App S
 |---|---|---|---|---|---|
 | **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.0.2** | Current direct download |
 | **Store** | iOS / iPadOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v0.7.8** | Current public App Store listing |
-| **Store** | macOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v0.8.6** | Current public App Store listing |
-| **Store** | visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v0.8.8** | Current public App Store listing |
+| **Store** | macOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v0.9.8** | Current public App Store listing |
+| **Store** | visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.0.2** | Current public App Store listing |
 | **Store Review** | iOS / iPadOS | Upcoming App Store update | App Store Connect review | **v1.0.2** | In Apple review |
 | **Beta** | iOS / iPadOS / macOS | Testing upcoming changes before stable | [TestFlight Invite](https://testflight.apple.com/join/YWB2fGAP) | **v1.0.2** | Early access builds for feedback; availability may vary by review state |
 


### PR DESCRIPTION
Updated next release target and version numbers for macOS and visionOS in the README.

## Summary

- What changed:
- Why:
- Scope: Bugfix / Feature / Docs / Release
- Linked issue/milestone:

## Validation

- [x] Built on macOS
- [x] Built on iOS simulator
- [x] Built on iPad simulator
- [x] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

## Checklist

- [ ] Accessibility checked (labels, focus order, no traps)
- [x] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [x] VoiceOver impact evaluated (if UI touched)
- [x] Changelog updated (if user-facing change)
- [x] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

## Risk

- Risk level: Low / Medium / High
- User-facing risk:
- Rollback plan:

## Summary by Sourcery

Documentation:
- Revise README to set the next release target to v1.1 and align macOS and visionOS App Store version numbers with current releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the release roadmap to target version v1.1.
  - Updated the listed Store versions for macOS and visionOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->