### PR TITLE
fix: reliably close the active tab with Cmd-W

### DIFF
--- a/Neon Vision Editor/App/AppMenus.swift
+++ b/Neon Vision Editor/App/AppMenus.swift
@@ -245,7 +245,7 @@ struct NeonVisionMacAppCommands: Commands {
                 post(.closeSelectedTabRequested)
             }
             .modifier(dynamicShortcut(.closeTab))
-            .disabled(!hasActiveEditorWindow() || !hasSelectedTab)
+            .disabled(!hasSelectedTab)
         }
     }
 

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -292,8 +292,24 @@ enum VirtualEditorResizePolicy {
 }
 
 enum VirtualEditorKeyRouting {
-    // macOS virtual-key code 13 is the physical W key.
-    static let closeTabKeyCode: UInt16 = 13
+    static func matches(_ event: NSEvent, shortcut: EditorShortcutDescriptor) -> Bool {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        var modifiers: EditorShortcutModifiers = []
+        if flags.contains(.command) { modifiers.insert(.command) }
+        if flags.contains(.shift) { modifiers.insert(.shift) }
+        if flags.contains(.option) { modifiers.insert(.alternate) }
+        if flags.contains(.control) { modifiers.insert(.control) }
+        guard modifiers == shortcut.modifiers else { return false }
+
+        switch shortcut.key {
+        case "←": return event.keyCode == 123
+        case "→": return event.keyCode == 124
+        case "↓": return event.keyCode == 125
+        case "↑": return event.keyCode == 126
+        default:
+            return event.charactersIgnoringModifiers?.lowercased() == shortcut.key.lowercased()
+        }
+    }
 
     static func shouldInterpretArrow(modifiers: NSEvent.ModifierFlags) -> Bool {
         modifiers.contains(.command) || modifiers.contains(.control)
@@ -1138,16 +1154,14 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     }
 
     override func keyDown(with event: NSEvent) {
-        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        let isCloseTabKey = event.charactersIgnoringModifiers?.lowercased() == "w" ||
-            event.keyCode == VirtualEditorKeyRouting.closeTabKeyCode
-        if modifiers.contains(.command),
-           !modifiers.contains(.option),
-           !modifiers.contains(.control),
-           isCloseTabKey {
+        if VirtualEditorKeyRouting.matches(
+            event,
+            shortcut: ShortcutPreferences.shortcut(for: .closeTab)
+        ) {
             requestCloseSelectedTab()
             return
         }
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         if VirtualEditorKeyRouting.shouldInterpretArrow(modifiers: modifiers) {
             interpretKeyEvents([event])
             return

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -292,6 +292,8 @@ enum VirtualEditorResizePolicy {
 }
 
 enum VirtualEditorKeyRouting {
+    static let closeTabKeyCode: UInt16 = 13
+
     static func shouldInterpretArrow(modifiers: NSEvent.ModifierFlags) -> Bool {
         modifiers.contains(.command) || modifiers.contains(.control)
     }
@@ -1136,17 +1138,8 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
 
     override func keyDown(with event: NSEvent) {
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if modifiers == .command,
-           event.charactersIgnoringModifiers?.lowercased() == "w" {
-            var userInfo: [AnyHashable: Any] = [:]
-            if let windowNumber = window?.windowNumber {
-                userInfo[EditorCommandUserInfo.windowNumber] = windowNumber
-            }
-            NotificationCenter.default.post(
-                name: .closeSelectedTabRequested,
-                object: nil,
-                userInfo: userInfo.isEmpty ? nil : userInfo
-            )
+        if modifiers == .command, event.keyCode == VirtualEditorKeyRouting.closeTabKeyCode {
+            requestCloseSelectedTab()
             return
         }
         if VirtualEditorKeyRouting.shouldInterpretArrow(modifiers: modifiers) {
@@ -1162,6 +1155,18 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         case 126: moveCaretVertically(-1, extending: extending)
         default: interpretKeyEvents([event])
         }
+    }
+
+    private func requestCloseSelectedTab() {
+        var userInfo: [AnyHashable: Any] = [:]
+        if let windowNumber = window?.windowNumber {
+            userInfo[EditorCommandUserInfo.windowNumber] = windowNumber
+        }
+        NotificationCenter.default.post(
+            name: .closeSelectedTabRequested,
+            object: nil,
+            userInfo: userInfo.isEmpty ? nil : userInfo
+        )
     }
 
     private func wordBoundary(from position: Int, direction: Int) -> Int {

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -1136,6 +1136,19 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
 
     override func keyDown(with event: NSEvent) {
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if modifiers == .command,
+           event.charactersIgnoringModifiers?.lowercased() == "w" {
+            var userInfo: [AnyHashable: Any] = [:]
+            if let windowNumber = window?.windowNumber {
+                userInfo[EditorCommandUserInfo.windowNumber] = windowNumber
+            }
+            NotificationCenter.default.post(
+                name: .closeSelectedTabRequested,
+                object: nil,
+                userInfo: userInfo.isEmpty ? nil : userInfo
+            )
+            return
+        }
         if VirtualEditorKeyRouting.shouldInterpretArrow(modifiers: modifiers) {
             interpretKeyEvents([event])
             return

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -292,6 +292,7 @@ enum VirtualEditorResizePolicy {
 }
 
 enum VirtualEditorKeyRouting {
+    // macOS virtual-key code 13 is the physical W key.
     static let closeTabKeyCode: UInt16 = 13
 
     static func shouldInterpretArrow(modifiers: NSEvent.ModifierFlags) -> Bool {
@@ -1138,7 +1139,12 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
 
     override func keyDown(with event: NSEvent) {
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if modifiers == .command, event.keyCode == VirtualEditorKeyRouting.closeTabKeyCode {
+        let isCloseTabKey = event.charactersIgnoringModifiers?.lowercased() == "w" ||
+            event.keyCode == VirtualEditorKeyRouting.closeTabKeyCode
+        if modifiers.contains(.command),
+           !modifiers.contains(.option),
+           !modifiers.contains(.control),
+           isCloseTabKey {
             requestCloseSelectedTab()
             return
         }


### PR DESCRIPTION
## Summary

- What changed: Route `Cmd+W` directly from the macOS virtual editor to the window-scoped close-tab command and remove the registry-only menu disablement.
- Why: The menu/notification path could be disabled or bypassed while the editor canvas had focus.
- Scope: Bugfix
- Linked issue/milestone: Fixes #197

## Validation

- [ ] Built on macOS (Xcode is not installed in the current environment)
- [ ] Built on iOS simulator
- [ ] Built on iPad simulator
- [ ] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

## Checklist

- [ ] Accessibility checked (labels, focus order, no traps)
- [x] Keyboard navigation verified in code path
- [ ] VoiceOver impact evaluated (if UI touched)
- [ ] Changelog updated (if user-facing change)
- [ ] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

## Risk

- Risk level: Low
- User-facing risk: `Cmd+W` is handled by the editor canvas before it falls through to text input handling.
- Rollback plan: Revert commit `f93a8278`.

## Summary by Sourcery

Route the close-tab shortcut directly through the active macOS editor canvas to make Cmd-W consistently close the selected tab.

Bug Fixes:
- Ensure Cmd-W reliably closes the selected tab when the macOS virtual editor canvas has focus.

Enhancements:
- Keep the close-tab menu available based on tab selection rather than editor-window registry state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for closing the selected tab using the configured Close Tab keyboard shortcut.
  * Shortcut matching now supports modifier keys, arrow keys, and character-based shortcuts in the editor.

* **Bug Fixes**
  * The Close Tab command remains enabled whenever a tab is selected, even without an active editor window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->