### PR TITLE
fix: repair signed post-release automation PRs

### DIFF
--- a/.github/workflows/post-release-documentation-sync.yml
+++ b/.github/workflows/post-release-documentation-sync.yml
@@ -157,7 +157,7 @@ jobs:
         if: steps.release.outputs.skip != 'true' && steps.changes.outputs.changed == 'true'
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
-          METRIC_TOKEN: ${{ secrets.METRIC_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -180,13 +180,21 @@ jobs:
           git commit -S -m "docs: self-heal ${RELEASE_TAG} documentation"
           git push --force-with-lease origin "HEAD:${DOCS_BRANCH}"
 
-          export GH_TOKEN="${METRIC_TOKEN:-}"
-          if ! gh pr view "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          docs_sha="$(git rev-parse HEAD)"
+          docs_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${DOCS_BRANCH}" \
+            --json number,headRefOid --jq ".[] | select(.headRefOid == \"${docs_sha}\") | .number" | head -n1)"
+          if [[ -z "${docs_pr}" ]]; then
             gh pr create --repo "${GITHUB_REPOSITORY}" --base main --head "${DOCS_BRANCH}" \
               --title "docs: self-heal ${RELEASE_TAG} documentation" \
               --body "Automated post-release documentation reconciliation."
+            docs_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${DOCS_BRANCH}" \
+              --json number,headRefOid --jq ".[] | select(.headRefOid == \"${docs_sha}\") | .number" | head -n1)"
           fi
-          if ! gh pr merge "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" --merge --delete-branch; then
-            gh pr merge "${DOCS_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
+          if [[ -z "${docs_pr}" ]]; then
+            echo "Could not resolve the open documentation PR for ${docs_sha}." >&2
+            exit 1
+          fi
+          if ! gh pr merge "${docs_pr}" --repo "${GITHUB_REPOSITORY}" --merge --delete-branch; then
+            gh pr merge "${docs_pr}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
               echo "Auto-merge is unavailable; leaving the documentation PR open."
           fi

--- a/.github/workflows/sync-readme-appstore-versions.yml
+++ b/.github/workflows/sync-readme-appstore-versions.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Commit and update pull request if changed
         env:
-          GH_TOKEN: ${{ secrets.METRIC_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -114,12 +114,21 @@ jobs:
           git commit -S -m "docs: sync App Store versions"
 
           git push --force-with-lease origin "HEAD:${SYNC_BRANCH}"
-          if ! gh pr view "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          sync_sha="$(git rev-parse HEAD)"
+          sync_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${SYNC_BRANCH}" \
+            --json number,headRefOid --jq ".[] | select(.headRefOid == \"${sync_sha}\") | .number" | head -n1)"
+          if [[ -z "${sync_pr}" ]]; then
             gh pr create --repo "${GITHUB_REPOSITORY}" --base main --head "${SYNC_BRANCH}" \
               --title "docs: sync App Store versions" \
               --body "Automated App Store version synchronization after release."
+            sync_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${SYNC_BRANCH}" \
+              --json number,headRefOid --jq ".[] | select(.headRefOid == \"${sync_sha}\") | .number" | head -n1)"
           fi
-          if ! gh pr merge "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" --merge --delete-branch; then
-            gh pr merge "${SYNC_BRANCH}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
+          if [[ -z "${sync_pr}" ]]; then
+            echo "Could not resolve the open App Store synchronization PR for ${sync_sha}." >&2
+            exit 1
+          fi
+          if ! gh pr merge "${sync_pr}" --repo "${GITHUB_REPOSITORY}" --merge --delete-branch; then
+            gh pr merge "${sync_pr}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
               echo "Auto-merge is unavailable; leaving the App Store synchronization PR open."
           fi

--- a/.github/workflows/update-download-metrics.yml
+++ b/.github/workflows/update-download-metrics.yml
@@ -96,7 +96,10 @@ jobs:
           git commit -S -m "docs: refresh download metrics chart"
           git push --force-with-lease origin "HEAD:${METRICS_BRANCH}"
 
-          if gh pr view "${METRICS_BRANCH}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          metrics_sha="$(git rev-parse HEAD)"
+          metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
+            --json number,headRefOid --jq ".[] | select(.headRefOid == \"${metrics_sha}\") | .number" | head -n1)"
+          if [[ -n "${metrics_pr}" ]]; then
             echo "Updated existing metrics pull request."
           else
             gh pr create \
@@ -105,13 +108,19 @@ jobs:
               --head "${METRICS_BRANCH}" \
               --title "docs: refresh daily download metrics" \
               --body "Automated refresh of README download and traffic metrics."
+            metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
+              --json number,headRefOid --jq ".[] | select(.headRefOid == \"${metrics_sha}\") | .number" | head -n1)"
           fi
 
-          if ! gh pr merge "${METRICS_BRANCH}" \
+          if [[ -z "${metrics_pr}" ]]; then
+            echo "Could not resolve the open metrics PR for ${metrics_sha}." >&2
+            exit 1
+          fi
+          if ! gh pr merge "${metrics_pr}" \
             --repo "${GITHUB_REPOSITORY}" \
             --merge \
             --delete-branch; then
-            gh pr merge "${METRICS_BRANCH}" \
+            gh pr merge "${metrics_pr}" \
               --repo "${GITHUB_REPOSITORY}" \
               --auto \
               --merge \


### PR DESCRIPTION
Uses GitHub's workflow token for PR APIs while retaining signed automation Git pushes, and binds App Store sync, documentation self-heal, and daily metrics PRs to their current head SHA. Repairs the v1.5.3 App Store sync failure from run 33070460507.

## Summary by Sourcery

Repair signed post-release automation pull requests by using workflow authentication and matching each PR to the commit it contains.

Bug Fixes:
- Repair post-release documentation, App Store version synchronization, and download metrics automation so their pull requests are reliably resolved and merged after signed pushes.

Enhancements:
- Use the workflow token for GitHub pull request operations while retaining signed automation commits and pushes.
- Associate automated pull request handling with the current head commit SHA and fail clearly when the matching pull request cannot be found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated documentation, app-store version, and download-metrics updates.
  * Pull requests created by these workflows are now identified and merged more reliably, reducing failures caused by branch or authentication mismatches.
  * Workflows now stop clearly when the expected pull request cannot be found, helping prevent incomplete or ambiguous updates.

* **Chores**
  * Streamlined automation authentication and merge handling for release-related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->