### PR TITLE
ci: align automation with merge-only rulesets

### DIFF
--- a/.github/workflows/post-release-documentation-sync.yml
+++ b/.github/workflows/post-release-documentation-sync.yml
@@ -186,5 +186,5 @@ jobs:
               --title "docs: self-heal ${RELEASE_TAG} documentation" \
               --body "Automated post-release documentation reconciliation."
           fi
-          gh pr merge "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --squash --delete-branch || \
+          gh pr merge "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
             echo "Auto-merge is unavailable; leaving the documentation PR open."

--- a/.github/workflows/release-github-only.yml
+++ b/.github/workflows/release-github-only.yml
@@ -727,7 +727,7 @@ jobs:
                   --body "Automated signed Sparkle appcast publication for ${TAG_NAME}."
               fi
               appcast_pr_number="$(gh pr view "${appcast_branch}" --repo "${GITHUB_REPOSITORY}" --json number --jq '.number')"
-              gh pr merge "${appcast_pr_number}" --repo "${GITHUB_REPOSITORY}" --auto --squash
+              gh pr merge "${appcast_pr_number}" --repo "${GITHUB_REPOSITORY}" --auto --merge
               for _ in {1..120}; do
                 merge_state="$(gh pr view "${appcast_pr_number}" --repo "${GITHUB_REPOSITORY}" --json state,mergeCommit --jq '[.state, (.mergeCommit.oid // "")] | join("|")' || true)"
                 if [[ "${merge_state%%|*}" == "MERGED" && -n "${merge_state#*|}" ]]; then

--- a/.github/workflows/sync-readme-appstore-versions.yml
+++ b/.github/workflows/sync-readme-appstore-versions.yml
@@ -119,5 +119,5 @@ jobs:
               --title "docs: sync App Store versions" \
               --body "Automated App Store version synchronization after release."
           fi
-          gh pr merge "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --squash --delete-branch || \
+          gh pr merge "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
             echo "Auto-merge is unavailable; leaving the App Store synchronization PR open."

--- a/.github/workflows/update-download-metrics.yml
+++ b/.github/workflows/update-download-metrics.yml
@@ -83,6 +83,12 @@ jobs:
           set -euo pipefail
           if git diff --quiet; then
             echo "No metrics changes."
+            metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --head "${METRICS_BRANCH}" --json number --jq '.[0].number // empty')"
+            if [ -n "${metrics_pr}" ]; then
+              gh pr close "${metrics_pr}" --repo "${GITHUB_REPOSITORY}" --delete-branch
+            elif git ls-remote --exit-code --heads origin "${METRICS_BRANCH}" >/dev/null 2>&1; then
+              git push origin --delete "${METRICS_BRANCH}"
+            fi
             exit 0
           fi
 
@@ -104,5 +110,5 @@ jobs:
           gh pr merge "${METRICS_BRANCH}" \
             --repo "${GITHUB_REPOSITORY}" \
             --auto \
-            --squash \
+            --merge \
             --delete-branch || echo "Auto-merge is unavailable; leaving the metrics pull request open."


### PR DESCRIPTION
Aligns daily metrics, appcast, App Store sync, and post-release documentation PRs with the protected merge-only branch rules. Also removes an orphaned daily-metrics branch when a run has no changes.

## Summary by Sourcery

Align automated release and metrics pull requests with merge-only branch protection and clean up unused metrics branches.

Bug Fixes:
- Remove orphaned daily-metrics pull request or branch when a metrics run produces no changes.

Enhancements:
- Align automated documentation, appcast, App Store synchronization, and download-metrics pull requests with merge-only protected branch rulesets.

CI:
- Update release-related automation to request merge commits instead of squash merges.