### PR TITLE
docs(release): add v1.5.4 hotfix inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to **Neon Vision Editor** are documented in this file.
 
 The format follows *Keep a Changelog*. Versions use semantic versioning with prerelease tags.
 
+## [v1.5.4] - 2026-08-27
+
+### Why Upgrade
+
+- Restores access to every wrapped source row in the macOS editor after project-sidebar or preview width changes.
+- Keeps the final document lines reachable at both narrow and wide editor widths.
+- Preserves responsive virtual-editor layout without performing unbounded full-document measurement.
+
+### Highlights
+
+- Measures a bounded, distributed sample of wrapped rows when calculating the virtual canvas scroll extent.
+- Uses exact row accounting for fully loaded documents and immediate expansion when wrapping increases.
+
+### Fixes
+
+- Prevents the macOS editor from stopping before the document's final lines when the project sidebar or preview narrows the source pane.
+- Recalculates cached row geometry after sidebar width transitions without reintroducing unbounded layout work.
+
+### Breaking changes
+
+- None.
+
+### Migration
+
+- None.
+
 ## [v1.5.3] - 2026-08-26
 
 ### Why Upgrade

--- a/scripts/prepare_release_docs.py
+++ b/scripts/prepare_release_docs.py
@@ -577,6 +577,7 @@ def rebuild_changelog_page(page: str, changelog: str, current_tag: str) -> str:
 
 LOCALIZED_TIMELINE_COPY = {
     "de": {
+        "v1.5.4": ("Alle Editorzeilen bleiben erreichbar", "Stellt sicher, dass umbrochene Zeilen nach Änderungen an Seitenleiste oder Vorschau bis zum Dokumentende erreichbar bleiben.", ["Editor", "Zeilenumbruch", "macOS"]),
         "v1.5.3": ("Große Dokumente reagieren schneller", "Beschleunigt Bearbeitung und Scrollen, reduziert unnötige Aktualisierungen und ergänzt einen ablenkungsfreien Fokusmodus.", ["Editor", "Leistung", "Fokusmodus"]),
         "v1.5.2": ("Editor und Vorschau bleiben synchron", "Gleicht die Schriftgröße der Markdown-Vorschau an den Editor an und misst die Leistung großer Dokumente.", ["Editor", "Vorschau", "Leistung"]),
         "v1.5.1": ("Lebendigere Markdown-Themes", "Verfeinert die Farbpaletten der Vorschau, verbessert das Öffnen von Projektordnern und stabilisiert Sparkle-Updates.", ["Markdown", "Themes", "Updates"]),
@@ -591,6 +592,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor und Snapshots werden verlässlicher", "Verbessert Auswahl, Tastaturnavigation und Themes im macOS-Editor und erweitert den Code-Snapshot-Export.", ["Editor", "Themes", "Snapshots"]),
     },
     "da": {
+        "v1.5.4": ("Alle editorlinjer forbliver tilgængelige", "Sikrer, at ombrudte linjer kan nås helt til dokumentets slutning efter ændringer i sidepanel eller forhåndsvisning.", ["Editor", "Linjeombrydning", "macOS"]),
         "v1.5.3": ("Store dokumenter reagerer hurtigere", "Gør redigering og rulning hurtigere, reducerer unødvendige opdateringer og tilføjer en fokustilstand uden forstyrrelser.", ["Editor", "Ydeevne", "Fokustilstand"]),
         "v1.5.2": ("Editor og forhåndsvisning følger hinanden", "Tilpasser Markdown-forhåndsvisningens skriftstørrelse til editoren og måler ydeevnen i store dokumenter.", ["Editor", "Forhåndsvisning", "Ydeevne"]),
         "v1.5.1": ("Mere levende Markdown-temaer", "Forfiner forhåndsvisningens farvepaletter, forbedrer åbning af projektmapper og stabiliserer Sparkle-opdateringer.", ["Markdown", "Temaer", "Opdateringer"]),
@@ -605,6 +607,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor og snapshots bliver mere pålidelige", "Forbedrer markering, tastaturnavigation og temaer i macOS-editoren og udvider eksporten af kodesnapshots.", ["Editor", "Temaer", "Snapshots"]),
     },
     "fr": {
+        "v1.5.4": ("Toutes les lignes restent accessibles", "Garantit l’accès aux lignes renvoyées à la ligne jusqu’à la fin du document après un changement de barre latérale ou d’aperçu.", ["Éditeur", "Retour à la ligne", "macOS"]),
         "v1.5.3": ("Les grands documents répondent plus vite", "Accélère l’édition et le défilement, réduit les actualisations inutiles et ajoute un mode concentration sans distraction.", ["Éditeur", "Performances", "Concentration"]),
         "v1.5.2": ("Éditeur et aperçu restent synchronisés", "Aligne la taille du texte de l’aperçu Markdown sur celle de l’éditeur et mesure les performances des grands documents.", ["Éditeur", "Aperçu", "Performances"]),
         "v1.5.1": ("Des thèmes Markdown plus vivants", "Affine les palettes de l’aperçu, améliore l’ouverture des dossiers de projet et stabilise les mises à jour Sparkle.", ["Markdown", "Thèmes", "Mises à jour"]),
@@ -619,6 +622,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Éditeur et instantanés plus fiables", "Améliore la sélection, la navigation au clavier et les thèmes dans l’éditeur macOS, tout en enrichissant l’export d’instantanés de code.", ["Éditeur", "Thèmes", "Instantanés"]),
     },
     "es": {
+        "v1.5.4": ("Todas las líneas siguen accesibles", "Garantiza el acceso a las líneas ajustadas hasta el final del documento tras cambiar la barra lateral o la vista previa.", ["Editor", "Ajuste de línea", "macOS"]),
         "v1.5.3": ("Los documentos grandes responden más rápido", "Acelera la edición y el desplazamiento, reduce actualizaciones innecesarias y añade un modo de concentración sin distracciones.", ["Editor", "Rendimiento", "Concentración"]),
         "v1.5.2": ("Editor y vista previa sincronizados", "Alinea el tamaño del texto de la vista previa Markdown con el editor y mide el rendimiento de documentos grandes.", ["Editor", "Vista previa", "Rendimiento"]),
         "v1.5.1": ("Temas Markdown más vivos", "Perfecciona las paletas de color de la vista previa, mejora la apertura de carpetas de proyecto y estabiliza las actualizaciones de Sparkle.", ["Markdown", "Temas", "Actualizaciones"]),
@@ -633,6 +637,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor y capturas más fiables", "Mejora la selección, la navegación por teclado y los temas del editor de macOS, y amplía la exportación de capturas de código.", ["Editor", "Temas", "Capturas"]),
     },
     "ja": {
+        "v1.5.4": ("すべての行に最後までアクセス", "サイドバーやプレビューの変更後も、折り返された行を文書の末尾まで確実に表示できるようにします。", ["エディタ", "行の折り返し", "macOS"]),
         "v1.5.3": ("大きな書類をさらに高速に操作", "編集とスクロールを高速化し、不要な更新を減らして、集中できるフォーカスモードを追加します。", ["エディタ", "パフォーマンス", "フォーカス"]),
         "v1.5.2": ("エディタとプレビューを同期", "Markdown プレビューの文字サイズをエディタに合わせ、大きなドキュメントのパフォーマンスを測定します。", ["エディタ", "プレビュー", "パフォーマンス"]),
         "v1.5.1": ("Markdown テーマをより鮮やかに", "プレビューのカラーパレットを改善し、プロジェクトフォルダの直接オープンと Sparkle の更新を安定させます。", ["Markdown", "テーマ", "アップデート"]),
@@ -647,6 +652,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("エディタとスナップショットをさらに信頼性向上", "macOS エディタの選択、キーボード操作、テーマを改善し、コードスナップショットの書き出しを拡充します。", ["エディタ", "テーマ", "スナップショット"]),
     },
     "zh-Hans": {
+        "v1.5.4": ("所有编辑器行均可访问", "在切换侧边栏或预览后，确保自动换行内容一直可以滚动到文档末尾。", ["编辑器", "自动换行", "macOS"]),
         "v1.5.3": ("大型文档响应更快", "加快编辑和滚动，减少不必要的刷新，并加入无干扰的专注模式。", ["编辑器", "性能", "专注模式"]),
         "v1.5.2": ("编辑器与预览保持同步", "让 Markdown 预览文字大小与编辑器一致，并测量大型文档的性能。", ["编辑器", "预览", "性能"]),
         "v1.5.1": ("更鲜明的 Markdown 主题", "改进预览配色，优化直接打开项目文件夹，并提高 Sparkle 更新的稳定性。", ["Markdown", "主题", "更新"]),


### PR DESCRIPTION
## Summary
- add the v1.5.4 hotfix changelog entry
- add localized timeline copy required by release-doc generation

## Verification
- release_notes_quality_gate.sh v1.5.4 --preflight passed
- v1.5.4 milestone is closed with zero open issues
- git diff --check passed

## Summary by Sourcery

Documentation:
- Add the v1.5.4 hotfix changelog entry and localized release timeline copy across supported languages.