### PR TITLE
fix: make up and down arrows move the caret

### DIFF
--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -1532,26 +1532,42 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
             selection = NSRange(location: absoluteCaret, length: 0)
             selectionAnchor = nil
         } else {
-            let next = nextCaretLocation(from: absoluteCaret, delta: delta)
-            if extending {
-                let anchor = selectionAnchor ?? absoluteCaret
-                selectionAnchor = anchor
-                absoluteCaret = next
-                selection = NSRange(location: min(anchor, next), length: abs(anchor - next))
-            } else {
-                absoluteCaret = next
-                selection = NSRange(location: absoluteCaret, length: 0)
-                selectionAnchor = nil
-            }
+            applyCaretLocation(nextCaretLocation(from: absoluteCaret, delta: delta), extending: extending)
         }
+        finishCaretMovement()
+    }
+
+    private func moveCaret(to location: Int, extending: Bool) {
+        applyCaretLocation(location, extending: extending)
+        finishCaretMovement()
+    }
+
+    private func applyCaretLocation(_ location: Int, extending: Bool) {
+        let next = max(0, min(document?.utf16Length ?? location, location))
+        if extending {
+            let anchor = selectionAnchor ?? absoluteCaret
+            selectionAnchor = anchor
+            absoluteCaret = next
+            selection = NSRange(location: min(anchor, next), length: abs(anchor - next))
+        } else {
+            absoluteCaret = next
+            selection = NSRange(location: absoluteCaret, length: 0)
+            selectionAnchor = nil
+        }
+    }
+
+    private func finishCaretMovement() {
         ensureCaretVisible()
         publishCaret()
         needsDisplay = true
     }
 
     private func nextCaretLocation(from location: Int, delta: Int) -> Int {
-        guard delta == -1 || delta == 1, let document else {
+        guard let document else {
             return location
+        }
+        guard delta == -1 || delta == 1 else {
+            return max(0, min(document.utf16Length, location + delta))
         }
         if viewport == nil ||
             location < viewportStartUTF16 ||
@@ -1583,26 +1599,42 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
 
     private func moveCaretVertically(_ direction: Int, extending: Bool) {
         let local = max(0, absoluteCaret - viewportLineOriginStartUTF16)
-        let currentLine = newlineCount(inUTF16PrefixOf: viewportText, length: local)
-        let currentStart = lineStarts[min(currentLine, lineStarts.count - 1)]
-        let column = local - currentStart
-        let targetLine = currentLine + direction
-        if targetLine < 0 || targetLine >= lineStarts.count {
-            let documentLine = lineForAbsoluteOffset(absoluteCaret)
-            let nextDocumentLine = min(max(0, documentLine + direction), max(0, (document?.lineCount ?? 1) - 1))
-            guard nextDocumentLine != documentLine else { return }
-            reloadViewport(anchorLine: nextDocumentLine)
-            let localTarget = max(0, min(lineStarts.count - 1, nextDocumentLine - viewportLineOrigin))
-            let targetStart = lineStarts[localTarget]
-            let targetEnd = localTarget + 1 < lineStarts.count ? lineStarts[localTarget + 1] : viewportText.utf16.count
-            let target = viewportLineOriginStartUTF16 + targetStart + min(column, max(0, targetEnd - targetStart))
-            moveCaret(target - absoluteCaret, extending: extending)
-            return
+        let rows = visualRows()
+        if let current = visualRow(containing: local, in: rows) {
+            let targetIndex = current.index + direction
+            if rows.indices.contains(targetIndex) {
+                let currentX = CGFloat(CTLineGetOffsetForStringIndex(
+                    current.row.fragment.line,
+                    local - current.row.fragment.absoluteStartUTF16,
+                    nil
+                ))
+                let targetRow = rows[targetIndex]
+                let targetOffset = CTLineGetStringIndexForPosition(
+                    targetRow.fragment.line,
+                    CGPoint(x: max(0, currentX), y: 0)
+                )
+                let localTarget = targetRow.fragment.absoluteStartUTF16 + min(
+                    targetOffset == kCFNotFound ? targetRow.fragment.lengthUTF16 : Int(targetOffset),
+                    targetRow.fragment.lengthUTF16
+                )
+                moveCaret(to: viewportLineOriginStartUTF16 + localTarget, extending: extending)
+                return
+            }
         }
-        let targetStart = lineStarts[targetLine]
-        let targetEnd = targetLine + 1 < lineStarts.count ? lineStarts[targetLine + 1] : viewportText.utf16.count
-        let target = viewportLineOriginStartUTF16 + targetStart + min(column, max(0, targetEnd - targetStart))
-        moveCaret(target - absoluteCaret, extending: extending)
+
+        let currentLine = lineForAbsoluteOffset(absoluteCaret)
+        let currentLocalLine = min(lineStarts.count - 1, newlineCount(inUTF16PrefixOf: viewportText, length: local))
+        let column = local - lineStarts[currentLocalLine]
+        let targetLine = currentLine + direction
+        guard targetLine >= 0, targetLine < (document?.lineCount ?? 1) else { return }
+        reloadViewport(anchorLine: targetLine)
+        let localLine = max(0, min(lineStarts.count - 1, targetLine - viewportLineOrigin))
+        let targetStart = lineStarts[localLine]
+        let targetEnd = localLine + 1 < lineStarts.count ? lineStarts[localLine + 1] : viewportText.utf16.count
+        moveCaret(
+            to: viewportLineOriginStartUTF16 + targetStart + min(column, max(0, targetEnd - targetStart)),
+            extending: extending
+        )
     }
 
     private func ensureCaretVisible() {

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -1597,27 +1597,36 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         return max(0, min(document.utf16Length, location + delta))
     }
 
+    private func caretLocation(in row: VisualRow, atX x: CGFloat) -> Int {
+        let targetOffset = CTLineGetStringIndexForPosition(
+            row.fragment.line,
+            CGPoint(x: max(0, x), y: 0)
+        )
+        let offset = min(
+            targetOffset == kCFNotFound ? row.fragment.lengthUTF16 : Int(targetOffset),
+            row.fragment.lengthUTF16
+        )
+        return viewportLineOriginStartUTF16 + row.fragment.absoluteStartUTF16 + offset
+    }
+
     private func moveCaretVertically(_ direction: Int, extending: Bool) {
         let local = max(0, absoluteCaret - viewportLineOriginStartUTF16)
         let rows = visualRows()
-        if let current = visualRow(containing: local, in: rows) {
+        let current = visualRow(containing: local, in: rows)
+        let preferredX = current.map {
+            CGFloat(CTLineGetOffsetForStringIndex(
+                $0.row.fragment.line,
+                local - $0.row.fragment.absoluteStartUTF16,
+                nil
+            ))
+        }
+        if let current {
             let targetIndex = current.index + direction
             if rows.indices.contains(targetIndex) {
-                let currentX = CGFloat(CTLineGetOffsetForStringIndex(
-                    current.row.fragment.line,
-                    local - current.row.fragment.absoluteStartUTF16,
-                    nil
-                ))
-                let targetRow = rows[targetIndex]
-                let targetOffset = CTLineGetStringIndexForPosition(
-                    targetRow.fragment.line,
-                    CGPoint(x: max(0, currentX), y: 0)
+                moveCaret(
+                    to: caretLocation(in: rows[targetIndex], atX: preferredX ?? 0),
+                    extending: extending
                 )
-                let localTarget = targetRow.fragment.absoluteStartUTF16 + min(
-                    targetOffset == kCFNotFound ? targetRow.fragment.lengthUTF16 : Int(targetOffset),
-                    targetRow.fragment.lengthUTF16
-                )
-                moveCaret(to: viewportLineOriginStartUTF16 + localTarget, extending: extending)
                 return
             }
         }
@@ -1628,6 +1637,16 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         let targetLine = currentLine + direction
         guard targetLine >= 0, targetLine < (document?.lineCount ?? 1) else { return }
         reloadViewport(anchorLine: targetLine)
+
+        if let preferredX {
+            let targetRows = visualRows().filter { $0.logicalLine == targetLine }
+            let targetRow = direction > 0 ? targetRows.first : targetRows.last
+            if let targetRow {
+                moveCaret(to: caretLocation(in: targetRow, atX: preferredX), extending: extending)
+                return
+            }
+        }
+
         let localLine = max(0, min(lineStarts.count - 1, targetLine - viewportLineOrigin))
         let targetStart = lineStarts[localLine]
         let targetEnd = localLine + 1 < lineStarts.count ? lineStarts[localLine + 1] : viewportText.utf16.count

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -1639,7 +1639,10 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         reloadViewport(anchorLine: targetLine)
 
         if let preferredX {
-            let targetRows = visualRows().filter { $0.logicalLine == targetLine }
+            // reloadViewport replaced the old viewport, so its visual rows must
+            // be rebuilt before selecting the target row.
+            let reloadedRows = visualRows()
+            let targetRows = reloadedRows.filter { $0.logicalLine == targetLine }
             let targetRow = direction > 0 ? targetRows.first : targetRows.last
             if let targetRow {
                 moveCaret(to: caretLocation(in: targetRow, atX: preferredX), extending: extending)

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -1615,13 +1615,14 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         let current = visualRow(containing: local, in: rows)
         let preferredX = current.map {
             CGFloat(CTLineGetOffsetForStringIndex(
-                $0.row.fragment.line,
-                local - $0.row.fragment.absoluteStartUTF16,
+                $0.fragment.line,
+                local - $0.fragment.absoluteStartUTF16,
                 nil
             ))
         }
         if let current {
-            let targetIndex = current.index + direction
+            guard let currentIndex = rows.firstIndex(of: current) else { return }
+            let targetIndex = currentIndex + direction
             if rows.indices.contains(targetIndex) {
                 moveCaret(
                     to: caretLocation(in: rows[targetIndex], atX: preferredX ?? 0),


### PR DESCRIPTION
## Summary

- What changed: Allow multi-character caret destinations and make vertical navigation use rendered visual rows when wrapping is enabled.
- Why: The previous path rejected every vertical movement whose UTF-16 delta was not exactly one character, and it navigated logical lines rather than wrapped rows.
- Scope: Bugfix
- Linked issue/milestone: Fixes #198

## Validation

- [ ] Built on macOS (Xcode is not installed in the current environment)
- [ ] Built on iOS simulator
- [ ] Built on iPad simulator
- [ ] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

## Checklist

- [ ] Accessibility checked (labels, focus order, no traps)
- [x] Keyboard navigation verified in code path
- [ ] VoiceOver impact evaluated (if UI touched)
- [ ] Changelog updated (if user-facing change)
- [ ] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

## Risk

- Risk level: Medium
- User-facing risk: Vertical movement now follows visual Core Text fragments and preserves the caret’s horizontal position; fallback handling remains for viewport edges.
- Rollback plan: Revert commit `46d43d92`.

## Summary by Sourcery

Make vertical arrow-key navigation move the caret correctly across wrapped and dynamically loaded editor content.

Bug Fixes:
- Fix vertical caret movement to follow rendered visual rows when text wrapping is enabled.
- Allow caret navigation to apply multi-character UTF-16 destinations instead of rejecting non-unit movements.

Enhancements:
- Preserve the caret’s horizontal position when moving between visual rows and retain fallback navigation at viewport boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caret movement across wrapped lines and visual rows.
  * Preserved horizontal caret positioning during vertical navigation.
  * Corrected cursor handling for UTF-16 surrogate pairs.
  * Added more consistent boundary clamping when moving the caret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->