### PR TITLE
docs: sync App Store metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 > Platform target: **macOS 26 (Tahoe)** compatible with **macOS Sequoia**
 > Apple Silicon: tested / Intel: not tested
 > Direct GitHub release: **v1.5.4** / App Store and TestFlight availability varies by platform and review status
-> Last updated (README): **2026-08-27** for latest release **v1.5.4**
+> Last updated (README): **2026-08-28** for latest release **v1.5.4**
 
 ## What's New in v1.5.3 and v1.5.4
 

--- a/site/index.html
+++ b/site/index.html
@@ -1458,9 +1458,9 @@
           <h3>App Store</h3>
           <p>Apple-managed installation across the supported Apple platforms. Store releases can trail the direct channel during review.</p>
           <div class="channel-meta">
-            <span data-app-store-version>iOS / iPadOS · v1.4.1</span>
+            <span data-app-store-version>iOS / iPadOS · v0.7.8</span>
             <span>macOS · v0.8.6</span>
-            <span>visionOS · v1.0.2 (review)</span>
+            <span>visionOS · v0.8.8</span>
             <span>Last verified · 28 July 2026</span>
             <span>Apple-managed updates</span>
           </div>


### PR DESCRIPTION
## Summary\n- refresh README documentation date for v1.5.4\n- align the English Pages App Store card with the recorded platform versions\n- preserve the existing localized Pages metadata\n\n## Verification\n- scripts/prepare_release_docs.py v1.5.4 --check\n- scripts/sync_readme_appstore_versions.py --check --store-version 0.7.8\n- scripts/ci/validate_release_metadata.sh v1.5.4\n- tracked SVG XML validation with xmllint\n- git diff --check

## Summary by Sourcery

Synchronize release documentation and English App Store metadata for the current platform versions.

Enhancements:
- Synchronize the English App Store metadata with the recorded iOS, iPadOS, macOS, and visionOS versions while preserving localized metadata.

Documentation:
- Update the README’s latest-release timestamp for version 1.5.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s last-updated date.
  * Updated App Store release labels for iOS/iPadOS and visionOS in the “Get Neon” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->