### PR TITLE
ci: make release reruns idempotent

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,7 +4,7 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-if [[ "${NVE_SKIP_BUILD_NUMBER_BUMP:-0}" == "1" ]]; then
+if [[ "${NVE_SKIP_BUILD_NUMBER_BUMP:-0}" == "1" || "${NVE_BUMP_BUILD_NUMBER:-0}" != "1" ]]; then
   exit 0
 fi
 

--- a/.github/workflows/release-github-only.yml
+++ b/.github/workflows/release-github-only.yml
@@ -460,17 +460,42 @@ jobs:
           if gh_retry gh release view "$TAG_NAME" >/dev/null 2>&1; then
             existing_is_draft="$(gh_retry gh release view "$TAG_NAME" --json isDraft --jq '.isDraft')"
             existing_assets="$(gh_retry gh release view "$TAG_NAME" --json assets --jq '.assets[].name')"
+            missing_assets=()
             for asset in Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg SHA256SUMS.txt; do
-              if printf '%s\n' "$existing_assets" | grep -Fx "$asset" >/dev/null; then
-                if [[ "$OVERWRITE_ASSETS" != "true" && "$existing_is_draft" != "true" ]]; then
-                  echo "Release ${TAG_NAME} already has asset ${asset}. Enable overwrite_assets to replace it." >&2
-                  exit 1
-                fi
+              if ! printf '%s\n' "$existing_assets" | grep -Fx "$asset" >/dev/null; then
+                missing_assets+=("$asset")
               fi
             done
 
             if [[ "$OVERWRITE_ASSETS" == "true" ]]; then
               bash scripts/preserve_release_download_baseline.sh "$TAG_NAME" release-notes.md
+              gh_retry gh release edit "$TAG_NAME" \
+                --title "Neon Vision Editor ${TAG_NAME}" \
+                --notes-file release-notes.md \
+                --draft=true \
+                "${RELEASE_FLAGS[@]}"
+              gh_retry gh release upload "$TAG_NAME" \
+                Neon.Vision.Editor.app.zip \
+                Neon.Vision.Editor.app.dmg \
+                SHA256SUMS.txt \
+                --clobber
+              printf 'assets_reused=false\n' >> "$GITHUB_OUTPUT"
+            elif (( ${#missing_assets[@]} == 0 )); then
+              echo "Release ${TAG_NAME} already contains all verified assets; reusing them idempotently."
+              printf 'assets_reused=true\n' >> "$GITHUB_OUTPUT"
+            else
+              echo "Release ${TAG_NAME} is missing assets: ${missing_assets[*]}"
+              gh_retry gh release edit "$TAG_NAME" \
+                --title "Neon Vision Editor ${TAG_NAME}" \
+                --notes-file release-notes.md \
+                --draft=true \
+                "${RELEASE_FLAGS[@]}"
+              gh_retry gh release upload "$TAG_NAME" \
+                Neon.Vision.Editor.app.zip \
+                Neon.Vision.Editor.app.dmg \
+                SHA256SUMS.txt \
+                --clobber
+              printf 'assets_reused=false\n' >> "$GITHUB_OUTPUT"
             fi
           else
             if ! gh_retry gh release create "$TAG_NAME" \
@@ -480,17 +505,18 @@ jobs:
               "${RELEASE_FLAGS[@]}"; then
               gh_retry gh release view "$TAG_NAME" >/dev/null
             fi
+            gh_retry gh release edit "$TAG_NAME" \
+              --title "Neon Vision Editor ${TAG_NAME}" \
+              --notes-file release-notes.md \
+              --draft=true \
+              "${RELEASE_FLAGS[@]}"
+            gh_retry gh release upload "$TAG_NAME" \
+              Neon.Vision.Editor.app.zip \
+              Neon.Vision.Editor.app.dmg \
+              SHA256SUMS.txt \
+              --clobber
+            printf 'assets_reused=false\n' >> "$GITHUB_OUTPUT"
           fi
-          gh_retry gh release edit "$TAG_NAME" \
-            --title "Neon Vision Editor ${TAG_NAME}" \
-            --notes-file release-notes.md \
-            --draft=true \
-            "${RELEASE_FLAGS[@]}"
-          gh_retry gh release upload "$TAG_NAME" \
-            Neon.Vision.Editor.app.zip \
-            Neon.Vision.Editor.app.dmg \
-            SHA256SUMS.txt \
-            --clobber
 
       - name: Verify uploaded release assets
         if: ${{ !(inputs.dry_run || false) }}
@@ -577,7 +603,7 @@ jobs:
           gh_retry gh release edit "$TAG_NAME" --draft=false "${RELEASE_FLAGS[@]}"
 
       - name: Generate and publish signed Sparkle appcast
-        if: ${{ !(inputs.dry_run || false) }}
+        if: ${{ !(inputs.dry_run || false) && steps.upload_release_assets.outputs.assets_reused != 'true' }}
         id: publish_appcast
         env:
           APPCAST_PATH: ${{ runner.temp }}/appcast.xml
@@ -667,7 +693,7 @@ jobs:
           printf 'build=%s\n' "$appcast_build" >> "$GITHUB_OUTPUT"
 
       - name: Trigger post-release updates
-        if: ${{ !(inputs.dry_run || false) && (inputs.trigger_post_release_updates || github.event_name == 'push') }}
+        if: ${{ !(inputs.dry_run || false) && steps.upload_release_assets.outputs.assets_reused != 'true' && (inputs.trigger_post_release_updates || github.event_name == 'push') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_BOT_TOKEN: ${{ secrets.TAP_BOT_TOKEN }}

--- a/.github/workflows/release-github-only.yml
+++ b/.github/workflows/release-github-only.yml
@@ -2,6 +2,9 @@ name: Release macOS app (GitHub-only)
 run-name: github-only release ${{ inputs.tag || github.ref_name }}
 
 on:
+  push:
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       tag:

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -7,4 +7,4 @@ cd "$repo_root"
 chmod +x .githooks/pre-commit scripts/bump_build_number.sh
 git config core.hooksPath .githooks
 
-echo "Git hooks installed. pre-commit will auto-bump CURRENT_PROJECT_VERSION."
+echo "Git hooks installed. Release preparation controls CURRENT_PROJECT_VERSION; set NVE_BUMP_BUILD_NUMBER=1 only for an intentional manual bump."


### PR DESCRIPTION
## Summary
- Reuse already verified release assets on reruns instead of failing on existing assets.
- Skip appcast and post-release dispatches when assets are reused.
- Stop automatic build-number mutations on ordinary commits.

## Verification
- Workflow YAML parsed successfully.
- Shell syntax checks passed.
- `git diff --check` passed.
- No Xcode build required; changes are CI and Git hook only.

## Summary by Sourcery

Make GitHub release workflow reruns idempotent by reusing existing verified assets and gating downstream release steps on asset reuse, while clarifying build-number bump behavior in Git hooks.

Enhancements:
- Reuse existing release assets on reruns when all required artifacts are already present, avoiding failures on existing assets.
- Gate Sparkle appcast generation and post-release update triggers so they only run when assets are freshly uploaded rather than reused.
- Clarify that automatic CURRENT_PROJECT_VERSION bumps are no longer done on every commit and must be explicitly requested via NVE_BUMP_BUILD_NUMBER during release preparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release handling by detecting missing or incomplete assets and reusing verified assets when appropriate.
  * Added verification for newly uploaded release assets before completing follow-up release steps.
  * Added support for releases triggered by version-tag pushes.

* **Documentation**
  * Clarified release preparation guidance for controlling build numbers and intentional manual bumps.

* **Chores**
  * Refined pre-commit build-number checks to honor both bump and skip settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->