### PR TITLE
fix: resolve caret placement at soft-wrap boundaries

### DIFF
--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -1058,16 +1058,19 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     }
 
     private func visualRow(containing localLocation: Int, in rows: [VisualRow]) -> VisualRow? {
+        guard !rows.isEmpty else { return nil }
         for (index, row) in rows.enumerated() {
             let start = row.fragment.absoluteStartUTF16
             let end = start + row.fragment.lengthUTF16
+            // A shared wrap boundary belongs to the following fragment; a gap
+            // or the final endpoint remains owned by the current fragment.
             let ownsEndpoint = localLocation == end &&
                 (index == rows.count - 1 || rows[index + 1].fragment.absoluteStartUTF16 > localLocation)
             if localLocation >= start && (localLocation < end || ownsEndpoint) {
                 return row
             }
         }
-        return rows.last
+        return nil
     }
 
     private func syntaxThemeKey(for colorScheme: ColorScheme) -> String {

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -952,7 +952,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         return created
     }
 
-    private struct VisualRow {
+    struct VisualRow {
         let logicalLine: Int
         let localStart: Int
         let fragment: VirtualEditorVisualFragment
@@ -1057,20 +1057,46 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         )
     }
 
-    private func visualRow(containing localLocation: Int, in rows: [VisualRow]) -> VisualRow? {
+    func visualRow(containing localLocation: Int, in rows: [VisualRow]) -> VisualRow? {
         guard !rows.isEmpty else { return nil }
-        for (index, row) in rows.enumerated() {
-            let start = row.fragment.absoluteStartUTF16
-            let end = start + row.fragment.lengthUTF16
-            // A shared wrap boundary belongs to the following fragment; a gap
-            // or the final endpoint remains owned by the current fragment.
-            let ownsEndpoint = localLocation == end &&
-                (index == rows.count - 1 || rows[index + 1].fragment.absoluteStartUTF16 > localLocation)
-            if localLocation >= start && (localLocation < end || ownsEndpoint) {
-                return row
+
+        // visualRows() is ordered by fragment start, so find the last row whose
+        // start is at or before the location instead of scanning every row.
+        var lower = 0
+        var upper = rows.count
+        while lower < upper {
+            let midpoint = (lower + upper) / 2
+            if rows[midpoint].fragment.absoluteStartUTF16 <= localLocation {
+                lower = midpoint + 1
+            } else {
+                upper = midpoint
             }
         }
-        return nil
+        let index = lower - 1
+        guard rows.indices.contains(index) else { return nil }
+
+        let row = rows[index]
+        let start = row.fragment.absoluteStartUTF16
+        let end = start + row.fragment.lengthUTF16
+        guard localLocation >= start,
+              (localLocation < end || ownsVisualRowEndpoint(
+                  localLocation,
+                  rowIndex: index,
+                  end: end,
+                  rows: rows
+              )) else { return nil }
+        return row
+    }
+
+    private func ownsVisualRowEndpoint(
+        _ localLocation: Int,
+        rowIndex: Int,
+        end: Int,
+        rows: [VisualRow]
+    ) -> Bool {
+        guard localLocation == end else { return false }
+        return rowIndex == rows.count - 1 ||
+            rows[rowIndex + 1].fragment.absoluteStartUTF16 > localLocation
     }
 
     private func syntaxThemeKey(for colorScheme: ColorScheme) -> String {

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -1057,6 +1057,19 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         )
     }
 
+    private func visualRow(containing localLocation: Int, in rows: [VisualRow]) -> VisualRow? {
+        for (index, row) in rows.enumerated() {
+            let start = row.fragment.absoluteStartUTF16
+            let end = start + row.fragment.lengthUTF16
+            let ownsEndpoint = localLocation == end &&
+                (index == rows.count - 1 || rows[index + 1].fragment.absoluteStartUTF16 > localLocation)
+            if localLocation >= start && (localLocation < end || ownsEndpoint) {
+                return row
+            }
+        }
+        return rows.last
+    }
+
     private func syntaxThemeKey(for colorScheme: ColorScheme) -> String {
         let syntax = currentEditorTheme(colorScheme: colorScheme).syntax
         return [
@@ -1069,7 +1082,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private func drawCurrentLineHighlight(rows: [VisualRow]) {
         guard highlightCurrentLine else { return }
         let local = absoluteCaret - viewportLineOriginStartUTF16
-        guard let row = rows.first(where: { local >= $0.fragment.absoluteStartUTF16 && local <= $0.fragment.absoluteStartUTF16 + $0.fragment.lengthUTF16 }) else { return }
+        guard let row = visualRow(containing: local, in: rows) else { return }
         NSColor.controlAccentColor.withAlphaComponent(0.08).setFill()
         NSRect(x: gutterWidth, y: row.baseline - lineHeight + 2, width: max(0, bounds.width - gutterWidth), height: lineHeight).fill()
     }
@@ -1094,7 +1107,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private func drawCaret(rows: [VisualRow]) {
         guard selection.length == 0 else { return }
         let local = absoluteCaret - viewportLineOriginStartUTF16
-        guard let row = rows.first(where: { local >= $0.fragment.absoluteStartUTF16 && local <= $0.fragment.absoluteStartUTF16 + $0.fragment.lengthUTF16 }) else { return }
+        guard let row = visualRow(containing: local, in: rows) else { return }
         let x = CGFloat(CTLineGetOffsetForStringIndex(row.fragment.line, local - row.fragment.absoluteStartUTF16, nil))
         NSColor.controlAccentColor.setFill()
         NSRect(x: gutterWidth + 8 + x, y: row.baseline - lineHeight + 2, width: 1.5, height: lineHeight).fill()
@@ -1624,7 +1637,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
 
     private func caretPoint(localLocation: Int) -> CGPoint {
         let rows = visualRows()
-        guard let row = rows.first(where: { localLocation >= $0.fragment.absoluteStartUTF16 && localLocation <= $0.fragment.absoluteStartUTF16 + $0.fragment.lengthUTF16 }) else {
+        guard let row = visualRow(containing: localLocation, in: rows) else {
             return CGPoint(x: gutterWidth + 8, y: 8)
         }
         let x = CGFloat(CTLineGetOffsetForStringIndex(row.fragment.line, localLocation - row.fragment.absoluteStartUTF16, nil))

--- a/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
+++ b/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
@@ -66,6 +66,38 @@ final class VirtualEditorLayoutTests: XCTestCase {
         )
     }
 
+    func testVisualRowOwnershipCoversWrapGapsAndEndpoints() {
+        let canvas = VirtualEditorCanvas(frame: .zero)
+        let font = NSFont.monospacedSystemFont(ofSize: 14, weight: .regular)
+
+        func row(start: Int, length: Int) -> VirtualEditorCanvas.VisualRow {
+            let line = CTLineCreateWithAttributedString(NSAttributedString(
+                string: String(repeating: "x", count: max(1, length)),
+                attributes: [.font: font]
+            ))
+            return VirtualEditorCanvas.VisualRow(
+                logicalLine: 0,
+                localStart: start,
+                fragment: VirtualEditorVisualFragment(
+                    absoluteStartUTF16: start,
+                    lengthUTF16: length,
+                    line: line
+                ),
+                baseline: 0,
+                isFirstFragment: start == 0
+            )
+        }
+
+        let rows = [row(start: 0, length: 5), row(start: 5, length: 5), row(start: 11, length: 0), row(start: 12, length: 3)]
+
+        XCTAssertEqual(canvas.visualRow(containing: 5, in: rows)?.fragment.absoluteStartUTF16, 5)
+        XCTAssertEqual(canvas.visualRow(containing: 10, in: rows)?.fragment.absoluteStartUTF16, 5)
+        XCTAssertEqual(canvas.visualRow(containing: 11, in: rows)?.fragment.absoluteStartUTF16, 11)
+        XCTAssertEqual(canvas.visualRow(containing: 15, in: rows)?.fragment.absoluteStartUTF16, 12)
+        XCTAssertNil(canvas.visualRow(containing: -1, in: rows))
+        XCTAssertNil(canvas.visualRow(containing: 16, in: rows))
+    }
+
     func testVisualFragmentsSplitLongLineAtAvailableWidth() {
         let text = "abcdefghijklmnopqrstuvwxyz"
         let fragments = VirtualEditorVisualLayout.fragments(


### PR DESCRIPTION
## Summary

- What changed: Centralize visual-row lookup for caret drawing, caret positioning, and current-line highlighting.
- Why: Inclusive fragment-end checks allowed both sides of a soft-wrap boundary to match, producing inconsistent caret placement.
- Scope: Bugfix
- Linked issue/milestone: Fixes #199

## Validation

- [ ] Built on macOS (Xcode is not installed in the current environment)
- [ ] Built on iOS simulator
- [ ] Built on iPad simulator
- [ ] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

## Checklist

- [ ] Accessibility checked (labels, focus order, no traps)
- [x] Keyboard navigation geometry verified in code path
- [ ] VoiceOver impact evaluated (if UI touched)
- [ ] Changelog updated (if user-facing change)
- [ ] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

## Risk

- Risk level: Low
- User-facing risk: Caret, current-line highlighting, and caret scrolling now use one consistent endpoint policy for wrapped fragments.
- Rollback plan: Revert commit `185d37fa`.

## Summary by Sourcery

Bug Fixes:
- Fix inconsistent caret placement and line highlighting at soft-wrap boundaries by centralizing visual-row lookup for a given text position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved current-line highlighting, caret rendering, and caret positioning at wrapped-line boundaries.
  * Ensured text locations shared by adjacent visual fragments are consistently associated with the correct fragment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->