### PR TITLE
perf: refine editor rendering for 1.5.3

### DIFF
--- a/.github/workflows/pre-release-ci.yml
+++ b/.github/workflows/pre-release-ci.yml
@@ -152,6 +152,35 @@ jobs:
             -only-testing:"Neon Vision EditorTests/ReleaseRuntimePolicyTests" \
             test
 
+      - name: Record virtual editor performance trends
+        if: ${{ steps.project_probe.outputs.project_compatible == 'true' }}
+        env:
+          DERIVED_DATA: ${{ runner.temp }}/DerivedData
+          RESULT_BUNDLE: ${{ runner.temp }}/VirtualEditorPerformance.xcresult
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project "Neon Vision Editor.xcodeproj" \
+            -scheme "Neon Vision Editor" \
+            -destination "platform=macOS" \
+            -derivedDataPath "$DERIVED_DATA" \
+            -resultBundlePath "$RESULT_BUNDLE" \
+            MACOSX_DEPLOYMENT_TARGET=15.5 \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            -only-testing:"Neon Vision EditorTests/VirtualEditorPerformanceTests" \
+            test
+
+      - name: Upload virtual editor performance results
+        if: ${{ always() && steps.project_probe.outputs.project_compatible == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: virtual-editor-performance-${{ github.run_id }}
+          path: ${{ runner.temp }}/VirtualEditorPerformance.xcresult
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Verify icon payload in built app
         if: ${{ steps.project_probe.outputs.project_compatible == 'true' }}
         env:

--- a/.github/workflows/release-github-only.yml
+++ b/.github/workflows/release-github-only.yml
@@ -703,6 +703,7 @@ jobs:
           git config commit.gpgsign true
 
           appcast_commit=""
+          appcast_pr_number=""
           appcast_branch="automation/appcast-${TAG_NAME#v}"
           for attempt in 1 2 3; do
             git fetch origin main
@@ -725,9 +726,10 @@ jobs:
                   --title "chore: publish Sparkle appcast for ${TAG_NAME}" \
                   --body "Automated signed Sparkle appcast publication for ${TAG_NAME}."
               fi
-              gh pr merge "${appcast_branch}" --repo "${GITHUB_REPOSITORY}" --auto --squash --delete-branch
+              appcast_pr_number="$(gh pr view "${appcast_branch}" --repo "${GITHUB_REPOSITORY}" --json number --jq '.number')"
+              gh pr merge "${appcast_pr_number}" --repo "${GITHUB_REPOSITORY}" --auto --squash
               for _ in {1..120}; do
-                merge_state="$(gh pr view "${appcast_branch}" --repo "${GITHUB_REPOSITORY}" --json state,mergeCommit --jq '[.state, (.mergeCommit.oid // "")] | join("|")' || true)"
+                merge_state="$(gh pr view "${appcast_pr_number}" --repo "${GITHUB_REPOSITORY}" --json state,mergeCommit --jq '[.state, (.mergeCommit.oid // "")] | join("|")' || true)"
                 if [[ "${merge_state%%|*}" == "MERGED" && -n "${merge_state#*|}" ]]; then
                   appcast_commit="${merge_state#*|}"
                   break
@@ -738,6 +740,7 @@ jobs:
                 echo "Appcast PR did not merge into main after publication." >&2
                 exit 1
               fi
+              git push origin --delete "${appcast_branch}" || true
               break
             fi
             if [[ "$attempt" -eq 3 ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to **Neon Vision Editor** are documented in this file.
 
 The format follows *Keep a Changelog*. Versions use semantic versioning with prerelease tags.
 
+## [v1.5.3] - 2026-08-26
+
+### Why Upgrade
+
+- Makes large-file editing and scrolling more responsive across macOS, iOS, and iPadOS.
+- Reduces unnecessary editor, project, preview, and session-state refreshes during routine interaction.
+- Adds a distraction-free focus mode while improving editor selection, project-row clarity, and accessibility context.
+
+### Highlights
+
+- Caches macOS viewport render snapshots and incrementally prepares syntax-highlighted lines outside the draw path.
+- Adds revision-aware iOS line metadata, no-wrap width caching, and bounded formatting for large documents.
+- Adds focused SwiftUI observation snapshots, preview reload measurements, and CI-exported performance results.
+- Adds Focus Mode to hide secondary editor chrome without changing the open document or workspace state.
+
+### Fixes
+
+- Prevents the editor canvas from taking focus merely because it moved into a window.
+- Improves editor accessibility with document, line, column, selection, and read-only context.
+- Splits the root observer composition so supported public Xcode releases can type-check it reliably.
+- Makes release appcast publication track its pull request by number and delays release-branch creation until metadata validation succeeds.
+
+### Breaking changes
+
+- None.
+
+### Migration
+
+- None.
+
 ## [v1.5.2] - 2026-08-22
 
 ### Why Upgrade

--- a/Neon Vision Editor/App/AppMenus.swift
+++ b/Neon Vision Editor/App/AppMenus.swift
@@ -13,7 +13,6 @@ struct NeonVisionMacAppCommands: Commands {
     let activeEditorViewModel: () -> EditorViewModel
     let hasActiveEditorWindow: () -> Bool
     let openNewWindow: () -> Void
-    let openFocusModeWindow: () -> Void
     let openAIDiagnosticsWindow: () -> Void
     let postWindowCommand: (_ name: Notification.Name, _ object: Any?) -> Void
     let isUpdaterEnabled: Bool
@@ -131,7 +130,7 @@ struct NeonVisionMacAppCommands: Commands {
             .keyboardShortcut("n", modifiers: .command)
 
             Button("Focus Mode") {
-                openFocusModeWindow()
+                post(.toggleFocusModeRequested)
             }
             .keyboardShortcut("n", modifiers: [.command, .shift])
 

--- a/Neon Vision Editor/App/NeonVisionEditorApp.swift
+++ b/Neon Vision Editor/App/NeonVisionEditorApp.swift
@@ -374,53 +374,6 @@ private struct DetachedWindowContentView: View {
     }
 }
 
-private struct FocusModeContentView: View {
-    @State private var viewModel = EditorViewModel()
-    @ObservedObject var supportPurchaseManager: SupportPurchaseManager
-    @ObservedObject var appUpdateManager: AppUpdateManager
-    @Binding var showGrokError: Bool
-    @Binding var grokErrorMessage: String
-
-    var body: some View {
-        FocusModeView(viewModel: viewModel)
-            .environmentObject(supportPurchaseManager)
-            .environmentObject(appUpdateManager)
-            .environment(\.showGrokError, $showGrokError)
-            .environment(\.grokErrorMessage, $grokErrorMessage)
-            .frame(minWidth: 500, minHeight: 300)
-    }
-}
-
-private struct FocusModeView: View {
-    @State var viewModel: EditorViewModel
-    @AppStorage("SettingsEditorFontSize") private var editorFontSize: Double = 14
-    @AppStorage("SettingsEditorFontName") private var editorFontName: String = ""
-    @AppStorage("SettingsShowLineNumbers") private var showLineNumbers: Bool = true
-    @AppStorage("SettingsLineWrapEnabled") private var settingsLineWrapEnabled: Bool = true
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text("Focus Mode")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                Spacer()
-                if let tab = viewModel.selectedTab {
-                    Text(tab.name)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(.ultraThinMaterial)
-
-            ContentView(startupBehavior: .forceBlankDocument)
-                .environment(viewModel)
-                .toolbar(.hidden)
-        }
-    }
-}
 #endif
 
 // MARK: - App Entry Point
@@ -815,25 +768,6 @@ struct NeonVisionEditorApp: App {
         .defaultSize(width: 1400, height: 900)
         .handlesExternalEvents(matching: [])
 
-        WindowGroup("Focus Mode", id: "focus-mode") {
-            FocusModeContentView(
-                supportPurchaseManager: supportPurchaseManager,
-                appUpdateManager: appUpdateManager,
-                showGrokError: $showGrokError,
-                grokErrorMessage: $grokErrorMessage
-            )
-            .onAppear { _ = AppearanceThemeCloudSync.syncIfEnabled() }
-            .onAppear { scheduleMacWindowChromePolicy() }
-            .onChange(of: appearance) { _, _ in applyGlobalAppearanceOverride() }
-            .onAppear { applyRuntimeLanguageOverride() }
-            .onChange(of: appLanguageCode) { _, _ in applyRuntimeLanguageOverride() }
-            .environment(\.locale, preferredLocale)
-            .tint(.blue)
-            .preferredColorScheme(preferredAppearance)
-        }
-        .defaultSize(width: 900, height: 600)
-        .handlesExternalEvents(matching: [])
-
         Settings {
             ConfiguredSettingsView(
                 supportsOpenInTabs: false,
@@ -993,7 +927,6 @@ struct NeonVisionEditorApp: App {
                 openNewWindow: {
                     openWindow(value: MacEditorWindowSessionStore.shared.createWindowID())
                 },
-                openFocusModeWindow: { openWindow(id: "focus-mode") },
                 openAIDiagnosticsWindow: { openWindow(id: "ai-logs") },
                 postWindowCommand: { name, object in
                     postWindowCommand(name, object: object)

--- a/Neon Vision Editor/Core/EditorPerformanceMonitor.swift
+++ b/Neon Vision Editor/Core/EditorPerformanceMonitor.swift
@@ -7,6 +7,11 @@ import OSLog
 // MARK: - Types
 
 final class EditorPerformanceMonitor {
+    struct PreviewReloadSnapshot: Equatable {
+        let requested: Int
+        let coalesced: Int
+        let executed: Int
+    }
     struct FileOpenEvent: Codable, Identifiable {
         let id: UUID
         let timestamp: Date
@@ -31,6 +36,9 @@ final class EditorPerformanceMonitor {
     private var fileOpenStartUptimeByTabID: [UUID: TimeInterval] = [:]
     private var minimapViewportStartUptimeByTabID: [UUID: TimeInterval] = [:]
     private var tabSwitchStartUptimeByTabID: [UUID: TimeInterval] = [:]
+    private var previewReloadRequestedCount = 0
+    private var previewReloadCoalescedCount = 0
+    private var previewReloadExecutedCount = 0
     private(set) var lastMinimapViewportLatencyMilliseconds: Int?
     private(set) var lastTabSwitchLatencyMilliseconds: Int?
     private let defaults = UserDefaults.standard
@@ -96,6 +104,38 @@ final class EditorPerformanceMonitor {
 
     func markPreviewUpdated(tabID: UUID) {
         signposter.emitEvent("preview")
+    }
+
+    func markPreviewReloadScheduled(coalesced: Bool) {
+        previewReloadRequestedCount &+= 1
+        if coalesced {
+            previewReloadCoalescedCount &+= 1
+        }
+    }
+
+    func markPreviewReloadExecuted() {
+        previewReloadExecutedCount &+= 1
+#if DEBUG
+        if previewReloadExecutedCount.isMultiple(of: 10) {
+            logger.debug(
+                "perf.preview_reload requested=\(self.previewReloadRequestedCount, privacy: .public) coalesced=\(self.previewReloadCoalescedCount, privacy: .public) executed=\(self.previewReloadExecutedCount, privacy: .public)"
+            )
+        }
+#endif
+    }
+
+    func previewReloadSnapshot() -> PreviewReloadSnapshot {
+        PreviewReloadSnapshot(
+            requested: previewReloadRequestedCount,
+            coalesced: previewReloadCoalescedCount,
+            executed: previewReloadExecutedCount
+        )
+    }
+
+    func resetPreviewReloadMetrics() {
+        previewReloadRequestedCount = 0
+        previewReloadCoalescedCount = 0
+        previewReloadExecutedCount = 0
     }
 
     func measureVirtualEditorLayout<T>(_ work: () -> T) -> T {

--- a/Neon Vision Editor/UI/ContentView+MarkdownProjectPreview.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownProjectPreview.swift
@@ -40,7 +40,8 @@ extension ContentView {
         isMarkdownProjectPreviewPresented &&
         projectRootFolderURL != nil &&
         !isSafeModeActive &&
-        !brainDumpLayoutEnabled
+        !brainDumpLayoutEnabled &&
+        !focusModeEnabled
     }
 
     var hasMarkdownOrPDFProjectPreviewFiles: Bool {

--- a/Neon Vision Editor/UI/ContentView+PreviewSplit.swift
+++ b/Neon Vision Editor/UI/ContentView+PreviewSplit.swift
@@ -160,7 +160,8 @@ extension ContentView {
         showMarkdownPreviewPane &&
         isMarkdownPreviewDocument &&
         !isSafeModeActive &&
-        !brainDumpLayoutEnabled
+        !brainDumpLayoutEnabled &&
+        !focusModeEnabled
     }
 
     var isWebPreviewSplitVisible: Bool {
@@ -168,7 +169,8 @@ extension ContentView {
         showWebPreviewPane &&
         (isSVGDocument || isHTMLPreviewDocument) &&
         !isSafeModeActive &&
-        !brainDumpLayoutEnabled
+        !brainDumpLayoutEnabled &&
+        !focusModeEnabled
     }
 
     var isImagePreviewSplitVisible: Bool {
@@ -176,7 +178,8 @@ extension ContentView {
         previewMode == .image &&
         isPNGPreviewDocument &&
         !isSafeModeActive &&
-        !brainDumpLayoutEnabled
+        !brainDumpLayoutEnabled &&
+        !focusModeEnabled
     }
 
     var isPDFPreviewSplitVisible: Bool {
@@ -184,7 +187,8 @@ extension ContentView {
         previewMode == .pdf &&
         isPDFPreviewDocument &&
         !isSafeModeActive &&
-        !brainDumpLayoutEnabled
+        !brainDumpLayoutEnabled &&
+        !focusModeEnabled
     }
 
 #if os(iOS) || os(visionOS)

--- a/Neon Vision Editor/UI/ContentView+QuickSwitcherFind.swift
+++ b/Neon Vision Editor/UI/ContentView+QuickSwitcherFind.swift
@@ -326,7 +326,7 @@ extension ContentView {
         case "cmd:join_lines":
             joinSelectedLines()
         case "cmd:focus_mode":
-            openFocusModeWindow()
+            focusModeEnabled.toggle()
         case "cmd:folder_compare":
             showFolderCompare = true
         case "cmd:toggle_git_changes":
@@ -1028,12 +1028,6 @@ extension ContentView {
         let source = currentContentBinding.wrappedValue
         let lines = source.components(separatedBy: .newlines).map { $0.trimmingCharacters(in: .whitespaces) }
         currentContentBinding.wrappedValue = lines.joined(separator: "\n")
-    }
-
-    func openFocusModeWindow() {
-#if os(macOS)
-        openWindow(id: "focus-mode")
-#endif
     }
 
     func scheduleWordCountRefresh(for text: String) {

--- a/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
+++ b/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
@@ -912,14 +912,14 @@ extension ContentView {
         }
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(isSelected ? Color.accentColor.opacity(0.18) : Color.secondary.opacity(0.10))
+                .fill(isSelected ? Color.accentColor.opacity(0.24) : Color.secondary.opacity(0.07))
         )
         .overlay(alignment: isDropTarget && !tabDropInsertionBefore ? .trailing : .leading) {
 #if os(macOS)
             if isSelected || wasPreviouslySelected || isDropTarget {
                 Capsule()
                     .fill(isDropTarget || isSelected ? Color.accentColor : Color.yellow)
-                    .frame(width: 3)
+                    .frame(width: isSelected ? 4 : 3)
                     .padding(.vertical, 3)
                     .accessibilityHidden(true)
             }
@@ -1038,7 +1038,7 @@ extension ContentView {
 
 #if os(macOS)
     private var usesProjectSidebarTabTransition: Bool {
-        showProjectStructureSidebar && projectNavigatorPlacement == .trailing && !brainDumpLayoutEnabled
+        showProjectStructureSidebar && projectNavigatorPlacement == .trailing && !brainDumpLayoutEnabled && !focusModeEnabled
     }
 
     private var usesTrailingTabTransition: Bool {

--- a/Neon Vision Editor/UI/ContentView+Types.swift
+++ b/Neon Vision Editor/UI/ContentView+Types.swift
@@ -1,6 +1,71 @@
 import Foundation
 
 extension ContentView {
+    struct TabChromeObservationSnapshot: Equatable {
+        let structureRevision: Int
+        let metadataRevision: Int
+    }
+
+    struct ProjectNavigationObservationSnapshot: Equatable {
+        let rootURL: URL?
+        let indexReady: Bool
+    }
+
+    struct EditorObservationSnapshot: Equatable {
+        let contentRevision: Int
+    }
+
+    struct PreviewObservationSnapshot: Equatable {
+        let projectEnabled: Bool
+        let contentFilter: String
+    }
+
+    struct WindowSessionObservationSnapshot: Equatable {
+        let persistenceRevision: Int
+    }
+
+    struct CommandRoutingObservationSnapshot: Equatable {
+        let windowNumber: Int?
+    }
+
+    var tabChromeObservationSnapshot: TabChromeObservationSnapshot {
+        TabChromeObservationSnapshot(
+            structureRevision: viewModel.tabsObservationToken,
+            metadataRevision: viewModel.tabMetadataObservationToken
+        )
+    }
+
+    var projectNavigationObservationSnapshot: ProjectNavigationObservationSnapshot {
+        ProjectNavigationObservationSnapshot(
+            rootURL: projectRootFolderURL,
+            indexReady: projectFileIndexHasCompleted
+        )
+    }
+
+    var editorObservationSnapshot: EditorObservationSnapshot {
+        EditorObservationSnapshot(contentRevision: viewModel.tabContentObservationToken)
+    }
+
+    var previewObservationSnapshot: PreviewObservationSnapshot {
+        PreviewObservationSnapshot(
+            projectEnabled: markdownProjectPreviewEnabled,
+            contentFilter: markdownProjectPreviewContentFilterRaw
+        )
+    }
+
+    var windowSessionObservationSnapshot: WindowSessionObservationSnapshot {
+        WindowSessionObservationSnapshot(persistenceRevision: viewModel.tabPersistenceObservationToken)
+    }
+
+    var commandRoutingObservationSnapshot: CommandRoutingObservationSnapshot {
+#if os(macOS)
+        let windowNumber = hostWindowNumber
+#else
+        let windowNumber: Int? = nil
+#endif
+        return CommandRoutingObservationSnapshot(windowNumber: windowNumber)
+    }
+
     enum SearchScope: String, CaseIterable, Identifiable {
         case currentFile = "currentFile"
         case openTabs = "openTabs"

--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -397,7 +397,7 @@ struct ContentView: View {
     }
 
     var effectiveShowCodeMinimap: Bool {
-        showCodeMinimap && !isSafeModeActive
+        showCodeMinimap && !isSafeModeActive && !focusModeEnabled
     }
 
     enum EditorPerformanceThresholds {
@@ -778,6 +778,7 @@ struct ContentView: View {
     @State var settingsSheetDetent: PresentationDetent = .large
     @SceneStorage("ProjectSidebarWidth") var projectSidebarWidth: Double = 450
     @SceneStorage("ProjectSidebarMode") var utilitySidebarModeRaw: String = UtilitySidebarMode.project.rawValue
+    @SceneStorage("EditorFocusModeEnabled") var focusModeEnabled: Bool = false
     @State var projectSidebarResizeStartWidth: CGFloat? = nil
 #if os(macOS)
     @SceneStorage("TOCSidebarWidth") var tocSidebarWidth: Double = 250
@@ -1283,8 +1284,8 @@ struct ContentView: View {
         guard let target = notif.userInfo?[EditorCommandUserInfo.windowNumber] as? Int else {
             return true
         }
-        guard let hostWindowNumber else { return false }
-        return target == hostWindowNumber
+        guard let windowNumber = commandRoutingObservationSnapshot.windowNumber else { return false }
+        return target == windowNumber
     }
 
     private func updateWindowRegistration(_ window: NSWindow?) {
@@ -2152,6 +2153,10 @@ struct ContentView: View {
                 guard matchesCurrentWindow(notif) else { return }
                 toggleSidebarFromToolbar()
             }
+            .onReceive(NotificationCenter.default.publisher(for: .toggleFocusModeRequested)) { notif in
+                guard matchesCurrentWindow(notif) else { return }
+                focusModeEnabled.toggle()
+            }
             .onReceive(NotificationCenter.default.publisher(for: .toggleBrainDumpModeRequested)) { notif in
                 guard matchesCurrentWindow(notif) else { return }
                 viewModel.isBrainDumpMode.toggle()
@@ -2441,7 +2446,7 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didResizeNotification)) { notification in
             persistWindowFrame(for: notification)
         }
-        .onChange(of: viewModel.tabsObservationToken) { _, _ in
+        .onChange(of: tabChromeObservationSnapshot) { _, _ in
             if activeSplitSecondaryTabID == nil {
                 splitSecondaryTabID = nil
             }
@@ -2632,7 +2637,7 @@ struct ContentView: View {
             .onChange(of: viewModel.isLineWrapEnabled) { _, _ in
                 scheduleHighlightRefresh()
             }
-            .onChange(of: viewModel.tabPersistenceObservationToken) { _, _ in
+            .onChange(of: windowSessionObservationSnapshot) { _, _ in
                 scheduleSessionPersistence()
                 scheduleUnsavedDraftSnapshotPersistence()
                 synchronizePDFNoteAttachment()
@@ -2640,6 +2645,9 @@ struct ContentView: View {
             .onChange(of: viewModel.selectedTabID) { previousTabID, selectedTabID in
                 guard previousTabID != selectedTabID else { return }
                 previousSelectedTabID = previousTabID
+                if activeSplitSecondaryTabID == nil {
+                    splitSecondaryTabID = nil
+                }
                 synchronizePDFNoteContext()
                 if let automaticPreviewMode = automaticPreviewModeForCurrentDocument {
                     previewMode = automaticPreviewMode
@@ -2679,6 +2687,13 @@ struct ContentView: View {
             }
             .onChange(of: previewMode) { _, _ in
                 persistSessionIfReady()
+            }
+            .onChange(of: focusModeEnabled) { _, enabled in
+                if enabled {
+                    cancelMarkdownProjectPreviewRefresh()
+                } else {
+                    refreshMarkdownProjectPreview()
+                }
             }
     }
 
@@ -3751,10 +3766,10 @@ struct ContentView: View {
 
     var shouldUseSplitView: Bool {
 #if os(macOS)
-        return viewModel.showSidebar && !brainDumpLayoutEnabled
+        return viewModel.showSidebar && !brainDumpLayoutEnabled && !focusModeEnabled
 #else
         // Keep iPhone layout single-column to avoid horizontal clipping.
-        return viewModel.showSidebar && !brainDumpLayoutEnabled && horizontalSizeClass == .regular
+        return viewModel.showSidebar && !brainDumpLayoutEnabled && !focusModeEnabled && horizontalSizeClass == .regular
 #endif
     }
 
@@ -3779,7 +3794,7 @@ struct ContentView: View {
     // Sidebar shows a lightweight table of contents (TOC) derived from the current document.
     @ViewBuilder
     var sidebarView: some View {
-        if viewModel.showSidebar && !brainDumpLayoutEnabled {
+        if viewModel.showSidebar && !brainDumpLayoutEnabled && !focusModeEnabled {
             SidebarView(
                 content: sidebarTOCContent,
                 language: currentLanguage,
@@ -4288,6 +4303,7 @@ struct ContentView: View {
             document: tab?.document,
             documentID: tabID,
             documentResourceID: documentResourceID(for: tabID),
+            documentDisplayName: tab?.name ?? "Untitled",
             contentRevision: tab?.contentRevision ?? 0,
             externalContentRevision: tab?.externalContentRevision ?? 0,
             storedCaretLocation: storedCaretLocation(for: tabID),
@@ -4876,14 +4892,14 @@ struct ContentView: View {
 #endif
 
         let content = HStack(spacing: 0) {
-            if showProjectStructureSidebar && projectNavigatorPlacement == .leading && !brainDumpLayoutEnabled {
+            if showProjectStructureSidebar && projectNavigatorPlacement == .leading && !brainDumpLayoutEnabled && !focusModeEnabled {
                 projectStructureSidebarPanel
                 projectSidebarResizeHandle
             }
 
             editorAndPreview
 
-            if showProjectStructureSidebar && projectNavigatorPlacement == .trailing && !brainDumpLayoutEnabled {
+            if showProjectStructureSidebar && projectNavigatorPlacement == .trailing && !brainDumpLayoutEnabled && !focusModeEnabled {
                 projectSidebarResizeHandle
                 projectStructureSidebarPanel
             }
@@ -4946,7 +4962,7 @@ struct ContentView: View {
                 presentMarkdownProjectPreviewIfAvailable()
             }
         }
-        .onChange(of: viewModel.tabContentObservationToken) { _, _ in
+        .onChange(of: editorObservationSnapshot) { _, _ in
             refreshSecondaryContentViewsIfNeeded()
             if let tabID = viewModel.selectedTabID {
                 EditorPerformanceMonitor.shared.markTOCUpdated(tabID: tabID)
@@ -4960,26 +4976,18 @@ struct ContentView: View {
         .onChange(of: viewModel.selectedTab?.fileURL) { _, _ in
             openAutomaticPreviewIfNeeded()
         }
-        .onChange(of: projectRootFolderURL) { _, _ in
+        .onChange(of: projectNavigationObservationSnapshot) { _, snapshot in
             refreshMarkdownProjectPreview()
-            if shouldAutomaticallyPresentMarkdownProjectPreview {
+            if snapshot.indexReady, shouldAutomaticallyPresentMarkdownProjectPreview {
                 presentMarkdownProjectPreviewIfAvailable()
             }
         }
-        .onChange(of: projectFileIndexHasCompleted) { _, isReady in
-            if isReady, shouldAutomaticallyPresentMarkdownProjectPreview {
-                presentMarkdownProjectPreviewIfAvailable()
-            }
-        }
-            .onChange(of: markdownProjectPreviewEnabled) { _, _ in
-            if !markdownProjectPreviewEnabled {
+        .onChange(of: previewObservationSnapshot) { _, snapshot in
+            if !snapshot.projectEnabled {
                 isMarkdownProjectPreviewPresented = false
             }
-                refreshMarkdownProjectPreview()
-            }
-            .onChange(of: markdownProjectPreviewContentFilterRaw) { _, _ in
-                refreshMarkdownProjectPreview()
-            }
+            refreshMarkdownProjectPreview()
+        }
         .onChange(of: delimitedViewMode) { _, newValue in
             handleDelimitedViewModeChange(newValue)
         }
@@ -5133,7 +5141,7 @@ struct ContentView: View {
             macToolbarBackgroundStyle,
             for: ToolbarPlacement.windowToolbar
         )
-        .modifier(MacToolbarVisibilityModifier())
+        .modifier(MacToolbarVisibilityModifier(hidden: focusModeEnabled))
         .tint(NeonUIStyle.accentBlue)
 #else
         .toolbarBackground(

--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -2603,7 +2603,17 @@ struct ContentView: View {
     }
 
     private var rootViewWithStateObservers: some View {
-        applyUpdateVisibilityObservers(to: basePlatformRootView)
+        applyPresentationStateObservers(
+            to: applySessionStateObservers(
+                to: applyEditorSettingObservers(
+                    to: applyUpdateVisibilityObservers(to: basePlatformRootView)
+                )
+            )
+        )
+    }
+
+    private func applyEditorSettingObservers<Content: View>(to view: Content) -> some View {
+        view
             .onAppear {
                 handleSettingsAndEditorDefaultsOnAppear()
             }
@@ -2637,6 +2647,10 @@ struct ContentView: View {
             .onChange(of: viewModel.isLineWrapEnabled) { _, _ in
                 scheduleHighlightRefresh()
             }
+    }
+
+    private func applySessionStateObservers<Content: View>(to view: Content) -> some View {
+        view
             .onChange(of: windowSessionObservationSnapshot) { _, _ in
                 scheduleSessionPersistence()
                 scheduleUnsavedDraftSnapshotPersistence()
@@ -2670,6 +2684,10 @@ struct ContentView: View {
             .onChange(of: viewModel.showSidebar) { _, _ in
                 persistSessionIfReady()
             }
+    }
+
+    private func applyPresentationStateObservers<Content: View>(to view: Content) -> some View {
+        view
             .onChange(of: showProjectStructureSidebar) { _, isPresented in
                 persistSessionIfReady()
                 if !isPresented {

--- a/Neon Vision Editor/UI/EditorTextView+iOS.swift
+++ b/Neon Vision Editor/UI/EditorTextView+iOS.swift
@@ -11,7 +11,75 @@ nonisolated func iPadShiftScrollFontSizeDelta(contentOffsetDeltaY: CGFloat) -> C
     -contentOffsetDeltaY * 0.04
 }
 
+enum EditorLineStartIndex {
+    static func offsets(in text: String) -> [Int] {
+        var starts = [0]
+        starts.reserveCapacity(max(32, text.utf16.count / 24))
+        var offset = 0
+        for codeUnit in text.utf16 {
+            offset += 1
+            if codeUnit == 10 { starts.append(offset) }
+        }
+        return starts
+    }
+
+    static func applying(replacementRange: NSRange, replacement: String, to lineStarts: [Int]) -> [Int] {
+        guard !lineStarts.isEmpty else { return offsets(in: replacement) }
+        let replacedEnd = NSMaxRange(replacementRange)
+        let delta = replacement.utf16.count - replacementRange.length
+        var updated = lineStarts
+        let firstAffected = firstIndex(in: updated, greaterThan: replacementRange.location)
+        let firstUnaffected = firstIndex(in: updated, greaterThan: replacedEnd)
+        if firstAffected < firstUnaffected {
+            updated.removeSubrange(firstAffected..<firstUnaffected)
+        }
+        for index in firstAffected..<updated.count {
+            updated[index] += delta
+        }
+        var insertedStarts: [Int] = []
+        var replacementOffset = 0
+        for codeUnit in replacement.utf16 {
+            replacementOffset += 1
+            if codeUnit == 10 {
+                insertedStarts.append(replacementRange.location + replacementOffset)
+            }
+        }
+        updated.insert(contentsOf: insertedStarts, at: firstAffected)
+        return updated
+    }
+
+    private static func firstIndex(in values: [Int], greaterThan target: Int) -> Int {
+        var lower = 0
+        var upper = values.count
+        while lower < upper {
+            let midpoint = (lower + upper) / 2
+            if values[midpoint] <= target { lower = midpoint + 1 } else { upper = midpoint }
+        }
+        return lower
+    }
+}
+
+enum EditorLargeTextFormatting {
+    static func updateRange(visibleRange: NSRange, textLength: Int, padding: Int = 8_000) -> NSRange {
+        guard textLength > 0 else { return NSRange(location: 0, length: 0) }
+        let safeLocation = min(max(0, visibleRange.location), textLength)
+        let safeEnd = min(max(safeLocation, NSMaxRange(visibleRange)), textLength)
+        let start = max(0, safeLocation - padding)
+        let end = min(textLength, safeEnd + padding)
+        return NSRange(location: start, length: end - start)
+    }
+}
+
 final class EditorInputTextView: UITextView {
+    private struct NoWrapWidthCache {
+        let revision: Int
+        let visibleWidth: CGFloat
+        let tabWidth: Int
+        let fontName: String
+        let fontSize: CGFloat
+        let width: CGFloat
+    }
+
     private let vimModeDefaultsKey = "EditorVimModeEnabled"
     private let vimInterceptionDefaultsKey = "EditorVimInterceptionEnabled"
     private let bracketTokens: [String] = ["(", ")", "{", "}", "[", "]", "<", ">", "'", "\"", "`", "()", "{}", "[]", "\"\"", "''"]
@@ -19,11 +87,68 @@ final class EditorInputTextView: UITextView {
     private var pendingDeleteCurrentLineCommand = false
     private var preferredShouldWrapText: Bool = true
     private var preferredTextContainerWidth: CGFloat = 0
+    private var textMetricsRevision = 0
+    private var noWrapWidthCache: NoWrapWidthCache?
+    private var lineStartCache: (revision: Int, offsets: [Int])?
     private var activeShiftPressIdentifiers: Set<ObjectIdentifier> = []
     var isHardwareKeyboardShiftPressed: Bool {
         !activeShiftPressIdentifiers.isEmpty
     }
     var markdownFormattingEnabled: Bool = false
+
+    func invalidateTextMetrics() {
+        textMetricsRevision &+= 1
+        noWrapWidthCache = nil
+        lineStartCache = nil
+    }
+
+    func applyTextMetricsMutation(range: NSRange, replacement: String) {
+        let cachedOffsets = lineStartCache.flatMap { cache in
+            cache.revision == textMetricsRevision ? cache.offsets : nil
+        }
+        textMetricsRevision &+= 1
+        noWrapWidthCache = nil
+        lineStartCache = cachedOffsets.map {
+            (
+                revision: textMetricsRevision,
+                offsets: EditorLineStartIndex.applying(
+                    replacementRange: range,
+                    replacement: replacement,
+                    to: $0
+                )
+            )
+        }
+    }
+
+    func cachedLineStartOffsets() -> [Int] {
+        if let lineStartCache, lineStartCache.revision == textMetricsRevision {
+            return lineStartCache.offsets
+        }
+        let offsets = EditorLineStartIndex.offsets(in: text ?? "")
+        lineStartCache = (textMetricsRevision, offsets)
+        return offsets
+    }
+
+    func cachedNoWrapWidth(visibleWidth: CGFloat, tabWidth: Int, font: UIFont, compute: () -> CGFloat) -> CGFloat {
+        if let cache = noWrapWidthCache,
+           cache.revision == textMetricsRevision,
+           abs(cache.visibleWidth - visibleWidth) < 0.5,
+           cache.tabWidth == tabWidth,
+           cache.fontName == font.fontName,
+           abs(cache.fontSize - font.pointSize) < 0.01 {
+            return cache.width
+        }
+        let width = compute()
+        noWrapWidthCache = NoWrapWidthCache(
+            revision: textMetricsRevision,
+            visibleWidth: visibleWidth,
+            tabWidth: tabWidth,
+            fontName: font.fontName,
+            fontSize: font.pointSize,
+            width: width
+        )
+        return width
+    }
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         for press in presses where press.key?.modifierFlags.contains(.shift) == true {
@@ -833,19 +958,7 @@ extension EditorInputTextView {
     }
 
     private func lineStartLocations() -> [Int] {
-        let nsText = vimText()
-        var starts: [Int] = [0]
-        var location = 0
-        while location < nsText.length {
-            let lineRange = nsText.lineRange(for: NSRange(location: location, length: 0))
-            let nextLocation = NSMaxRange(lineRange)
-            if nextLocation >= nsText.length {
-                break
-            }
-            starts.append(nextLocation)
-            location = nextLocation
-        }
-        return starts
+        cachedLineStartOffsets()
     }
 
     private func wordCharacterSetContains(_ scalar: UnicodeScalar) -> Bool {
@@ -1309,7 +1422,7 @@ final class LineNumberedTextViewContainer: UIView {
             cachedFontPointSize = numberFont.pointSize
             needsDisplayRefresh = true
         }
-        let lineStarts = lineStartOffsets(for: text)
+        let lineStarts = EditorLineStartIndex.offsets(in: text)
         if lineStarts != cachedLineStarts {
             cachedLineStarts = lineStarts
             lineNumberView.lineStarts = lineStarts
@@ -1341,18 +1454,33 @@ final class LineNumberedTextViewContainer: UIView {
         updateLineNumbers(for: text, fontSize: fontSize)
     }
 
-    private func lineStartOffsets(for text: String) -> [Int] {
-        var starts: [Int] = [0]
-        let utf16 = text.utf16
-        starts.reserveCapacity(max(32, utf16.count / 24))
-        var idx = 0
-        for codeUnit in utf16 {
-            idx += 1
-            if codeUnit == 10 { // '\n'
-                starts.append(idx)
-            }
+    func updateLineNumbers(
+        afterReplacing range: NSRange,
+        with replacement: String,
+        resultingText: String,
+        fontSize: CGFloat
+    ) {
+        cachedLineStarts = EditorLineStartIndex.applying(
+            replacementRange: range,
+            replacement: replacement,
+            to: cachedLineStarts
+        )
+        lineNumberView.lineStarts = cachedLineStarts
+        cachedTextLength = resultingText.utf16.count
+        let numberFont = UIFont.monospacedDigitSystemFont(ofSize: max(11, fontSize - 1), weight: .regular)
+        if abs(cachedFontPointSize - numberFont.pointSize) > 0.01 {
+            lineNumberView.font = numberFont
+            cachedFontPointSize = numberFont.pointSize
         }
-        return starts
+        let digits = max(2, String(max(1, cachedLineStarts.count)).count)
+        let glyphWidth = NSString(string: "8").size(withAttributes: [.font: numberFont]).width
+        let targetWidth = ceil((glyphWidth * CGFloat(digits)) + 14)
+        if abs(cachedLineNumberWidth - targetWidth) > 0.5 {
+            cachedLineNumberWidth = targetWidth
+            lineNumberWidthConstraint?.constant = targetWidth
+            setNeedsLayout()
+        }
+        lineNumberView.setNeedsDisplay()
     }
 }
 
@@ -1536,27 +1664,30 @@ struct CustomTextEditor: UIViewRepresentable {
         let text = textView.text ?? ""
         let minimumScrollableWidth = noWrapMinimumScrollableWidth(visibleWidth: visibleWidth)
         guard !text.isEmpty else { return minimumScrollableWidth }
-        let nsText = text as NSString
-        let sampleLimit = min(nsText.length, 120_000)
-        var maxColumns = 0
-        var currentColumns = 0
         let tabWidth = max(1, indentWidth)
-        for index in 0..<sampleLimit {
-            let unit = nsText.character(at: index)
-            if unit == 10 || unit == 13 {
-                maxColumns = max(maxColumns, currentColumns)
-                currentColumns = 0
-            } else if unit == 9 {
-                currentColumns += tabWidth
-            } else {
-                currentColumns += 1
-            }
-        }
-        maxColumns = max(maxColumns, currentColumns)
         let font = textView.font ?? resolvedUIFont()
-        let columnWidth = NSString(string: "W").size(withAttributes: [.font: font]).width
-        let measuredWidth = ceil(CGFloat(maxColumns) * max(1, columnWidth)) + textView.textContainerInset.left + textView.textContainerInset.right + 32
-        return max(minimumScrollableWidth, min(measuredWidth, 20_000))
+        guard let editorTextView = textView as? EditorInputTextView else { return minimumScrollableWidth }
+        return editorTextView.cachedNoWrapWidth(visibleWidth: visibleWidth, tabWidth: tabWidth, font: font) {
+            let nsText = text as NSString
+            let sampleLimit = min(nsText.length, 120_000)
+            var maxColumns = 0
+            var currentColumns = 0
+            for index in 0..<sampleLimit {
+                let unit = nsText.character(at: index)
+                if unit == 10 || unit == 13 {
+                    maxColumns = max(maxColumns, currentColumns)
+                    currentColumns = 0
+                } else if unit == 9 {
+                    currentColumns += tabWidth
+                } else {
+                    currentColumns += 1
+                }
+            }
+            maxColumns = max(maxColumns, currentColumns)
+            let columnWidth = NSString(string: "W").size(withAttributes: [.font: font]).width
+            let measuredWidth = ceil(CGFloat(maxColumns) * max(1, columnWidth)) + textView.textContainerInset.left + textView.textContainerInset.right + 32
+            return max(minimumScrollableWidth, min(measuredWidth, 20_000))
+        }
     }
 
     private func noWrapMinimumScrollableWidth(visibleWidth: CGFloat) -> CGFloat {
@@ -1596,6 +1727,7 @@ struct CustomTextEditor: UIViewRepresentable {
         } else {
             textView.text = text
         }
+        textView.invalidateTextMetrics()
         if text.count <= 200_000 {
             textView.textStorage.beginEditing()
             textView.textStorage.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: textView.textStorage.length))
@@ -1709,6 +1841,7 @@ struct CustomTextEditor: UIViewRepresentable {
                     )
                     if !didInstallLargeText {
                         textView.text = text
+                        textView.invalidateTextMetrics()
                         let length = (textView.text as NSString).length
                         if didSwitchDocumentResource {
                             textView.selectedRange = NSRange(location: 0, length: 0)
@@ -1736,14 +1869,31 @@ struct CustomTextEditor: UIViewRepresentable {
            context.coordinator.lastLineHeight != lineHeightMultiple
             || context.coordinator.lastLetterSpacing != letterSpacing {
             let len = textView.textStorage.length
-            if len > 0 && len <= 200_000 {
+            if len > 0 {
+                let formattingRange: NSRange
+                if len <= 200_000 {
+                    formattingRange = NSRange(location: 0, length: len)
+                } else {
+                    let visibleGlyphs = textView.layoutManager.glyphRange(
+                        forBoundingRect: textView.bounds.insetBy(dx: 0, dy: -textView.bounds.height),
+                        in: textView.textContainer
+                    )
+                    let visibleCharacters = textView.layoutManager.characterRange(
+                        forGlyphRange: visibleGlyphs,
+                        actualGlyphRange: nil
+                    )
+                    formattingRange = EditorLargeTextFormatting.updateRange(
+                        visibleRange: visibleCharacters,
+                        textLength: len
+                    )
+                }
                 let undoWasEnabled = textView.undoManager?.isUndoRegistrationEnabled ?? false
                 if undoWasEnabled {
                     textView.undoManager?.disableUndoRegistration()
                 }
                 textView.textStorage.beginEditing()
-                textView.textStorage.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: len))
-                textView.textStorage.addAttribute(.kern, value: letterSpacing, range: NSRange(location: 0, length: len))
+                textView.textStorage.addAttribute(.paragraphStyle, value: paragraphStyle, range: formattingRange)
+                textView.textStorage.addAttribute(.kern, value: letterSpacing, range: formattingRange)
                 textView.textStorage.endEditing()
                 if undoWasEnabled {
                     textView.undoManager?.enableUndoRegistration()
@@ -2023,6 +2173,7 @@ struct CustomTextEditor: UIViewRepresentable {
             let installDocumentResourceID = parent.documentResourceID
             textView.isEditable = false
             textView.text = ""
+            textView.invalidateTextMetrics()
 
             let nsTarget = target as NSString
 
@@ -2039,6 +2190,7 @@ struct CustomTextEditor: UIViewRepresentable {
                 let remaining = targetLength - location
                 guard remaining > 0 else {
                     self.isInstallingLargeText = false
+                    textView.invalidateTextMetrics()
                     textView.isEditable = !parent.isReadOnly
                     if let restoredCaretLocation {
                         let range = NSRange(
@@ -2765,6 +2917,7 @@ struct CustomTextEditor: UIViewRepresentable {
 
         func textViewDidChange(_ textView: UITextView) {
             guard !isApplyingHighlight else { return }
+            let lineNumberMutation = pendingTextMutation
             let didApplyIncrementalMutation = applyPendingTextMutationIfPossible()
             if !didApplyIncrementalMutation {
                 syncBindingText(textView.text)
@@ -2773,9 +2926,26 @@ struct CustomTextEditor: UIViewRepresentable {
                editorTextView.rendersInvisibleCharacters || editorTextView.rendersIndentationGuides {
                 editorTextView.invisibleCharactersOverlayView?.requestRedraw(immediate: !isPhoneActivelyEditing)
             }
+            if let editorTextView = textView as? EditorInputTextView {
+                if let lineNumberMutation {
+                    editorTextView.applyTextMetricsMutation(
+                        range: lineNumberMutation.range,
+                        replacement: lineNumberMutation.replacement
+                    )
+                } else {
+                    editorTextView.invalidateTextMetrics()
+                }
+            }
             if shouldRenderLineNumbers() {
                 if UIDevice.current.userInterfaceIdiom == .phone, textView.isFirstResponder {
                     container?.lineNumberView.setNeedsDisplay()
+                } else if didApplyIncrementalMutation, let lineNumberMutation {
+                    container?.updateLineNumbers(
+                        afterReplacing: lineNumberMutation.range,
+                        with: lineNumberMutation.replacement,
+                        resultingText: textView.text,
+                        fontSize: parent.fontSize
+                    )
                 } else {
                     container?.updateLineNumbersAfterInteractiveEdit(for: textView.text, fontSize: parent.fontSize)
                 }

--- a/Neon Vision Editor/UI/GlassSurface.swift
+++ b/Neon Vision Editor/UI/GlassSurface.swift
@@ -12,10 +12,14 @@ enum GlassShapeKind {
 
 #if os(macOS)
 struct MacToolbarVisibilityModifier: ViewModifier {
+    var hidden: Bool = false
+
     @ViewBuilder
     func body(content: Content) -> some View {
         if #available(macOS 15.0, *) {
-            content.toolbarBackgroundVisibility(.visible, for: .windowToolbar)
+            content
+                .toolbar(hidden ? .hidden : .automatic, for: .windowToolbar)
+                .toolbarBackgroundVisibility(hidden ? .hidden : .visible, for: .windowToolbar)
         } else {
             content
         }

--- a/Neon Vision Editor/UI/MarkdownPreviewWebView.swift
+++ b/Neon Vision Editor/UI/MarkdownPreviewWebView.swift
@@ -90,6 +90,7 @@ struct MarkdownPreviewWebView: NSViewRepresentable {
         private static let scrollMessageName = "nvePreviewScroll"
 
         func scheduleReloadPreservingScroll(webView: WKWebView, html: String, baseURL: URL?) {
+            EditorPerformanceMonitor.shared.markPreviewReloadScheduled(coalesced: pendingReload != nil)
             pendingReload?.cancel()
             reloadGeneration &+= 1
             let generation = reloadGeneration
@@ -107,6 +108,7 @@ struct MarkdownPreviewWebView: NSViewRepresentable {
             webView.evaluateJavaScript(capture) { [weak self, weak webView] value, _ in
                 guard let self, let webView, self.reloadGeneration == generation else { return }
                 let ratio = value as? Double ?? 0
+                EditorPerformanceMonitor.shared.markPreviewReloadExecuted()
                 webView.loadHTMLString(html, baseURL: baseURL)
                 let clamped = min(1.0, max(0.0, ratio))
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) { [weak self, weak webView] in
@@ -226,6 +228,7 @@ struct MarkdownPreviewWebView: UIViewRepresentable {
         private static let scrollMessageName = "nvePreviewScroll"
 
         func scheduleReloadPreservingScroll(webView: WKWebView, html: String, baseURL: URL?) {
+            EditorPerformanceMonitor.shared.markPreviewReloadScheduled(coalesced: pendingReload != nil)
             pendingReload?.cancel()
             reloadGeneration &+= 1
             let generation = reloadGeneration
@@ -243,6 +246,7 @@ struct MarkdownPreviewWebView: UIViewRepresentable {
             webView.evaluateJavaScript(capture) { [weak self, weak webView] value, _ in
                 guard let self, let webView, self.reloadGeneration == generation else { return }
                 let ratio = value as? Double ?? 0
+                EditorPerformanceMonitor.shared.markPreviewReloadExecuted()
                 webView.loadHTMLString(html, baseURL: baseURL)
                 let clamped = min(1.0, max(0.0, ratio))
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) { [weak self, weak webView] in

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -4260,6 +4260,7 @@ extension Notification.Name {
     static let structureTextAsJSONRequested = Notification.Name("structureTextAsJSONRequested")
     static let showIntegratedTerminalRequested = Notification.Name("showIntegratedTerminalRequested")
     static let toggleCodeMinimapRequested = Notification.Name("toggleCodeMinimapRequested")
+    static let toggleFocusModeRequested = Notification.Name("toggleFocusModeRequested")
     static let editorViewportDidChange = Notification.Name("editorViewportDidChange")
     static let requestEditorViewport = Notification.Name("requestEditorViewport")
     static let virtualEditorTextDidChange = Notification.Name("virtualEditorTextDidChange")

--- a/Neon Vision Editor/UI/SidebarViews.swift
+++ b/Neon Vision Editor/UI/SidebarViews.swift
@@ -156,13 +156,29 @@ struct SidebarView: View {
         .padding(.horizontal, tocRowHorizontalPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(isSelected ? Color.accentColor.opacity(colorScheme == .dark ? 0.26 : 0.20) : sidebarRowFill)
+            RoundedRectangle(cornerRadius: tocRowCornerRadius, style: .continuous)
+                .fill(tocRowBackground(isSelected: isSelected))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
+            RoundedRectangle(cornerRadius: tocRowCornerRadius, style: .continuous)
                 .stroke(isSelected ? Color.accentColor.opacity(0.62) : Color.clear, lineWidth: 1)
         )
+    }
+
+    private func tocRowBackground(isSelected: Bool) -> Color {
+#if os(macOS)
+        isSelected ? Color.accentColor.opacity(colorScheme == .dark ? 0.22 : 0.16) : Color.clear
+#else
+        isSelected ? Color.accentColor.opacity(colorScheme == .dark ? 0.26 : 0.20) : sidebarRowFill
+#endif
+    }
+
+    private var tocRowCornerRadius: CGFloat {
+#if os(macOS)
+        6
+#else
+        12
+#endif
     }
 
     @ViewBuilder
@@ -275,7 +291,7 @@ struct SidebarView: View {
 #if os(iOS)
         isCompactTOCWidth ? 2.5 : 6
 #else
-        8
+        4
 #endif
     }
 
@@ -2029,6 +2045,7 @@ struct ProjectStructureSidebarView: View {
                             .symbolRenderingMode(.hierarchical)
                         Text(node.url.lastPathComponent)
                             .lineLimit(1)
+                            .font(.system(size: CGFloat(sidebarFontSize), weight: isSelected ? .semibold : .regular))
                         Spacer()
                     }
                     .font(rowFont)
@@ -2041,7 +2058,7 @@ struct ProjectStructureSidebarView: View {
                         if isSelected {
                             Capsule(style: .continuous)
                                 .fill(Color.accentColor)
-                                .frame(width: 3)
+                                .frame(width: 4)
                                 .padding(.vertical, 5)
                         } else if let gitStatus {
                             Capsule(style: .continuous)
@@ -2265,8 +2282,16 @@ struct ProjectStructureSidebarView: View {
     }
 
     private func rowChrome(isSelected: Bool, isHovered: Bool) -> some View {
-        RoundedRectangle(cornerRadius: isCompactDensity ? 10 : 12, style: .continuous)
+        RoundedRectangle(cornerRadius: projectRowCornerRadius, style: .continuous)
             .fill(rowFill(isSelected: isSelected, isHovered: isHovered))
+    }
+
+    private var projectRowCornerRadius: CGFloat {
+#if os(macOS)
+        isCompactDensity ? 5 : 6
+#else
+        isCompactDensity ? 10 : 12
+#endif
     }
 
     private func rowFill(isSelected: Bool, isHovered: Bool) -> Color {
@@ -2311,7 +2336,11 @@ struct ProjectStructureSidebarView: View {
         if isHovered {
             return Color.accentColor
         }
+#if os(macOS)
+        return Color.secondary
+#else
         return translucentBackgroundEnabled ? Color.accentColor.opacity(0.92) : Color.accentColor.opacity(0.96)
+#endif
     }
 
     private func gitStatusColor(_ status: GitFileStatus) -> Color {

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -9,6 +9,44 @@ struct VirtualEditorVisualFragment {
     let line: CTLine
 }
 
+struct VirtualEditorViewportLine: Sendable {
+    let localLine: Int
+    let startUTF16: Int
+    let text: String
+}
+
+nonisolated private struct VirtualEditorSyntaxSpan: Sendable {
+    let range: NSRange
+    let color: Color
+}
+
+nonisolated private struct VirtualEditorSyntaxLineCacheKey: Hashable, Sendable {
+    let language: String
+    let theme: String
+    let text: String
+}
+
+private enum VirtualEditorSyntaxLineCache {
+    nonisolated private static let maximumEntryCount = 2_048
+    nonisolated private static let maximumCachedLineLength = 8_192
+    nonisolated static let storage = NVELock<[VirtualEditorSyntaxLineCacheKey: [VirtualEditorSyntaxSpan]]>([:])
+
+    nonisolated static func spans(for key: VirtualEditorSyntaxLineCacheKey) -> [VirtualEditorSyntaxSpan]? {
+        guard key.text.utf16.count <= maximumCachedLineLength else { return nil }
+        return storage.withLock { $0[key] }
+    }
+
+    nonisolated static func store(_ spans: [VirtualEditorSyntaxSpan], for key: VirtualEditorSyntaxLineCacheKey) {
+        guard key.text.utf16.count <= maximumCachedLineLength else { return }
+        storage.withLock { cache in
+            if cache[key] == nil, cache.count >= maximumEntryCount, let evictionKey = cache.keys.first {
+                cache.removeValue(forKey: evictionKey)
+            }
+            cache[key] = spans
+        }
+    }
+}
+
 struct VirtualEditorVisualFragmentCache {
     private struct Entry {
         let width: CGFloat
@@ -154,6 +192,7 @@ struct VirtualEditorView: NSViewRepresentable {
     let document: (any EditorDocument)?
     let documentID: UUID?
     let documentResourceID: String
+    let documentDisplayName: String
     let contentRevision: Int
     let externalContentRevision: Int
     let storedCaretLocation: Int?
@@ -193,6 +232,7 @@ struct VirtualEditorView: NSViewRepresentable {
             document: document,
             documentID: documentID,
             resourceID: documentResourceID,
+            displayName: documentDisplayName,
             contentRevision: contentRevision,
             externalContentRevision: externalContentRevision,
             caret: storedCaretLocation,
@@ -225,6 +265,7 @@ struct VirtualEditorView: NSViewRepresentable {
             document: document,
             documentID: documentID,
             resourceID: documentResourceID,
+            displayName: documentDisplayName,
             contentRevision: contentRevision,
             externalContentRevision: externalContentRevision,
             caret: storedCaretLocation,
@@ -451,7 +492,8 @@ final class VirtualEditorScrollView: NSScrollView {
     }
 
     func configure(
-        document: (any EditorDocument)?, documentID: UUID?, resourceID: String, contentRevision: Int, externalContentRevision: Int,
+        document: (any EditorDocument)?, documentID: UUID?, resourceID: String, displayName: String,
+        contentRevision: Int, externalContentRevision: Int,
         caret: Int?, language: String, colorScheme: ColorScheme, fontSize: CGFloat,
         fontName: String, lineHeightMultiplier: CGFloat,
         isReadOnly: Bool, translucentBackgroundEnabled: Bool, showsLineNumbers: Bool, highlightCurrentLine: Bool,
@@ -465,7 +507,8 @@ final class VirtualEditorScrollView: NSScrollView {
         hasHorizontalScroller = !lineWrapEnabled
         MacOverlayScrollerPolicy.configure(self, clearBackground: true)
         canvas.configure(
-            document: document, documentID: documentID, resourceID: resourceID, contentRevision: contentRevision, externalContentRevision: externalContentRevision,
+            document: document, documentID: documentID, resourceID: resourceID, displayName: displayName,
+            contentRevision: contentRevision, externalContentRevision: externalContentRevision,
             caret: caret, language: language, colorScheme: colorScheme,
             fontSize: fontSize, fontName: fontName, lineHeightMultiplier: lineHeightMultiplier,
             isReadOnly: isReadOnly,
@@ -600,6 +643,24 @@ final class VirtualEditorScrollView: NSScrollView {
     }
 }
 
+struct VirtualEditorAccessibilityContext: Equatable {
+    let documentName: String
+    let line: Int
+    let column: Int
+    let isReadOnly: Bool
+    let selectionLength: Int
+
+    var label: String { "\(documentName), editor" }
+
+    var help: String {
+        let editability = isReadOnly ? "read only" : "editable"
+        let selectionStatus = selectionLength > 0
+            ? "\(selectionLength) characters selected"
+            : "no selection"
+        return "Line \(line), column \(column), \(editability), \(selectionStatus)."
+    }
+}
+
 @MainActor
 final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private enum Geometry {
@@ -636,6 +697,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private var viewport: EditorDocumentViewport?
     private var viewportText = ""
     private var lineStarts: [Int] = [0]
+    private var viewportLines: [VirtualEditorViewportLine] = []
     var viewportLineOrigin = 0
     private var absoluteCaret = 0
     private var selection = NSRange(location: 0, length: 0)
@@ -646,14 +708,20 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private var pendingDragPublication: DispatchWorkItem?
     private let documentUndoManager = UndoManager()
     private var lastConfigurationKey = ""
+    private var documentDisplayName = "Untitled"
     private var layoutCache: [Int: CTLine] = [:]
     private var attributedLineCache: [Int: NSAttributedString] = [:]
     private var visualFragmentCache = VirtualEditorVisualFragmentCache()
+    private var visualRowsSnapshot: (key: String, rows: [VisualRow])?
+    private var syntaxSpansByLine: [Int: [VirtualEditorSyntaxSpan]] = [:]
+    private var syntaxHighlightTask: Task<Void, Never>?
+    private var syntaxHighlightGeneration = 0
     private var visibleColors: [NSRange: NSColor] = [:]
     private var viewportSize: CGSize = .zero {
         didSet {
             guard viewportSize != oldValue else { return }
             visualFragmentCache.removeAll(keepingCapacity: true)
+            visualRowsSnapshot = nil
             invalidateIntrinsicContentSize()
             needsDisplay = true
         }
@@ -696,7 +764,13 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         let rows = EditorPerformanceMonitor.shared.measureVirtualEditorLayout {
             visualRows()
         }
-        let logicalLines = max(1, Set(rows.map(\.logicalLine)).count)
+        var logicalLines = 0
+        var previousLogicalLine: Int?
+        for row in rows where row.logicalLine != previousLogicalLine {
+            logicalLines += 1
+            previousLogicalLine = row.logicalLine
+        }
+        logicalLines = max(1, logicalLines)
         let observed = CGFloat(max(1, rows.count)) / CGFloat(logicalLines)
         if abs(observed - estimatedRowsPerLogicalLine) > 0.05 {
             estimatedRowsPerLogicalLine = VirtualEditorVisualRowIndex.smoothedEstimate(
@@ -713,8 +787,22 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     override var undoManager: UndoManager? { documentUndoManager }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
     override func accessibilityRole() -> NSAccessibility.Role? { .textArea }
-    override func accessibilityLabel() -> String? { "Editor" }
+    override func accessibilityLabel() -> String? { accessibilityContext.label }
     override func accessibilityValue() -> Any? { viewportText }
+    override func accessibilityHelp() -> String? { accessibilityContext.help }
+
+    private var accessibilityContext: VirtualEditorAccessibilityContext {
+        let localCaret = max(0, min(viewportText.utf16.count, absoluteCaret - viewportLineOriginStartUTF16))
+        let localLine = newlineCount(inUTF16PrefixOf: viewportText, length: localCaret)
+        let lineStart = lineStarts[min(localLine, max(0, lineStarts.count - 1))]
+        return VirtualEditorAccessibilityContext(
+            documentName: documentDisplayName,
+            line: viewportLineOrigin + localLine + 1,
+            column: localCaret - lineStart + 1,
+            isReadOnly: isReadOnly,
+            selectionLength: selection.length
+        )
+    }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -726,7 +814,10 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-    deinit { NotificationCenter.default.removeObserver(self) }
+    deinit {
+        syntaxHighlightTask?.cancel()
+        NotificationCenter.default.removeObserver(self)
+    }
 
     @objc private func moveToLine(_ notification: Notification) {
         guard matchesDocument(notification), let line = notification.object as? Int else { return }
@@ -864,7 +955,8 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     }
 
     func configure(
-        document: (any EditorDocument)?, documentID: UUID?, resourceID: String, contentRevision: Int, externalContentRevision: Int,
+        document: (any EditorDocument)?, documentID: UUID?, resourceID: String, displayName: String,
+        contentRevision: Int, externalContentRevision: Int,
         caret: Int?, language: String, colorScheme: ColorScheme, fontSize: CGFloat,
         fontName: String, lineHeightMultiplier: CGFloat,
         isReadOnly: Bool, translucentBackgroundEnabled: Bool, showsLineNumbers: Bool, highlightCurrentLine: Bool,
@@ -881,6 +973,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         self.document = document
         self.documentID = documentID
         self.resourceID = resourceID
+        self.documentDisplayName = displayName
         self.language = language
         self.scheme = colorScheme
         self.resolvedEditorTheme = currentEditorTheme(colorScheme: colorScheme)
@@ -930,6 +1023,8 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         layoutCache.removeAll()
         attributedLineCache.removeAll()
         visualFragmentCache.removeAll()
+        visualRowsSnapshot = nil
+        syntaxSpansByLine.removeAll(keepingCapacity: true)
         if isNewDocument {
             absoluteCaret = min(max(0, caret ?? 0), document?.utf16Length ?? 0)
             selection = NSRange(location: absoluteCaret, length: 0)
@@ -946,8 +1041,6 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         setFrameSize(NSSize(width: contentWidth, height: logicalHeight))
         needsDisplay = true
     }
-
-    override func viewDidMoveToWindow() { super.viewDidMoveToWindow(); window?.makeFirstResponder(self) }
 
     override func draw(_ dirtyRect: NSRect) {
         if let documentID {
@@ -1093,34 +1186,40 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         // metrics have been recalculated. The viewport is the current editor
         // allocation and is therefore the authoritative wrapping width.
         let availableWidth = max(1, viewportSize.width - gutterWidth - 16)
+        let snapshotKey = [
+            lastConfigurationKey,
+            String(configuredContentRevision ?? 0),
+            String(configuredExternalContentRevision ?? 0),
+            String(viewportLineOrigin),
+            String(Int((availableWidth * 2).rounded())),
+            String(Int((bounds.maxY * 2).rounded())),
+            String(Int((lineHeight * 100).rounded()))
+        ].joined(separator: "|")
+        if let visualRowsSnapshot, visualRowsSnapshot.key == snapshotKey {
+            return visualRowsSnapshot.rows
+        }
         var rows: [VisualRow] = []
         var baseline = VirtualEditorVisualLayout.baseline(
             rowOrigin: visualRowIndex.rowOrigin(forLogicalLine: viewportLineOrigin),
             lineHeight: lineHeight,
             fontAscender: editorFont.ascender
         )
-        for localLine in lineStarts.indices {
+        for viewportLine in viewportLines {
             let estimatedBaseline = baseline
             let viewportMaxY = bounds.maxY + lineHeight * 2
             if estimatedBaseline > viewportMaxY {
                 break
             }
-            let start = lineStarts[localLine]
-            let end = localLine + 1 < lineStarts.count ? lineStarts[localLine + 1] : viewportText.utf16.count
-            let text = (viewportText as NSString)
-                .substring(with: NSRange(location: start, length: max(0, end - start)))
-                .trimmingCharacters(in: .newlines)
             let fragments = cachedVisualFragments(
-                for: text,
-                localLine: localLine,
-                absoluteStart: start,
-                width: availableWidth,
-                dark: scheme == .dark
+                for: viewportLine.text,
+                localLine: viewportLine.localLine,
+                absoluteStart: viewportLine.startUTF16,
+                width: availableWidth
             )
             for (index, fragment) in fragments.enumerated() {
                 rows.append(VisualRow(
-                    logicalLine: viewportLineOrigin + localLine,
-                    localStart: start,
+                    logicalLine: viewportLineOrigin + viewportLine.localLine,
+                    localStart: viewportLine.startUTF16,
                     fragment: fragment,
                     baseline: baseline,
                     isFirstFragment: index == 0
@@ -1128,35 +1227,30 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
                 baseline += lineHeight
             }
         }
+        visualRowsSnapshot = (snapshotKey, rows)
         return rows
     }
 
-    private func attributedLine(_ line: String, absoluteStart: Int, dark: Bool) -> NSAttributedString {
+    private func attributedLine(_ line: String, localLine: Int) -> NSAttributedString {
         let base = NSMutableAttributedString(string: line, attributes: [
             .font: editorFont,
             .foregroundColor: NSColor(resolvedEditorTheme.text)
         ])
-        let range = NSRange(location: 0, length: (line as NSString).length)
-        guard range.length > 0 else { return base }
-        for (pattern, color) in getSyntaxPatterns(for: language, colors: resolvedSyntaxColors) {
-            guard let regex = cachedSyntaxRegex(pattern: pattern, options: [.anchorsMatchLines]) else { continue }
-            for match in regex.matches(in: line, range: range) {
-                base.addAttribute(.foregroundColor, value: NSColor(color), range: match.range)
-            }
+        let utf16Length = (line as NSString).length
+        for span in syntaxSpansByLine[localLine] ?? [] where isSyntaxHighlightRangeValid(span.range, utf16Length: utf16Length) {
+            base.addAttribute(.foregroundColor, value: NSColor(span.color), range: span.range)
         }
         return base
     }
 
     private func cachedAttributedLine(
         _ line: String,
-        localLine: Int,
-        absoluteStart: Int,
-        dark: Bool
+        localLine: Int
     ) -> NSAttributedString {
         if let cached = attributedLineCache[localLine] {
             return cached
         }
-        let created = attributedLine(line, absoluteStart: absoluteStart, dark: dark)
+        let created = attributedLine(line, localLine: localLine)
         attributedLineCache[localLine] = created
         return created
     }
@@ -1165,15 +1259,12 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         for line: String,
         localLine: Int,
         absoluteStart: Int,
-        width: CGFloat,
-        dark: Bool
+        width: CGFloat
     ) -> [VirtualEditorVisualFragment] {
         visualFragmentCache.fragments(
             for: cachedAttributedLine(
                 line,
-                localLine: localLine,
-                absoluteStart: absoluteStart,
-                dark: dark
+                localLine: localLine
             ),
             localLine: localLine,
             lineStartUTF16: absoluteStart,
@@ -1896,6 +1987,20 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         visualFragmentCache.removeAll(keepingCapacity: true)
         var offset = 0
         for scalar in viewportText.utf16 { offset += 1; if scalar == 10 { lineStarts.append(offset) } }
+        let nsViewportText = viewportText as NSString
+        viewportLines = lineStarts.indices.map { localLine in
+            let start = lineStarts[localLine]
+            let end = localLine + 1 < lineStarts.count ? lineStarts[localLine + 1] : nsViewportText.length
+            return VirtualEditorViewportLine(
+                localLine: localLine,
+                startUTF16: start,
+                text: nsViewportText
+                    .substring(with: NSRange(location: start, length: max(0, end - start)))
+                    .trimmingCharacters(in: .newlines)
+            )
+        }
+        scheduleSyntaxHighlighting()
+        visualRowsSnapshot = nil
         contentWidth = lineWrapEnabled ? max(viewportSize.width, 1) : unwrappedContentWidth()
         layoutCache.removeAll(keepingCapacity: true)
         needsDisplay = true
@@ -1904,16 +2009,70 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private func unwrappedContentWidth() -> CGFloat {
         guard !viewportText.isEmpty else { return max(viewportSize.width, 1) }
         var maximum: CGFloat = 0
-        for localLine in lineStarts.indices {
-            let start = lineStarts[localLine]
-            let end = localLine + 1 < lineStarts.count ? lineStarts[localLine + 1] : viewportText.utf16.count
-            let text = (viewportText as NSString)
-                .substring(with: NSRange(location: start, length: max(0, end - start)))
-                .trimmingCharacters(in: .newlines)
-            let line = CTLineCreateWithAttributedString(attributedLine(text, absoluteStart: start, dark: scheme == .dark))
+        for viewportLine in viewportLines {
+            let line = CTLineCreateWithAttributedString(attributedLine(
+                viewportLine.text,
+                localLine: viewportLine.localLine
+            ))
             maximum = max(maximum, CGFloat(CTLineGetTypographicBounds(line, nil, nil, nil)))
         }
         return max(viewportSize.width, gutterWidth + 16 + maximum)
+    }
+
+    private func scheduleSyntaxHighlighting() {
+        syntaxHighlightTask?.cancel()
+        syntaxHighlightGeneration &+= 1
+        let generation = syntaxHighlightGeneration
+        let lines = viewportLines
+        let syntaxLanguage = language
+        let syntaxTheme = syntaxThemeKey(for: scheme)
+        let patterns = getSyntaxPatterns(for: syntaxLanguage, colors: resolvedSyntaxColors)
+        syntaxHighlightTask = Task { [weak self] in
+            let worker = Task.detached(priority: .userInitiated) {
+                var result: [Int: [VirtualEditorSyntaxSpan]] = [:]
+                result.reserveCapacity(lines.count)
+                for line in lines {
+                    guard !Task.isCancelled else { return result }
+                    let cacheKey = VirtualEditorSyntaxLineCacheKey(
+                        language: syntaxLanguage,
+                        theme: syntaxTheme,
+                        text: line.text
+                    )
+                    if let cachedSpans = VirtualEditorSyntaxLineCache.spans(for: cacheKey) {
+                        if !cachedSpans.isEmpty { result[line.localLine] = cachedSpans }
+                        continue
+                    }
+                    let range = NSRange(location: 0, length: (line.text as NSString).length)
+                    guard range.length > 0 else {
+                        VirtualEditorSyntaxLineCache.store([], for: cacheKey)
+                        continue
+                    }
+                    var lineSpans: [VirtualEditorSyntaxSpan] = []
+                    for (pattern, color) in patterns {
+                        guard !Task.isCancelled else { return result }
+                        guard let regex = cachedSyntaxRegex(pattern: pattern, options: [.anchorsMatchLines]) else { continue }
+                        lineSpans.append(contentsOf: regex.matches(in: line.text, range: range).map {
+                            VirtualEditorSyntaxSpan(range: $0.range, color: color)
+                        })
+                    }
+                    VirtualEditorSyntaxLineCache.store(lineSpans, for: cacheKey)
+                    if !lineSpans.isEmpty { result[line.localLine] = lineSpans }
+                }
+                return result
+            }
+            let spans = await withTaskCancellationHandler {
+                await worker.value
+            } onCancel: {
+                worker.cancel()
+            }
+            guard let self, !Task.isCancelled, generation == self.syntaxHighlightGeneration else { return }
+            self.syntaxSpansByLine = spans
+            self.attributedLineCache.removeAll(keepingCapacity: true)
+            self.visualFragmentCache.removeAll(keepingCapacity: true)
+            self.visualRowsSnapshot = nil
+            self.layoutCache.removeAll(keepingCapacity: true)
+            self.needsDisplay = true
+        }
     }
 
     private func caretPoint(localLocation: Int) -> CGPoint {

--- a/Neon Vision EditorTests/EditorSettingsDefaultsTests.swift
+++ b/Neon Vision EditorTests/EditorSettingsDefaultsTests.swift
@@ -3,6 +3,29 @@ import XCTest
 
 @MainActor
 final class EditorSettingsDefaultsTests: XCTestCase {
+    func testFocusedObservationSnapshotsOnlyCompareOwnedState() {
+        XCTAssertEqual(
+            ContentView.TabChromeObservationSnapshot(structureRevision: 3, metadataRevision: 7),
+            ContentView.TabChromeObservationSnapshot(structureRevision: 3, metadataRevision: 7)
+        )
+        XCTAssertEqual(
+            ContentView.ProjectNavigationObservationSnapshot(rootURL: URL(fileURLWithPath: "/tmp/project"), indexReady: true),
+            ContentView.ProjectNavigationObservationSnapshot(rootURL: URL(fileURLWithPath: "/tmp/project"), indexReady: true)
+        )
+        XCTAssertEqual(
+            ContentView.EditorObservationSnapshot(contentRevision: 11),
+            ContentView.EditorObservationSnapshot(contentRevision: 11)
+        )
+        XCTAssertEqual(
+            ContentView.PreviewObservationSnapshot(projectEnabled: true, contentFilter: "markdown"),
+            ContentView.PreviewObservationSnapshot(projectEnabled: true, contentFilter: "markdown")
+        )
+        XCTAssertEqual(
+            ContentView.WindowSessionObservationSnapshot(persistenceRevision: 5),
+            ContentView.WindowSessionObservationSnapshot(persistenceRevision: 5)
+        )
+    }
+
     func testCodeTemplateCatalogProvidesUsefulDefaultsForEverySupportedLanguage() throws {
         XCTAssertEqual(Set(CodeTemplateCatalog.supportedLanguages).count, CodeTemplateCatalog.supportedLanguages.count)
 
@@ -84,6 +107,131 @@ final class EditorSettingsDefaultsTests: XCTestCase {
     func testIPadShiftScrollConvertsBothScrollDirectionsToFontDeltas() {
         XCTAssertEqual(iPadShiftScrollFontSizeDelta(contentOffsetDeltaY: -25), 1, accuracy: 0.0001)
         XCTAssertEqual(iPadShiftScrollFontSizeDelta(contentOffsetDeltaY: 25), -1, accuracy: 0.0001)
+    }
+
+    func testLineStartIndexAppliesSingleLineEditWithoutRescanningDocument() {
+        let original = "one\ntwo\nthree"
+        let starts = EditorLineStartIndex.offsets(in: original)
+
+        XCTAssertEqual(
+            EditorLineStartIndex.applying(
+                replacementRange: NSRange(location: 5, length: 1),
+                replacement: "W",
+                to: starts
+            ),
+            starts
+        )
+    }
+
+    func testLineStartIndexAppliesInsertedAndRemovedNewlines() {
+        let starts = EditorLineStartIndex.offsets(in: "one\ntwo\nthree")
+        let inserted = EditorLineStartIndex.applying(
+            replacementRange: NSRange(location: 5, length: 0),
+            replacement: "x\ny",
+            to: starts
+        )
+        XCTAssertEqual(inserted, EditorLineStartIndex.offsets(in: "one\ntx\nywo\nthree"))
+
+        let removed = EditorLineStartIndex.applying(
+            replacementRange: NSRange(location: 3, length: 1),
+            replacement: "",
+            to: starts
+        )
+        XCTAssertEqual(removed, EditorLineStartIndex.offsets(in: "onetwo\nthree"))
+    }
+
+    func testLineStartIndexMatchesFullScanAcrossUnicodeMutations() {
+        let original = "a😀\nbé\n末"
+        let starts = EditorLineStartIndex.offsets(in: original)
+        let boundaries = original.indices.map { original[..<$0].utf16.count } + [original.utf16.count]
+        let replacements = ["", "x", "\n", "😀\nq"]
+
+        for lowerIndex in boundaries.indices {
+            for upperIndex in lowerIndex..<boundaries.count {
+                let lower = boundaries[lowerIndex]
+                let upper = boundaries[upperIndex]
+                let range = NSRange(location: lower, length: upper - lower)
+                for replacement in replacements {
+                    let expectedText = (original as NSString).replacingCharacters(in: range, with: replacement)
+                    XCTAssertEqual(
+                        EditorLineStartIndex.applying(
+                            replacementRange: range,
+                            replacement: replacement,
+                            to: starts
+                        ),
+                        EditorLineStartIndex.offsets(in: expectedText),
+                        "Mismatch for range \(range) and replacement \(replacement.debugDescription)"
+                    )
+                }
+            }
+        }
+    }
+
+    func testNoWrapWidthCacheInvalidatesOnlyForMeaningfulTextMetricsChanges() {
+        let textView = EditorInputTextView()
+        let font = UIFont.monospacedSystemFont(ofSize: 14, weight: .regular)
+        var computations = 0
+
+        func width() -> CGFloat {
+            textView.cachedNoWrapWidth(visibleWidth: 600, tabWidth: 4, font: font) {
+                computations += 1
+                return 2_000
+            }
+        }
+
+        XCTAssertEqual(width(), 2_000)
+        XCTAssertEqual(width(), 2_000)
+        XCTAssertEqual(computations, 1)
+
+        textView.invalidateTextMetrics()
+        XCTAssertEqual(width(), 2_000)
+        XCTAssertEqual(computations, 2)
+    }
+
+    func testVimLineStartCacheTracksDocumentRevision() {
+        let textView = EditorInputTextView()
+        textView.text = "one\ntwo"
+        textView.invalidateTextMetrics()
+        XCTAssertEqual(textView.cachedLineStartOffsets(), [0, 4])
+        XCTAssertEqual(textView.cachedLineStartOffsets(), [0, 4])
+
+        textView.text = "one\ntwo\nthree"
+        textView.invalidateTextMetrics()
+        XCTAssertEqual(textView.cachedLineStartOffsets(), [0, 4, 8])
+    }
+
+    func testVimLineStartCacheAppliesInteractiveEditIncrementally() {
+        let textView = EditorInputTextView()
+        textView.text = "one\ntwo\nthree"
+        textView.invalidateTextMetrics()
+        XCTAssertEqual(textView.cachedLineStartOffsets(), [0, 4, 8])
+
+        textView.text = "one\nsecond line\nthree"
+        textView.applyTextMetricsMutation(
+            range: NSRange(location: 4, length: 3),
+            replacement: "second line"
+        )
+
+        XCTAssertEqual(textView.cachedLineStartOffsets(), [0, 4, 16])
+    }
+
+    func testLargeTextFormattingRangeIsBoundedAndClamped() {
+        XCTAssertEqual(
+            EditorLargeTextFormatting.updateRange(
+                visibleRange: NSRange(location: 100_000, length: 2_000),
+                textLength: 500_000,
+                padding: 8_000
+            ),
+            NSRange(location: 92_000, length: 18_000)
+        )
+        XCTAssertEqual(
+            EditorLargeTextFormatting.updateRange(
+                visibleRange: NSRange(location: 498_000, length: 5_000),
+                textLength: 500_000,
+                padding: 8_000
+            ),
+            NSRange(location: 490_000, length: 10_000)
+        )
     }
 #endif
 

--- a/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
+++ b/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
@@ -4,6 +4,32 @@ import XCTest
 
 @MainActor
 final class VirtualEditorLayoutTests: XCTestCase {
+    func testAccessibilityContextIncludesDocumentPositionEditabilityAndSelection() {
+        let context = VirtualEditorAccessibilityContext(
+            documentName: "Notes.md",
+            line: 12,
+            column: 7,
+            isReadOnly: true,
+            selectionLength: 4
+        )
+
+        XCTAssertEqual(context.label, "Notes.md, editor")
+        XCTAssertEqual(context.help, "Line 12, column 7, read only, 4 characters selected.")
+    }
+
+    func testPreviewReloadMetricsExposeCoalescing() {
+        let monitor = EditorPerformanceMonitor.shared
+        monitor.resetPreviewReloadMetrics()
+        monitor.markPreviewReloadScheduled(coalesced: false)
+        monitor.markPreviewReloadScheduled(coalesced: true)
+        monitor.markPreviewReloadExecuted()
+
+        XCTAssertEqual(
+            monitor.previewReloadSnapshot(),
+            EditorPerformanceMonitor.PreviewReloadSnapshot(requested: 2, coalesced: 1, executed: 1)
+        )
+    }
+
     func testShiftWheelZoomConvertsBothScrollDirectionsToFontDeltas() {
         XCTAssertEqual(VirtualEditorWheelZoom.fontSizeDelta(scrollingDeltaY: 5, fallbackDeltaY: 0), 1)
         XCTAssertEqual(VirtualEditorWheelZoom.fontSizeDelta(scrollingDeltaY: -5, fallbackDeltaY: 0), -1)

--- a/scripts/ci/check_performance_budget.py
+++ b/scripts/ci/check_performance_budget.py
@@ -81,6 +81,15 @@ def main() -> None:
         if f"func {test_name}(" not in benchmark_source:
             fail(f"missing interaction benchmark {test_name}")
 
+    pre_release_workflow = (ROOT / ".github" / "workflows" / "pre-release-ci.yml").read_text(encoding="utf-8")
+    for required_trend_export in (
+        "VirtualEditorPerformanceTests",
+        "VirtualEditorPerformance.xcresult",
+        "actions/upload-artifact@v4",
+    ):
+        if required_trend_export not in pre_release_workflow:
+            fail(f"pre-release CI does not export {required_trend_export}")
+
     policy = baseline["capturePolicy"]
     if set(policy["platforms"]) != {"macos", "iphone", "ipad"}:
         fail("capture policy must cover macOS, iPhone, and iPad")

--- a/scripts/ci/markdown_preview_theme_audit.py
+++ b/scripts/ci/markdown_preview_theme_audit.py
@@ -94,7 +94,12 @@ def main() -> None:
         fail("invalid iPhone preview clamp: .content max-width must use 100%, not 100vw")
     if "max(19px, 1.18em)" in source or "112%" in source or "108%" in source:
         fail("invalid runtime font scaling: Markdown preview must stay anchored to the editor font size")
-    if "-webkit-text-size-adjust: 100%" not in source or "font-size: 1em !important" not in source:
+    exact_runtime_size_contract = 'let resolvedRuntimeFontSize = runtimeFontSize.map { "\\(Int($0.rounded()))px" } ?? "1em"'
+    if (
+        "-webkit-text-size-adjust: 100%" not in source
+        or exact_runtime_size_contract not in source
+        or "font-size: \\(resolvedRuntimeFontSize) !important" not in source
+    ):
         fail("missing editor-size parity guardrail for iOS Markdown preview runtime CSS")
 
     fixture = CLIPPING_FIXTURE.read_text(encoding="utf-8")

--- a/scripts/prepare_release_docs.py
+++ b/scripts/prepare_release_docs.py
@@ -577,6 +577,7 @@ def rebuild_changelog_page(page: str, changelog: str, current_tag: str) -> str:
 
 LOCALIZED_TIMELINE_COPY = {
     "de": {
+        "v1.5.3": ("Große Dokumente reagieren schneller", "Beschleunigt Bearbeitung und Scrollen, reduziert unnötige Aktualisierungen und ergänzt einen ablenkungsfreien Fokusmodus.", ["Editor", "Leistung", "Fokusmodus"]),
         "v1.5.2": ("Editor und Vorschau bleiben synchron", "Gleicht die Schriftgröße der Markdown-Vorschau an den Editor an und misst die Leistung großer Dokumente.", ["Editor", "Vorschau", "Leistung"]),
         "v1.5.1": ("Lebendigere Markdown-Themes", "Verfeinert die Farbpaletten der Vorschau, verbessert das Öffnen von Projektordnern und stabilisiert Sparkle-Updates.", ["Markdown", "Themes", "Updates"]),
         "v1.3.6": ("Quick Look und Einstellungen werden stabiler", "Verfeinert Quick Look und die Größenanpassung des macOS-Einstellungsfensters für einen ruhigeren Arbeitsablauf.", ["Quick Look", "Einstellungen", "macOS"]),
@@ -590,6 +591,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor und Snapshots werden verlässlicher", "Verbessert Auswahl, Tastaturnavigation und Themes im macOS-Editor und erweitert den Code-Snapshot-Export.", ["Editor", "Themes", "Snapshots"]),
     },
     "da": {
+        "v1.5.3": ("Store dokumenter reagerer hurtigere", "Gør redigering og rulning hurtigere, reducerer unødvendige opdateringer og tilføjer en fokustilstand uden forstyrrelser.", ["Editor", "Ydeevne", "Fokustilstand"]),
         "v1.5.2": ("Editor og forhåndsvisning følger hinanden", "Tilpasser Markdown-forhåndsvisningens skriftstørrelse til editoren og måler ydeevnen i store dokumenter.", ["Editor", "Forhåndsvisning", "Ydeevne"]),
         "v1.5.1": ("Mere levende Markdown-temaer", "Forfiner forhåndsvisningens farvepaletter, forbedrer åbning af projektmapper og stabiliserer Sparkle-opdateringer.", ["Markdown", "Temaer", "Opdateringer"]),
         "v1.3.6": ("Quick Look og indstillinger bliver mere stabile", "Forfiner Quick Look og størrelsestilpasningen af macOS-indstillingsvinduet for et roligere arbejdsforløb.", ["Quick Look", "Indstillinger", "macOS"]),
@@ -603,6 +605,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor og snapshots bliver mere pålidelige", "Forbedrer markering, tastaturnavigation og temaer i macOS-editoren og udvider eksporten af kodesnapshots.", ["Editor", "Temaer", "Snapshots"]),
     },
     "fr": {
+        "v1.5.3": ("Les grands documents répondent plus vite", "Accélère l’édition et le défilement, réduit les actualisations inutiles et ajoute un mode concentration sans distraction.", ["Éditeur", "Performances", "Concentration"]),
         "v1.5.2": ("Éditeur et aperçu restent synchronisés", "Aligne la taille du texte de l’aperçu Markdown sur celle de l’éditeur et mesure les performances des grands documents.", ["Éditeur", "Aperçu", "Performances"]),
         "v1.5.1": ("Des thèmes Markdown plus vivants", "Affine les palettes de l’aperçu, améliore l’ouverture des dossiers de projet et stabilise les mises à jour Sparkle.", ["Markdown", "Thèmes", "Mises à jour"]),
         "v1.3.6": ("Quick Look et les réglages gagnent en stabilité", "Affine Quick Look et l’adaptation de taille de la fenêtre Réglages sur macOS pour un flux de travail plus calme.", ["Quick Look", "Réglages", "macOS"]),
@@ -616,6 +619,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Éditeur et instantanés plus fiables", "Améliore la sélection, la navigation au clavier et les thèmes dans l’éditeur macOS, tout en enrichissant l’export d’instantanés de code.", ["Éditeur", "Thèmes", "Instantanés"]),
     },
     "es": {
+        "v1.5.3": ("Los documentos grandes responden más rápido", "Acelera la edición y el desplazamiento, reduce actualizaciones innecesarias y añade un modo de concentración sin distracciones.", ["Editor", "Rendimiento", "Concentración"]),
         "v1.5.2": ("Editor y vista previa sincronizados", "Alinea el tamaño del texto de la vista previa Markdown con el editor y mide el rendimiento de documentos grandes.", ["Editor", "Vista previa", "Rendimiento"]),
         "v1.5.1": ("Temas Markdown más vivos", "Perfecciona las paletas de color de la vista previa, mejora la apertura de carpetas de proyecto y estabiliza las actualizaciones de Sparkle.", ["Markdown", "Temas", "Actualizaciones"]),
         "v1.3.6": ("Quick Look y Ajustes ganan estabilidad", "Perfecciona Quick Look y el ajuste de tamaño de la ventana Ajustes de macOS para un flujo de trabajo más tranquilo.", ["Quick Look", "Ajustes", "macOS"]),
@@ -629,6 +633,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor y capturas más fiables", "Mejora la selección, la navegación por teclado y los temas del editor de macOS, y amplía la exportación de capturas de código.", ["Editor", "Temas", "Capturas"]),
     },
     "ja": {
+        "v1.5.3": ("大きな書類をさらに高速に操作", "編集とスクロールを高速化し、不要な更新を減らして、集中できるフォーカスモードを追加します。", ["エディタ", "パフォーマンス", "フォーカス"]),
         "v1.5.2": ("エディタとプレビューを同期", "Markdown プレビューの文字サイズをエディタに合わせ、大きなドキュメントのパフォーマンスを測定します。", ["エディタ", "プレビュー", "パフォーマンス"]),
         "v1.5.1": ("Markdown テーマをより鮮やかに", "プレビューのカラーパレットを改善し、プロジェクトフォルダの直接オープンと Sparkle の更新を安定させます。", ["Markdown", "テーマ", "アップデート"]),
         "v1.3.6": ("Quick Look と設定がさらに安定", "Quick Look と macOS 設定ウインドウのサイズ調整を改善し、より落ち着いた作業環境にします。", ["Quick Look", "設定", "macOS"]),
@@ -642,6 +647,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("エディタとスナップショットをさらに信頼性向上", "macOS エディタの選択、キーボード操作、テーマを改善し、コードスナップショットの書き出しを拡充します。", ["エディタ", "テーマ", "スナップショット"]),
     },
     "zh-Hans": {
+        "v1.5.3": ("大型文档响应更快", "加快编辑和滚动，减少不必要的刷新，并加入无干扰的专注模式。", ["编辑器", "性能", "专注模式"]),
         "v1.5.2": ("编辑器与预览保持同步", "让 Markdown 预览文字大小与编辑器一致，并测量大型文档的性能。", ["编辑器", "预览", "性能"]),
         "v1.5.1": ("更鲜明的 Markdown 主题", "改进预览配色，优化直接打开项目文件夹，并提高 Sparkle 更新的稳定性。", ["Markdown", "主题", "更新"]),
         "v1.3.6": ("Quick Look 与设置更加稳定", "优化 Quick Look 和 macOS 设置窗口的尺寸调整，让工作流程更加稳定。", ["Quick Look", "设置", "macOS"]),

--- a/scripts/release_dry_run.sh
+++ b/scripts/release_dry_run.sh
@@ -34,8 +34,8 @@ trap cleanup EXIT
 
 (
   cd "$TMP_WORKTREE"
-  scripts/ci/release_preflight.sh "$TAG"
   scripts/release_prep.sh "$TAG"
+  scripts/ci/release_preflight.sh "$TAG"
 )
 
 echo "Dry-run finished. Release content for ${TAG} validated in temporary worktree."

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -220,9 +220,6 @@ if [[ "$DO_PUSH" -eq 1 ]]; then
     echo "Release branch ${RELEASE_BRANCH} already exists. Refusing to overwrite it." >&2
     exit 1
   fi
-  git switch -c "${RELEASE_BRANCH}"
-  RELEASE_BRANCH_CREATED=1
-  trap 'status=$?; if [[ "$status" -ne 0 && "$RELEASE_BRANCH_CREATED" -eq 1 ]]; then git switch develop >/dev/null 2>&1 || true; git branch -D "$RELEASE_BRANCH" >/dev/null 2>&1 || true; fi; exit "$status"' EXIT
 fi
 
 if git rev-parse "$TAG" >/dev/null 2>&1; then
@@ -307,6 +304,14 @@ fi
 
 scripts/ci/validate_release_metadata.sh "$TAG"
 
+if [[ "$DO_PUSH" -eq 1 ]]; then
+  # Keep validation failures on develop. Create the release branch only after
+  # all generated metadata has passed its gates.
+  git switch -c "${RELEASE_BRANCH}"
+  RELEASE_BRANCH_CREATED=1
+  trap 'status=$?; if [[ "$status" -ne 0 && "$RELEASE_BRANCH_CREATED" -eq 1 ]]; then git switch develop >/dev/null 2>&1 || true; git branch -D "$RELEASE_BRANCH" >/dev/null 2>&1 || true; fi; exit "$status"' EXIT
+fi
+
 git add README.md ARCHITECTURE.md CHANGELOG.md site/index.html site/changelog.html site/de/index.html site/da/index.html site/fr/index.html \
   site/es/index.html site/ja/index.html site/zh-Hans/index.html "Neon Vision Editor/UI/PanelsAndHelpers.swift" "$PBXPROJ_FILE" \
   docs/images/neon-vision-release-history-0.1-to-0.5.svg \
@@ -321,6 +326,8 @@ else
 fi
 
 if [[ "$DO_PUSH" -eq 1 ]]; then
+  RELEASE_BRANCH_CREATED=0
+  trap - EXIT
   BRANCH="$(git branch --show-current)"
   if [[ "$BRANCH" != "release/${TAG#v}" ]]; then
     echo "Release preparation expected branch release/${TAG#v} (current: ${BRANCH})." >&2


### PR DESCRIPTION
## Summary
- cache macOS viewport layout and incremental syntax results
- reduce iOS large-document rescans and formatting work
- narrow editor observation and add Focus Mode/preview performance refinements
- record virtual-editor performance results in pre-release CI

## Branch dependency
- based on the head of #209, which synchronizes `develop` with `main` using preserved ancestry
- merge #209 first; this PR then contains only the 1.5.3 editor work

## Verification
- macOS editor, layout, settings, and all four performance tests passed
- focused iOS incremental line-index and large-formatting tests passed
- macOS/iOS/iPadOS build matrix passed with the locally available Xcode 27 beta override
- performance-budget contract, workflow YAML, and `git diff --check` passed

## Summary by Sourcery

Improve editor responsiveness and interaction across macOS, iOS, and iPadOS while adding Focus Mode, accessibility refinements, and performance tracking.

New Features:
- Add an in-place Focus Mode that hides secondary editor chrome and previews without changing the active workspace.
- Provide richer macOS editor accessibility context, including document name, caret position, selection, and editability.

Bug Fixes:
- Prevent the editor canvas from claiming focus when moved into a window.
- Improve release appcast pull-request tracking and defer release-branch creation until metadata validation succeeds.
- Bound large-document formatting work and reduce unnecessary preview refreshes.

Enhancements:
- Improve macOS virtual-editor rendering with cached viewport layouts and asynchronous, cached syntax highlighting.
- Optimize iOS and iPadOS large-document editing with incremental line indexes, cached no-wrap measurements, and targeted formatting updates.
- Narrow SwiftUI observation scopes to reduce unrelated editor, preview, project, and session refreshes.
- Refine sidebar, tab chrome, preview behavior, and editor presentation for Focus Mode and platform-specific clarity.

CI:
- Record and upload virtual-editor performance test results from pre-release CI.
- Extend CI performance and preview theme guardrails for performance-result export and editor-size parity.

Deployment:
- Harden release automation by tracking generated appcast pull requests by number and cleaning up their branches after merge.

Documentation:
- Document the v1.5.3 performance, Focus Mode, accessibility, and large-document editing improvements in the changelog and localized release timelines.

Tests:
- Add coverage for focused observation snapshots, incremental line-index updates, cached text metrics, bounded formatting ranges, accessibility context, and preview reload metrics.