### PR TITLE
fix(editor): keep final wrapped rows reachable

### DIFF
--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -166,6 +166,22 @@ struct VirtualEditorVisualRowIndex {
     static func smoothedEstimate(previous: CGFloat, observed: CGFloat) -> CGFloat {
         min(4, max(1, previous * 0.75 + observed * 0.25))
     }
+
+    /// Growing the scroll extent must happen in one pass. A smoothed increase
+    /// can leave wrapped rows beyond AppKit's reachable document height until
+    /// another unrelated resize occurs. Shrinking remains gradual so ordinary
+    /// viewport samples do not make the scrollbar jump inward.
+    static func scrollExtentEstimate(
+        previous: CGFloat,
+        observed: CGFloat,
+        measurementIsComplete: Bool = false
+    ) -> CGFloat {
+        guard observed.isFinite else { return max(1, previous) }
+        let safeObserved = max(1, observed)
+        if measurementIsComplete { return safeObserved }
+        guard safeObserved < previous else { return safeObserved }
+        return max(safeObserved, previous * 0.75 + safeObserved * 0.25)
+    }
 }
 
 enum VirtualEditorScrollAnchorPolicy {
@@ -733,6 +749,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private var configuredExternalContentRevision: Int?
     private let viewportMaximumByteCount = 256_000
     private let editRefreshMaximumByteCount = 128_000
+    private let visualMetricSampleLineLimit = 512
     private var lineHeight: CGFloat { max(1, (editorFont.ascender - editorFont.descender + editorFont.leading + 4) * lineHeightMultiplier) }
     private var editorFont: NSFont { resolvedEditorFont }
     private var gutterWidth: CGFloat { max(44, CGFloat(max(1, document?.lineCount ?? 1).description.count) * editorFontSize * 0.7 + 18) }
@@ -761,25 +778,47 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
             if !lineWrapEnabled { contentWidth = unwrappedContentWidth() }
             return
         }
-        let rows = EditorPerformanceMonitor.shared.measureVirtualEditorLayout {
-            visualRows()
+        let measurement = EditorPerformanceMonitor.shared.measureVirtualEditorLayout {
+            measuredRowsPerLogicalLine()
         }
-        var logicalLines = 0
-        var previousLogicalLine: Int?
-        for row in rows where row.logicalLine != previousLogicalLine {
-            logicalLines += 1
-            previousLogicalLine = row.logicalLine
-        }
-        logicalLines = max(1, logicalLines)
-        let observed = CGFloat(max(1, rows.count)) / CGFloat(logicalLines)
+        let observed = measurement.rowsPerLogicalLine
         if abs(observed - estimatedRowsPerLogicalLine) > 0.05 {
-            estimatedRowsPerLogicalLine = VirtualEditorVisualRowIndex.smoothedEstimate(
+            estimatedRowsPerLogicalLine = VirtualEditorVisualRowIndex.scrollExtentEstimate(
                 previous: estimatedRowsPerLogicalLine,
-                observed: observed
+                observed: observed,
+                measurementIsComplete: measurement.isComplete
             )
+            visualRowsSnapshot = nil
         }
         contentWidth = max(viewportSize.width, 1)
         invalidateIntrinsicContentSize()
+    }
+
+    private func measuredRowsPerLogicalLine() -> (rowsPerLogicalLine: CGFloat, isComplete: Bool) {
+        guard !viewportLines.isEmpty else { return (1, true) }
+        let availableWidth = max(1, viewportSize.width - gutterWidth - 16)
+        let step = max(1, Int(ceil(Double(viewportLines.count) / Double(visualMetricSampleLineLimit))))
+        var sampledLineCount = 0
+        var measuredRowCount = 0
+        var index = 0
+        while index < viewportLines.count, sampledLineCount < visualMetricSampleLineLimit {
+            let viewportLine = viewportLines[index]
+            measuredRowCount += cachedVisualFragments(
+                for: viewportLine.text,
+                localLine: viewportLine.localLine,
+                absoluteStart: viewportLine.startUTF16,
+                width: availableWidth
+            ).count
+            sampledLineCount += 1
+            index += step
+        }
+        let coversWholeDocument = viewport?.lineRange.lowerBound == 0
+            && (viewport?.lineRange.upperBound ?? -1) >= max(0, (document?.lineCount ?? 1) - 1)
+        let isComplete = coversWholeDocument && sampledLineCount == viewportLines.count
+        return (
+            CGFloat(max(1, measuredRowCount)) / CGFloat(max(1, sampledLineCount)),
+            isComplete
+        )
     }
 
     override var isFlipped: Bool { true }

--- a/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
+++ b/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
@@ -138,6 +138,98 @@ final class VirtualEditorLayoutTests: XCTestCase {
         )
     }
 
+    func testWrappedRowEstimateExpandsScrollExtentInOnePass() {
+        XCTAssertEqual(
+            VirtualEditorVisualRowIndex.scrollExtentEstimate(previous: 1, observed: 2.75),
+            2.75,
+            accuracy: 0.001
+        )
+    }
+
+    func testWrappedRowEstimateShrinksGraduallyWithoutUndercountingObservation() {
+        XCTAssertEqual(
+            VirtualEditorVisualRowIndex.scrollExtentEstimate(previous: 3, observed: 1.5),
+            2.625,
+            accuracy: 0.001
+        )
+        XCTAssertGreaterThanOrEqual(
+            VirtualEditorVisualRowIndex.scrollExtentEstimate(previous: 3, observed: 1.5),
+            1.5
+        )
+    }
+
+    func testCompleteWrappedRowMeasurementResizesExactlyAfterSidebarTransition() {
+        XCTAssertEqual(
+            VirtualEditorVisualRowIndex.scrollExtentEstimate(
+                previous: 3,
+                observed: 1.5,
+                measurementIsComplete: true
+            ),
+            1.5,
+            accuracy: 0.001
+        )
+    }
+
+    func testWrappedDocumentScrollExtentIncludesFinalLineAcrossSidebarWidths() {
+        let logicalLine = String(repeating: "wrapped markdown content ", count: 10)
+        let content = Array(repeating: logicalLine, count: 361).joined(separator: "\n")
+        let document = FileBackedTextDocument(content: content)
+        let canvas = VirtualEditorCanvas(frame: NSRect(x: 0, y: 0, width: 440, height: 700))
+        let documentID = UUID()
+
+        func configure(width: CGFloat) {
+            _ = canvas.setViewportSize(CGSize(width: width, height: 700))
+            canvas.configure(
+                document: document,
+                documentID: documentID,
+                resourceID: "wrapped-sidebar-regression",
+                displayName: "Architecture.md",
+                contentRevision: 0,
+                externalContentRevision: 0,
+                caret: 0,
+                language: "markdown",
+                colorScheme: .light,
+                fontSize: 14,
+                fontName: "",
+                lineHeightMultiplier: 1,
+                isReadOnly: false,
+                translucentBackgroundEnabled: false,
+                showsLineNumbers: true,
+                highlightCurrentLine: false,
+                lineWrapEnabled: true,
+                showsInvisibleCharacters: false,
+                showsIndentationGuides: false,
+                showsScopeGuides: false,
+                highlightsScopeBackground: false,
+                highlightsMatchingBrackets: false,
+                autoIndentEnabled: true,
+                autoCloseBracketsEnabled: false,
+                onFontSizeChange: nil,
+                onTextMutation: nil
+            )
+            canvas.recalculateVisualMetrics()
+        }
+
+        func expectedHeight(width: CGFloat) -> CGFloat {
+            let font = NSFont.monospacedSystemFont(ofSize: 14, weight: .regular)
+            let gutterWidth = max(44, CGFloat(document.lineCount.description.count) * 14 * 0.7 + 18)
+            let fragments = VirtualEditorVisualLayout.fragments(
+                for: NSAttributedString(string: logicalLine, attributes: [.font: font]),
+                lineStartUTF16: 0,
+                width: max(1, width - gutterWidth - 16),
+                wraps: true
+            )
+            let lineHeight = font.ascender - font.descender + font.leading + 4
+            return CGFloat(document.lineCount * fragments.count) * lineHeight + 16
+        }
+
+        configure(width: 440)
+        XCTAssertEqual(canvas.logicalHeight, expectedHeight(width: 440), accuracy: 0.001)
+
+        configure(width: 760)
+        XCTAssertEqual(canvas.logicalHeight, expectedHeight(width: 760), accuracy: 0.001)
+    }
+
     func testWrappedFragmentsRemainContiguousForAbsoluteSelectionGeometry() {
         let text = "wide text that must wrap across visual rows"
         let fragments = VirtualEditorVisualLayout.fragments(


### PR DESCRIPTION
## Summary
- measure a bounded distributed sample when estimating wrapped virtual rows
- grow the macOS editor scroll extent immediately when wrapping increases
- cover narrow and wide sidebar layouts with a 361-line regression test

## Verification
- VirtualEditorLayoutTests passed with Xcode 27 beta
- focused sidebar-width regression test passed
- git diff --check passed

## Summary by Sourcery

Keep final wrapped editor rows reachable by using bounded row sampling and one-pass scroll-extent growth.

Bug Fixes:
- Ensure wrapped editor rows remain reachable by expanding the macOS scroll extent immediately when wrapping increases.
- Improve wrapped-row estimation across narrow and wide sidebar layouts, including complete-document measurements.

Enhancements:
- Bound visual-row sampling to efficiently estimate wrapping across large documents while preserving gradual shrinkage of the scroll extent.

Tests:
- Add regression coverage for scroll-extent growth, gradual shrinkage, complete measurements, and a 361-line wrapped document across sidebar widths.