### PR TITLE
ci: merge clean automation pull requests immediately

### DIFF
--- a/.github/workflows/post-release-documentation-sync.yml
+++ b/.github/workflows/post-release-documentation-sync.yml
@@ -186,5 +186,7 @@ jobs:
               --title "docs: self-heal ${RELEASE_TAG} documentation" \
               --body "Automated post-release documentation reconciliation."
           fi
-          gh pr merge "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
-            echo "Auto-merge is unavailable; leaving the documentation PR open."
+          if ! gh pr merge "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" --merge --delete-branch; then
+            gh pr merge "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
+              echo "Auto-merge is unavailable; leaving the documentation PR open."
+          fi

--- a/.github/workflows/release-github-only.yml
+++ b/.github/workflows/release-github-only.yml
@@ -727,7 +727,9 @@ jobs:
                   --body "Automated signed Sparkle appcast publication for ${TAG_NAME}."
               fi
               appcast_pr_number="$(gh pr view "${appcast_branch}" --repo "${GITHUB_REPOSITORY}" --json number --jq '.number')"
-              gh pr merge "${appcast_pr_number}" --repo "${GITHUB_REPOSITORY}" --auto --merge
+              if ! gh pr merge "${appcast_pr_number}" --repo "${GITHUB_REPOSITORY}" --merge; then
+                gh pr merge "${appcast_pr_number}" --repo "${GITHUB_REPOSITORY}" --auto --merge
+              fi
               for _ in {1..120}; do
                 merge_state="$(gh pr view "${appcast_pr_number}" --repo "${GITHUB_REPOSITORY}" --json state,mergeCommit --jq '[.state, (.mergeCommit.oid // "")] | join("|")' || true)"
                 if [[ "${merge_state%%|*}" == "MERGED" && -n "${merge_state#*|}" ]]; then

--- a/.github/workflows/sync-readme-appstore-versions.yml
+++ b/.github/workflows/sync-readme-appstore-versions.yml
@@ -119,5 +119,7 @@ jobs:
               --title "docs: sync App Store versions" \
               --body "Automated App Store version synchronization after release."
           fi
-          gh pr merge "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
-            echo "Auto-merge is unavailable; leaving the App Store synchronization PR open."
+          if ! gh pr merge "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" --merge --delete-branch; then
+            gh pr merge "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
+              echo "Auto-merge is unavailable; leaving the App Store synchronization PR open."
+          fi

--- a/.github/workflows/update-download-metrics.yml
+++ b/.github/workflows/update-download-metrics.yml
@@ -107,8 +107,13 @@ jobs:
               --body "Automated refresh of README download and traffic metrics."
           fi
 
-          gh pr merge "${METRICS_BRANCH}" \
+          if ! gh pr merge "${METRICS_BRANCH}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --auto \
             --merge \
-            --delete-branch || echo "Auto-merge is unavailable; leaving the metrics pull request open."
+            --delete-branch; then
+            gh pr merge "${METRICS_BRANCH}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --auto \
+              --merge \
+              --delete-branch || echo "Auto-merge is unavailable; leaving the metrics pull request open."
+          fi

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -345,8 +345,10 @@ if [[ "$DO_PUSH" -eq 1 ]]; then
   fi
   # Preserve the develop ancestry so main can merge back into develop without
   # replaying or duplicating the release commits.
-  gh pr merge "${BRANCH}" --auto --merge --delete-branch || \
-    echo "Auto-merge is unavailable; leaving the release pull request open."
+  if ! gh pr merge "${BRANCH}" --merge --delete-branch; then
+    gh pr merge "${BRANCH}" --auto --merge --delete-branch || \
+      echo "Auto-merge is unavailable; leaving the release pull request open."
+  fi
 else
   echo "Next steps:"
   echo "  git switch develop"


### PR DESCRIPTION
Handles both GitHub CLI states: immediately merges clean protected PRs, and falls back to auto-merge only when requirements are pending. Applies consistently to release prep, metrics, appcast, App Store sync, and post-release documentation.

## Summary by Sourcery

Merge clean automation pull requests immediately, falling back to auto-merge when required checks or protections are still pending.

Enhancements:
- Update automated pull request workflows to merge clean, eligible pull requests immediately and use auto-merge only when merge requirements are still pending.

CI:
- Apply the revised merge behavior consistently across release preparation, appcast publication, metrics updates, App Store synchronization, and post-release documentation workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release-related pull requests are now merged immediately when possible.
  * If immediate merging is unavailable, automatic merging is enabled as a fallback.
  * Pull requests remain open with a clear status message only when neither option succeeds.
  * Improved automation for documentation updates, appcast publication, App Store version synchronization, download metrics, and release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->