### PR TITLE
fix: keep failed releases private

### DIFF
--- a/.github/workflows/release-github-only.yml
+++ b/.github/workflows/release-github-only.yml
@@ -903,4 +903,4 @@ jobs:
           gh_retry gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.zip" -y || true
           gh_retry gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.dmg" -y || true
           gh_retry gh release delete-asset "$TAG_NAME" "SHA256SUMS.txt" -y || true
-          gh_retry gh release edit "$TAG_NAME" --draft true || true
+          gh_retry gh release edit "$TAG_NAME" --draft=true || true


### PR DESCRIPTION
Corrects the rollback command so a failed publication returns the release to draft state after removing incomplete assets. The v1.5.3 release was manually restored to draft before this PR.

## Summary by Sourcery

Bug Fixes:
- Ensure failed GitHub releases are returned to draft status after incomplete release assets are removed.