### PR TITLE
ci: sync protected release workflow into develop

### DIFF
--- a/.github/workflows/post-release-documentation-sync.yml
+++ b/.github/workflows/post-release-documentation-sync.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: post-release-documentation-${{ github.event.release.tag_name || inputs.tag }}
@@ -32,6 +33,19 @@ jobs:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.METRIC_TOKEN }}
+
+      - name: Prepare automation branch
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${RELEASE_TAG:-manual}"
+          tag="${tag#v}"
+          branch="automation/post-release-docs-${tag}"
+          git fetch origin main
+          git fetch origin "${branch}" || true
+          git checkout -B "${branch}" origin/main
+          echo "DOCS_BRANCH=${branch}" >> "$GITHUB_ENV"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -143,6 +157,7 @@ jobs:
         if: steps.release.outputs.skip != 'true' && steps.changes.outputs.changed == 'true'
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          METRIC_TOKEN: ${{ secrets.METRIC_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -163,16 +178,13 @@ jobs:
 
           git add -- "${paths[@]}"
           git commit -S -m "docs: self-heal ${RELEASE_TAG} documentation"
+          git push --force-with-lease origin "HEAD:${DOCS_BRANCH}"
 
-          for attempt in 1 2 3; do
-            git fetch origin main
-            git rebase origin/main
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            if [[ "$attempt" -eq 3 ]]; then
-              echo "Documentation repair could not push after ${attempt} attempts." >&2
-              exit 1
-            fi
-            sleep "$attempt"
-          done
+          export GH_TOKEN="${METRIC_TOKEN:-}"
+          if ! gh pr view "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh pr create --repo "${GITHUB_REPOSITORY}" --base main --head "${DOCS_BRANCH}" \
+              --title "docs: self-heal ${RELEASE_TAG} documentation" \
+              --body "Automated post-release documentation reconciliation."
+          fi
+          gh pr merge "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --squash --delete-branch || \
+            echo "Auto-merge is unavailable; leaving the documentation PR open."

--- a/.github/workflows/pre-release-ci.yml
+++ b/.github/workflows/pre-release-ci.yml
@@ -1,5 +1,7 @@
 name: Pre-release CI
 
+# CodeQL default setup supplies the required scan for PRs targeting either
+# protected branch alongside these repository-specific release checks.
 on:
   pull_request:
     branches: ["main", "develop"]

--- a/.github/workflows/pre-release-ci.yml
+++ b/.github/workflows/pre-release-ci.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   preflight:
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     timeout-minutes: 45
     concurrency:
       group: pre-release-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pre-release-ci.yml
+++ b/.github/workflows/pre-release-ci.yml
@@ -82,8 +82,43 @@ jobs:
         run: |
           set -euo pipefail
           probe_log="$(mktemp)"
-          if xcodebuild -list -project "Neon Vision Editor.xcodeproj" >"$probe_log" 2>&1; then
+          set +e
+          python3 - "$probe_log" <<'PY'
+          import os
+          import signal
+          import subprocess
+          import sys
+
+          log_path = sys.argv[1]
+          with open(log_path, "wb") as log:
+              process = subprocess.Popen(
+                  ["xcodebuild", "-list", "-project", "Neon Vision Editor.xcodeproj"],
+                  stdout=log,
+                  stderr=subprocess.STDOUT,
+                  start_new_session=True,
+              )
+              try:
+                  status = process.wait(timeout=180)
+              except subprocess.TimeoutExpired:
+                  os.killpg(process.pid, signal.SIGTERM)
+                  try:
+                      process.wait(timeout=5)
+                  except subprocess.TimeoutExpired:
+                      os.killpg(process.pid, signal.SIGKILL)
+                      process.wait()
+                  status = 124
+          raise SystemExit(status)
+          PY
+          probe_status=$?
+          set -e
+          if [[ "$probe_status" -eq 0 ]]; then
             echo "project_compatible=true" >> "$GITHUB_OUTPUT"
+            rm -f "$probe_log"
+            exit 0
+          fi
+          if [[ "$probe_status" -eq 124 ]]; then
+            echo "::warning::Hosted Xcode project probe timed out after 180 seconds. Runtime tests are skipped for this run."
+            echo "project_compatible=false" >> "$GITHUB_OUTPUT"
             rm -f "$probe_log"
             exit 0
           fi

--- a/.github/workflows/release-github-only.yml
+++ b/.github/workflows/release-github-only.yml
@@ -47,6 +47,7 @@ permissions:
   contents: write
   actions: write
   issues: write
+  pull-requests: write
 
 jobs:
   release:
@@ -646,7 +647,7 @@ jobs:
         id: publish_appcast
         env:
           APPCAST_PATH: ${{ runner.temp }}/appcast.xml
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.METRIC_TOKEN }}
           METRICS_SIGNING_SSH_KEY: ${{ secrets.METRICS_SIGNING_SSH_KEY }}
           METRICS_SIGNING_NAME: ${{ secrets.METRICS_SIGNING_NAME }}
           METRICS_SIGNING_EMAIL: ${{ secrets.METRICS_SIGNING_EMAIL }}
@@ -702,9 +703,11 @@ jobs:
           git config commit.gpgsign true
 
           appcast_commit=""
+          appcast_branch="automation/appcast-${TAG_NAME#v}"
           for attempt in 1 2 3; do
             git fetch origin main
-            git checkout -B appcast-publish origin/main
+            git fetch origin "${appcast_branch}" || true
+            git checkout -B "${appcast_branch}" origin/main
             cp "$APPCAST_PATH" appcast.xml
             mkdir -p site
             cp "$APPCAST_PATH" site/appcast.xml
@@ -716,8 +719,25 @@ jobs:
 
             git add appcast.xml site/appcast.xml
             git commit -S -m "chore: publish Sparkle appcast for ${TAG_NAME}"
-            if git push origin HEAD:main; then
-              appcast_commit="$(git rev-parse HEAD)"
+            if git push --force-with-lease origin "HEAD:${appcast_branch}"; then
+              if ! gh pr view "${appcast_branch}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+                gh pr create --repo "${GITHUB_REPOSITORY}" --base main --head "${appcast_branch}" \
+                  --title "chore: publish Sparkle appcast for ${TAG_NAME}" \
+                  --body "Automated signed Sparkle appcast publication for ${TAG_NAME}."
+              fi
+              gh pr merge "${appcast_branch}" --repo "${GITHUB_REPOSITORY}" --auto --squash --delete-branch
+              for _ in {1..120}; do
+                merge_state="$(gh pr view "${appcast_branch}" --repo "${GITHUB_REPOSITORY}" --json state,mergeCommit --jq '[.state, (.mergeCommit.oid // "")] | join("|")' || true)"
+                if [[ "${merge_state%%|*}" == "MERGED" && -n "${merge_state#*|}" ]]; then
+                  appcast_commit="${merge_state#*|}"
+                  break
+                fi
+                sleep 15
+              done
+              if [[ -z "$appcast_commit" ]]; then
+                echo "Appcast PR did not merge into main after publication." >&2
+                exit 1
+              fi
               break
             fi
             if [[ "$attempt" -eq 3 ]]; then

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: macos-latest
 
     steps:
@@ -31,6 +32,7 @@ jobs:
         run: scripts/ci/build_platform_matrix.sh
 
   macos_sequoia_syntax_regressions:
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     name: macOS Sequoia syntax regressions
     runs-on: macos-15
 

--- a/.github/workflows/sync-readme-appstore-versions.yml
+++ b/.github/workflows/sync-readme-appstore-versions.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:
@@ -31,6 +32,19 @@ jobs:
           # Keep signed documentation sync commits attributable to the
           # repository automation identity that may bypass protected main.
           token: ${{ secrets.METRIC_TOKEN }}
+
+      - name: Prepare automation branch
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${RELEASE_TAG:-manual}"
+          tag="${tag#v}"
+          branch="automation/appstore-version-${tag}"
+          git fetch origin main
+          git fetch origin "${branch}" || true
+          git checkout -B "${branch}" origin/main
+          echo "SYNC_BRANCH=${branch}" >> "$GITHUB_ENV"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -85,7 +99,9 @@ jobs:
           git config user.signingkey "$SIGNING_PUB_KEY_PATH"
           git config commit.gpgsign true
 
-      - name: Commit and push if changed
+      - name: Commit and update pull request if changed
+        env:
+          GH_TOKEN: ${{ secrets.METRIC_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -97,19 +113,11 @@ jobs:
           git add README.md site/index.html
           git commit -S -m "docs: sync App Store versions"
 
-          branch="${GITHUB_REF_NAME:-main}"
-          for attempt in 1 2 3; do
-            git fetch origin "$branch"
-            git rebase "origin/$branch"
-            if git push origin "HEAD:$branch"; then
-              exit 0
-            fi
-
-            if [ "$attempt" -eq 3 ]; then
-              echo "README version sync could not push after $attempt attempts."
-              exit 1
-            fi
-
-            # A concurrent release or documentation update moved main after rebase.
-            sleep "$attempt"
-          done
+          git push --force-with-lease origin "HEAD:${SYNC_BRANCH}"
+          if ! gh pr view "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh pr create --repo "${GITHUB_REPOSITORY}" --base main --head "${SYNC_BRANCH}" \
+              --title "docs: sync App Store versions" \
+              --body "Automated App Store version synchronization after release."
+          fi
+          gh pr merge "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --squash --delete-branch || \
+            echo "Auto-merge is unavailable; leaving the App Store synchronization PR open."

--- a/scripts/release_all.sh
+++ b/scripts/release_all.sh
@@ -26,13 +26,13 @@ Examples:
   scripts/release_all.sh v0.8.9 notarized --retag
 
 What it does:
-  1) Synchronize local main with origin/main before release checks and again before preparation
-     so separately generated download-metrics commits are included
+  1) Synchronize local develop with origin/develop before release checks; release preparation
+     creates release/<version> and opens a PR into main
   2) Run release preflight checks (docs + build + icon payload + tests)
   3) Prepare README/CHANGELOG docs
   4) Commit docs changes
-  5) Push the signed release-preparation commit to origin/main
-  6) Trigger the primary GitHub-hosted release workflow, which creates the tag only after its gates pass
+  5) Push the signed release-preparation commit to release/<version> and merge its PR into main
+  6) Trigger the primary GitHub-hosted release workflow from the merged main commit
   7) Optionally use an explicit fallback workflow for an existing tag and approve its
      protected release environment when the current user is an authorized reviewer
   8) Wait for notarized workflow and verify uploaded release asset payload
@@ -183,6 +183,30 @@ sync_main_with_origin() {
   echo "  local main:  ${local_main_sha}" >&2
   echo "  origin/main: ${origin_main_sha}" >&2
   exit 1
+}
+
+sync_develop_with_origin() {
+  local current_branch local_sha origin_sha
+  current_branch="$(git branch --show-current)"
+  if [[ "$current_branch" != "develop" ]]; then
+    echo "Release preparation must run from develop (current: ${current_branch})." >&2
+    exit 1
+  fi
+
+  echo "Synchronizing develop with origin/develop before release checks..."
+  retry_cmd git fetch origin develop >/dev/null
+  local_sha="$(git rev-parse HEAD)"
+  origin_sha="$(git rev-parse origin/develop)"
+  if [[ "$local_sha" == "$origin_sha" ]]; then
+    echo "Local develop is aligned with origin/develop."
+  elif git merge-base --is-ancestor HEAD origin/develop; then
+    git merge --ff-only origin/develop
+  elif git merge-base --is-ancestor origin/develop HEAD; then
+    echo "Local develop already contains origin/develop; continuing."
+  else
+    echo "Local develop and origin/develop both moved. Rebase before release preparation." >&2
+    exit 1
+  fi
 }
 
 is_allowed_release_dirty_path() {
@@ -639,7 +663,7 @@ if [[ "$REQUIRES_CLEAN_TREE" -eq 1 && "$AUTOSTASH" -eq 0 && -n "$(git status --p
 fi
 
 if step_enabled prep; then
-  sync_main_with_origin "release checks"
+  sync_develop_with_origin
 fi
 print_release_state_summary "before docs/preflight"
 
@@ -699,8 +723,7 @@ assert_remote_tag_matches_head() {
 }
 
 if step_enabled prep; then
-  sync_main_with_origin "release prep commit and tag (including external download-metrics commits)"
-  print_release_state_summary "before release prep/tag"
+  print_release_state_summary "before release branch preparation"
 
   if git rev-parse "$TAG" >/dev/null 2>&1; then
     if [[ "$RETAG" -eq 1 ]]; then
@@ -712,7 +735,6 @@ if step_enabled prep; then
       assert_remote_tag_matches_head "$TAG"
       echo "Tag ${TAG} already exists. Skipping release prep. Use --retag to recreate it."
       if [[ "$(git branch --show-current)" == "main" ]]; then
-        git push origin main
         git push origin "$TAG"
       fi
     fi
@@ -726,7 +748,25 @@ if step_enabled prep; then
     fi
     prep_cmd+=(--push)
     "${prep_cmd[@]}"
-    echo "Release-preparation commit push completed."
+    RELEASE_BRANCH="release/${TAG#v}"
+    echo "Release-preparation branch pushed; waiting for ${RELEASE_BRANCH} to merge into main..."
+    merged=0
+    for _ in {1..120}; do
+      pr_state="$(gh_retry gh pr view "${RELEASE_BRANCH}" --json state,mergeCommit --jq '[.state, (.mergeCommit.oid // "")] | join("|")' || true)"
+      if [[ "${pr_state%%|*}" == "MERGED" ]]; then
+        merged=1
+        break
+      fi
+      sleep 15
+    done
+    if [[ "$merged" -ne 1 ]]; then
+      echo "Release PR ${RELEASE_BRANCH} did not merge into main; release workflow was not dispatched." >&2
+      exit 1
+    fi
+    git switch main
+    retry_cmd git fetch origin main >/dev/null
+    git merge --ff-only origin/main
+    echo "Release PR merged; main is ready for ${TAG}."
   fi
 fi
 

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -17,11 +17,11 @@ Examples:
 Notes:
   - Runs scripts/prepare_release_docs.py
   - Auto-syncs MARKETING_VERSION in Xcode project to the release tag version
-  - With --push, refreshes origin/main and preserves allowed release-doc changes
+  - With --push, refreshes origin/develop, creates release/<version>, and opens a PR into main
   - Commits README.md, ARCHITECTURE.md, CHANGELOG.md, and Welcome Tour release page updates
   - With --next, chooses the next stable tag; patch releases are capped at .9
   - Does not create a tag: the canonical GitHub-hosted workflow tags only after its gates pass
-  - With --push, pushes only the prepared commit to origin/main
+  - With --push, pushes only the prepared release branch and requests squash auto-merge
 EOF
 }
 
@@ -138,44 +138,44 @@ retry_cmd() {
   done
 }
 
-sync_main_before_push() {
-  local current_branch local_main_sha origin_main_sha
+sync_develop_before_push() {
+  local current_branch local_develop_sha origin_develop_sha
 
   current_branch="$(git branch --show-current)"
-  if [[ "$current_branch" != "main" ]]; then
-    echo "--push is only supported from main (current: ${current_branch})." >&2
+  if [[ "$current_branch" != "develop" ]]; then
+    echo "--push is only supported from develop (current: ${current_branch})." >&2
     exit 1
   fi
 
-  echo "Synchronizing main with origin/main before release prep..."
-  retry_cmd git fetch --tags origin main
-  local_main_sha="$(git rev-parse HEAD)"
-  origin_main_sha="$(git rev-parse origin/main)"
+  echo "Synchronizing develop with origin/develop before release prep..."
+  retry_cmd git fetch --tags origin develop
+  local_develop_sha="$(git rev-parse HEAD)"
+  origin_develop_sha="$(git rev-parse origin/develop)"
 
-  if [[ "$local_main_sha" == "$origin_main_sha" ]]; then
-    echo "Local main is aligned with origin/main."
+  if [[ "$local_develop_sha" == "$origin_develop_sha" ]]; then
+    echo "Local develop is aligned with origin/develop."
     return 0
   fi
 
-  if git merge-base --is-ancestor HEAD origin/main; then
+  if git merge-base --is-ancestor HEAD origin/develop; then
     if [[ -n "$(git status --porcelain)" ]]; then
-      echo "Local main is behind origin/main. Fast-forwarding while preserving release metadata changes..."
-      git rebase --autostash origin/main
+      echo "Local develop is behind origin/develop. Fast-forwarding while preserving release metadata changes..."
+      git rebase --autostash origin/develop
     else
-      git merge --ff-only origin/main
+      git merge --ff-only origin/develop
     fi
     return 0
   fi
 
-  if git merge-base --is-ancestor origin/main HEAD; then
-    echo "Local main already contains origin/main; continuing."
+  if git merge-base --is-ancestor origin/develop HEAD; then
+    echo "Local develop already contains origin/develop; continuing."
     return 0
   fi
 
-  echo "Local main and origin/main both moved. Refusing to create an implicit release merge." >&2
-  echo "Rebase the local commits onto origin/main, then rerun release prep." >&2
-  echo "  local main:  ${local_main_sha}" >&2
-  echo "  origin/main: ${origin_main_sha}" >&2
+  echo "Local develop and origin/develop both moved. Refusing to create an implicit release merge." >&2
+  echo "Rebase the local commits onto origin/develop, then rerun release prep." >&2
+  echo "  local develop:  ${local_develop_sha}" >&2
+  echo "  origin/develop: ${origin_develop_sha}" >&2
   exit 1
 }
 
@@ -214,7 +214,13 @@ if ! git diff --quiet || ! git diff --cached --quiet || [[ -n "$(git ls-files --
 fi
 
 if [[ "$DO_PUSH" -eq 1 ]]; then
-  sync_main_before_push
+  sync_develop_before_push
+  RELEASE_BRANCH="release/${TAG#v}"
+  if git show-ref --verify --quiet "refs/heads/${RELEASE_BRANCH}" || git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null 2>&1; then
+    echo "Release branch ${RELEASE_BRANCH} already exists. Refusing to overwrite it." >&2
+    exit 1
+  fi
+  git switch -c "${RELEASE_BRANCH}"
 fi
 
 if git rev-parse "$TAG" >/dev/null 2>&1; then
@@ -314,14 +320,25 @@ fi
 
 if [[ "$DO_PUSH" -eq 1 ]]; then
   BRANCH="$(git branch --show-current)"
-  if [[ "$BRANCH" != "main" ]]; then
-    echo "--push is only supported from main (current: ${BRANCH})." >&2
+  if [[ "$BRANCH" != "release/${TAG#v}" ]]; then
+    echo "Release preparation expected branch release/${TAG#v} (current: ${BRANCH})." >&2
     exit 1
   fi
-  git push origin main
-  echo "Pushed prepared release commit to main."
+  git push -u origin "${BRANCH}"
+  if gh pr view "${BRANCH}" --repo "${GH_REPO:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}" >/dev/null 2>&1; then
+    echo "Updated existing release pull request."
+  else
+    gh pr create \
+      --base main \
+      --head "${BRANCH}" \
+      --title "chore(release): prepare ${TAG}" \
+      --body "Release preparation for ${TAG}."
+  fi
+  gh pr merge "${BRANCH}" --auto --squash --delete-branch || \
+    echo "Auto-merge is unavailable; leaving the release pull request open."
 else
   echo "Next steps:"
-  echo "  git push origin main"
+  echo "  git switch develop"
+  echo "  scripts/release_prep.sh ${TAG} --push"
 fi
-echo "Then dispatch .github/workflows/release-github-only.yml with tag=${TAG} and ref=main."
+echo "After the release PR merges, dispatch .github/workflows/release-github-only.yml with tag=${TAG} and ref=main."

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -221,6 +221,8 @@ if [[ "$DO_PUSH" -eq 1 ]]; then
     exit 1
   fi
   git switch -c "${RELEASE_BRANCH}"
+  RELEASE_BRANCH_CREATED=1
+  trap 'status=$?; if [[ "$status" -ne 0 && "$RELEASE_BRANCH_CREATED" -eq 1 ]]; then git switch develop >/dev/null 2>&1 || true; git branch -D "$RELEASE_BRANCH" >/dev/null 2>&1 || true; fi; exit "$status"' EXIT
 fi
 
 if git rev-parse "$TAG" >/dev/null 2>&1; then


### PR DESCRIPTION
Sync the protected release workflow and automation PR changes from main into develop.

## Summary by Sourcery

Adopt protected-branch pull request automation for release preparation and post-release updates while improving release CI resilience.

New Features:
- Route release preparation through protected release branches and pull requests before merging into main.
- Automate post-release documentation, App Store version, and Sparkle appcast updates through pull requests with optional auto-merge.

Bug Fixes:
- Prevent release-related CI jobs from running on release branches and handle stalled Xcode project probes without hanging indefinitely.

Enhancements:
- Align release preparation with develop, require the release PR to merge before dispatching the release workflow, and refresh main afterward.

CI:
- Grant workflows pull-request permissions and use the automation token for protected-branch release updates.