### PR TITLE
ci: use workflow token for metrics pull requests

### DIFF
--- a/.github/workflows/update-download-metrics.yml
+++ b/.github/workflows/update-download-metrics.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Commit and update metrics pull request
         env:
-          GH_TOKEN: ${{ secrets.METRIC_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           METRICS_BRANCH: automation/daily-metrics
         run: |
           set -euo pipefail


### PR DESCRIPTION
Uses the workflow-scoped GitHub token for PR creation and auto-merge while retaining the dedicated metrics token for signed branch pushes and traffic API access.

## Summary by Sourcery

Enhancements:
- Use the workflow-scoped GitHub token for creating and auto-merging metrics pull requests while retaining the dedicated metrics token for signed pushes and traffic API access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated download-metrics pull request creation to use the workflow’s built-in authentication token.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->