### PR TITLE
Fix StoreKit support price loading on iOS

### DIFF
--- a/Neon Vision Editor.xcodeproj/xcshareddata/xcschemes/Neon Vision Editor AppStore.xcscheme
+++ b/Neon Vision Editor.xcodeproj/xcshareddata/xcschemes/Neon Vision Editor AppStore.xcscheme
@@ -59,7 +59,7 @@
          </AdditionalOption>
       </AdditionalOptions>
       <StoreKitConfigurationFileReference
-         identifier = "../../../Neon Vision Editor/SupportOptional.storekit">
+         identifier = "../../Neon Vision Editor/SupportOptional.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction

--- a/Neon Vision Editor.xcodeproj/xcshareddata/xcschemes/Neon Vision Editor.xcscheme
+++ b/Neon Vision Editor.xcodeproj/xcshareddata/xcschemes/Neon Vision Editor.xcscheme
@@ -66,7 +66,7 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <StoreKitConfigurationFileReference
-         identifier = "../../../Neon Vision Editor/SupportOptional.storekit">
+         identifier = "../../Neon Vision Editor/SupportOptional.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction

--- a/Neon Vision Editor/UI/NeonSettingsView.swift
+++ b/Neon Vision Editor/UI/NeonSettingsView.swift
@@ -1333,6 +1333,8 @@ struct NeonSettingsView: View {
 #elseif os(iOS)
             if newValue == "toolbar" || newValue == "templates" || newValue == "more" {
                 settingsActiveTab = "tools"
+            } else if newValue == "support" {
+                refreshSupportStoreStateIfNeeded()
             }
             #else
             if newValue == "ai" {

--- a/scripts/ci/app_store_review_preflight.sh
+++ b/scripts/ci/app_store_review_preflight.sh
@@ -23,6 +23,7 @@ scripts/ci/privacy_log_audit.sh
 scripts/ci/review_metadata_audit.py
 scripts/ci/markdown_preview_remote_audit.sh
 scripts/ci/app_store_execution_boundary_audit.sh
+scripts/ci/storekit_configuration_audit.sh
 python3 scripts/ci/markdown_preview_theme_audit.py
 
 section "Review-critical tests"

--- a/scripts/ci/storekit_configuration_audit.sh
+++ b/scripts/ci/storekit_configuration_audit.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STOREKIT_FILE="$ROOT/Neon Vision Editor/SupportOptional.storekit"
+SETTINGS_FILE="$ROOT/Neon Vision Editor/UI/NeonSettingsView.swift"
+PURCHASE_MANAGER_FILE="$ROOT/Neon Vision Editor/Data/SupportPurchaseManager.swift"
+EXPECTED_REFERENCE='identifier = "../../Neon Vision Editor/SupportOptional.storekit"'
+EXPECTED_PRODUCT_ID="002420160"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+[[ -f "$STOREKIT_FILE" ]] || fail "Missing StoreKit configuration: $STOREKIT_FILE"
+python3 -m json.tool "$STOREKIT_FILE" >/dev/null || fail "StoreKit configuration is not valid JSON."
+
+product_id="$(plutil -extract products.0.productID raw "$STOREKIT_FILE")"
+product_type="$(plutil -extract products.0.type raw "$STOREKIT_FILE")"
+display_price="$(plutil -extract products.0.displayPrice raw "$STOREKIT_FILE")"
+
+[[ "$product_id" == "$EXPECTED_PRODUCT_ID" ]] || fail "Unexpected support product ID: $product_id"
+[[ "$product_type" == "Consumable" ]] || fail "Support product must remain consumable."
+[[ -n "$display_price" ]] || fail "Support product is missing a local test price."
+grep -Fq "static let supportProductID = \"$EXPECTED_PRODUCT_ID\"" "$PURCHASE_MANAGER_FILE" || \
+  fail "SupportPurchaseManager product ID does not match the StoreKit configuration."
+
+python3 - "$SETTINGS_FILE" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+anchor = '.onChange(of: settingsActiveTab)'
+if anchor not in source:
+    raise SystemExit("error: Missing settings-tab change handler.")
+handler = source.split(anchor, 1)[1].split('.onChange(of: moreSectionTab)', 1)[0]
+ios_branch = handler.split('#elseif os(iOS)', 1)[1].split('#else', 1)[0]
+if 'newValue == "support"' not in ios_branch or 'refreshSupportStoreStateIfNeeded()' not in ios_branch:
+    raise SystemExit("error: Selecting Support on iOS must refresh StoreKit state.")
+PY
+
+for scheme in \
+  "$ROOT/Neon Vision Editor.xcodeproj/xcshareddata/xcschemes/Neon Vision Editor.xcscheme" \
+  "$ROOT/Neon Vision Editor.xcodeproj/xcshareddata/xcschemes/Neon Vision Editor AppStore.xcscheme"; do
+  [[ -f "$scheme" ]] || fail "Missing shared scheme: $scheme"
+  grep -Fq "$EXPECTED_REFERENCE" "$scheme" || \
+    fail "$(basename "$scheme") does not activate SupportOptional.storekit for Run."
+done
+
+echo "StoreKit configuration audit passed for product $EXPECTED_PRODUCT_ID."

--- a/scripts/ci/xcode_cloud_release_preflight.sh
+++ b/scripts/ci/xcode_cloud_release_preflight.sh
@@ -27,6 +27,8 @@ fail() {
   exit 1
 }
 
+scripts/ci/storekit_configuration_audit.sh
+
 # Select a full Xcode installation even when the host's xcode-select currently
 # points at CommandLineTools. The shared selector prefers the newest stable
 # Xcode 17+ installation and rejects beta Xcode unless explicitly allowed for


### PR DESCRIPTION
## Summary
- restore the valid shared-scheme reference to `SupportOptional.storekit`
- refresh StoreKit state when the iOS Support settings tab is selected
- add a release audit for the product ID, consumable type, local price, scheme activation, and iOS refresh hook

## Verification
- reproduced the original `Unavailable` state on iPhone 17 Pro Simulator
- verified General → Support now resolves the localized StoreKit price `4,99 €` and enables the support button
- `scripts/ci/storekit_configuration_audit.sh`
- `scripts/ci/app_store_review_preflight.sh` (passed; visionOS runtime unavailable and skipped)
- `scripts/ci/build_platform_matrix.sh` (macOS, iPhone Simulator, iPad Simulator passed)

## Real-device boundary
The runtime continues to use StoreKit product metadata; no price is hardcoded. Xcode local StoreKit testing is fixed for Simulator and Xcode-launched devices. TestFlight/App Store availability still depends on product `002420160`, storefront availability, and agreements in App Store Connect.

## Summary by Sourcery

Restore reliable iOS support purchase price loading and add automated audits to protect the StoreKit configuration.

Bug Fixes:
- Restore iOS StoreKit support price loading by activating the shared StoreKit configuration and refreshing purchase state when the Support settings tab is selected.

CI:
- Add StoreKit configuration checks to review and release preflight workflows, covering the support product metadata, scheme activation, and iOS refresh hook.