### PR TITLE
docs: sync App Store 1.5.4 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,14 @@
 
 Prebuilt binaries are available on [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases).
 
-The direct GitHub release is currently ahead of the App Store version. The App Store version may temporarily lag while updates are in Apple review.
+The iOS/iPadOS App Store listing is currently aligned with the direct GitHub release. The macOS App Store update is currently in Apple review.
 
 | Channel | Platform | Best For | Download | Release Track | Notes |
 |---|---|---|---|---|---|
 | **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.5.4** | Current direct download |
-| **Store** | iOS / iPadOS / macOS / visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v0.7.8** | Current public App Store listing |
-| **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.2.6** | Resubmitted after review fixes |
+| **Store** | iOS / iPadOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.5.4** | Current public App Store listing |
+| **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.5.4** | In Apple review |
+| **Store** | visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v0.8.8** | Current recorded visionOS listing |
 | **Beta** | iOS / iPadOS / macOS | Testing upcoming changes before stable | [TestFlight Invite](https://testflight.apple.com/join/YWB2fGAP) | **v1.5.4** | Early access builds for feedback; availability may vary by review state |
 
 ## Install

--- a/scripts/sync_readme_appstore_versions.py
+++ b/scripts/sync_readme_appstore_versions.py
@@ -94,10 +94,11 @@ def sync_readme_versions(readme: str, latest_tag: str, public_store_tag: str, to
     store_is_current = public_store_tag == latest_tag
 
     availability_note = (
-        "The direct GitHub release and public App Store listing are currently aligned."
+        "The iOS/iPadOS App Store listing is currently aligned with the direct GitHub release. "
+        "The macOS App Store update is currently in Apple review."
         if store_is_current
         else (
-            "The direct GitHub release is currently ahead of the App Store version. "
+            "The direct GitHub release is currently ahead of the iOS/iPadOS App Store version. "
             "The App Store version may temporarily lag while updates are in Apple review."
         )
     )
@@ -121,7 +122,7 @@ def sync_readme_versions(readme: str, latest_tag: str, public_store_tag: str, to
         "last updated status",
     )
     readme = replace_required(
-        r"^The direct GitHub release(?: and public App Store listing are currently aligned\.| is currently ahead of the App Store version\. The App Store version may temporarily lag while updates are in Apple review\.)$",
+        r"^(?:The direct GitHub release and public App Store listing are currently aligned\.|The iOS/iPadOS App Store listing is currently aligned with the direct GitHub release\. The macOS App Store update is currently in Apple review\.|The direct GitHub release is currently ahead of the iOS/iPadOS App Store version\. The App Store version may temporarily lag while updates are in Apple review\.)$",
         availability_note,
         readme,
         "download availability note",
@@ -132,11 +133,17 @@ def sync_readme_versions(readme: str, latest_tag: str, public_store_tag: str, to
         readme,
         "GitHub release table row",
     )
-    readme = replace_if_present(
-        r"^(\| \*\*Store Review\*\* \| iOS / iPadOS \| [^|]+ \| App Store Connect review \| )\*\*[^*]+\*\*( \| ).*$",
-        rf"\1**{latest_tag}**\2{'Already public on App Store' if store_is_current else 'In Apple review'} |",
+    readme = replace_required(
+        r"^(\| \*\*Store\*\* \| iOS / iPadOS \| [^|]+ \| \[Neon Vision Editor on the App Store\]\(https://apps\.apple\.com/de/app/neon-vision-editor/id6758950965\) \| )\*\*[^*]+\*\*( \| ).*$",
+        rf"\1**{public_store_tag}**\2Current public App Store listing |",
         readme,
-        "iOS App Store review row",
+        "iOS App Store table row",
+    )
+    readme = replace_required(
+        r"^(\| \*\*Store Review\*\* \| macOS \| [^|]+ \| App Store Connect review \| )\*\*[^*]+\*\*( \| ).*$",
+        rf"\1**{latest_tag}**\2In Apple review |",
+        readme,
+        "macOS App Store review row",
     )
     readme = replace_required(
         r"^(\| \*\*Beta\*\* \| iOS / iPadOS / macOS \| [^|]+ \| \[TestFlight Invite\]\(https://testflight\.apple\.com/join/YWB2fGAP\) \| )\*\*[^*]+\*\*( \| ).*$",

--- a/site/da/index.html
+++ b/site/da/index.html
@@ -1413,10 +1413,10 @@
           <h3>App Store</h3>
           <p>Apple-administreret installation på de understøttede Apple-platforme. Store-versioner kan være forsinkede under Apples gennemgang.</p>
           <div class="channel-meta">
-            <span data-app-store-version>iOS / iPadOS · v0.7.8</span>
-            <span>macOS · v0.8.6</span>
+            <span data-app-store-version>iOS / iPadOS · v1.5.4</span>
+            <span>macOS · v1.5.4 (gennemgang)</span>
             <span>visionOS · v0.8.8</span>
-            <span>Senest kontrolleret · 28 July 2026</span>
+            <span>Senest kontrolleret · 28 August 2026</span>
             <span>Apple-administrerede opdateringer</span>
           </div>
           <a class="button" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Åbn App Store</a>

--- a/site/de/index.html
+++ b/site/de/index.html
@@ -1414,10 +1414,10 @@
           <h3>App Store</h3>
           <p>Apple-verwaltete Installation auf den unterstützten Apple-Plattformen. Store-Versionen können während der Prüfung hinter dem Direktkanal zurückbleiben.</p>
           <div class="channel-meta">
-            <span data-app-store-Version>iOS / iPadOS · v0.7.8</span>
-            <span>macOS · v0.8.6</span>
+            <span data-app-store-Version>iOS / iPadOS · v1.5.4</span>
+            <span>macOS · v1.5.4 (Prüfung)</span>
             <span>visionOS · v0.8.8</span>
-            <span>Zuletzt geprüft · 28. Juli 2026</span>
+            <span>Zuletzt geprüft · 28. August 2026</span>
             <span>Apple-verwaltete Updates</span>
           </div>
           <a class="button" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store öffnen</a>

--- a/site/es/index.html
+++ b/site/es/index.html
@@ -1413,10 +1413,10 @@
           <h3>App Store</h3>
           <p>Instalación gestionada por Apple en las plataformas compatibles. Las versiónes de la tienda pueden tardar más que el canal directo durante la revisión.</p>
           <div class="channel-meta">
-            <span data-app-store-versión>iOS / iPadOS · v0.7.8</span>
-            <span>macOS · v0.8.6</span>
+            <span data-app-store-versión>iOS / iPadOS · v1.5.4</span>
+            <span>macOS · v1.5.4 (en revisión)</span>
             <span>visionOS · v0.8.8</span>
-            <span>Última verificación · 28 July 2026</span>
+            <span>Última verificación · 28 de agosto de 2026</span>
             <span>Actualizaciones gestionadas por Apple</span>
           </div>
           <a class="button" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Abrir App Store</a>

--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -1413,10 +1413,10 @@
           <h3>App Store</h3>
           <p>Installation gérée par Apple sur les plateformes prises en charge. Les versions du Store peuvent être retardées pendant la validation.</p>
           <div class="channel-meta">
-            <span data-app-store-version>iOS / iPadOS · v0.7.8</span>
-            <span>macOS · v0.8.6</span>
+            <span data-app-store-version>iOS / iPadOS · v1.5.4</span>
+            <span>macOS · v1.5.4 (validation)</span>
             <span>visionOS · v0.8.8</span>
-            <span>Vérifié le · 28 July 2026</span>
+            <span>Vérifié le · 28 août 2026</span>
             <span>Mises à jour gérées par Apple</span>
           </div>
           <a class="button" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Ouvrir l’App Store</a>

--- a/site/index.html
+++ b/site/index.html
@@ -1458,10 +1458,10 @@
           <h3>App Store</h3>
           <p>Apple-managed installation across the supported Apple platforms. Store releases can trail the direct channel during review.</p>
           <div class="channel-meta">
-            <span data-app-store-version>iOS / iPadOS · v0.7.8</span>
-            <span>macOS · v0.8.6</span>
+            <span data-app-store-version>iOS / iPadOS · v1.5.4</span>
+            <span>macOS · v1.5.4 (review)</span>
             <span>visionOS · v0.8.8</span>
-            <span>Last verified · 28 July 2026</span>
+            <span>Last verified · 28 August 2026</span>
             <span>Apple-managed updates</span>
           </div>
           <a class="button" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Open App Store</a>

--- a/site/ja/index.html
+++ b/site/ja/index.html
@@ -1413,10 +1413,10 @@
           <h3>App Store</h3>
           <p>対応するAppleプラットフォームでAppleが管理するインストール。審査中はStore版の公開が遅れる場合があります。</p>
           <div class="channel-meta">
-            <span data-app-store-バージョン>iOS / iPadOS · v0.7.8</span>
-            <span>macOS · v0.8.6</span>
+            <span data-app-store-バージョン>iOS / iPadOS · v1.5.4</span>
+            <span>macOS · v1.5.4 (審査中)</span>
             <span>visionOS · v0.8.8</span>
-            <span>Last verified · 28 July 2026</span>
+            <span>Last verified · 28 August 2026</span>
             <span>Apple管理のアップデート</span>
           </div>
           <a class="button" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Storeを開く</a>

--- a/site/zh-Hans/index.html
+++ b/site/zh-Hans/index.html
@@ -1413,10 +1413,10 @@
           <h3>App Store</h3>
           <p>在支持的 Apple 平台上由 Apple 管理安装。商店版本在审核期间可能晚于直接发布渠道。</p>
           <div class="channel-meta">
-            <span data-app-store-版本>iOS / iPadOS · v0.7.8</span>
-            <span>macOS · v0.8.6</span>
+            <span data-app-store-版本>iOS / iPadOS · v1.5.4</span>
+            <span>macOS · v1.5.4（审核中）</span>
             <span>visionOS · v0.8.8</span>
-            <span>Last verified · 28 July 2026</span>
+            <span>Last verified · 28 August 2026</span>
             <span>Apple 管理的更新</span>
           </div>
           <a class="button" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">打开 App Store</a>


### PR DESCRIPTION
## Summary\n- update README App Store tracking to iOS/iPadOS v1.5.4\n- record macOS v1.5.4 as in Apple review\n- retain the recorded visionOS v0.8.8 listing\n- update all seven Pages locales\n- keep the App Store sync script compatible with the split platform rows\n\n## Verification\n- scripts/prepare_release_docs.py v1.5.4 --check\n- scripts/sync_readme_appstore_versions.py --check --store-version 1.5.4\n- scripts/ci/validate_release_metadata.sh v1.5.4\n- git diff --check

## Summary by Sourcery

Synchronize App Store version tracking across the README and localized Pages sites for the latest Apple platform release statuses.

Enhancements:
- Update App Store release tracking to distinguish iOS/iPadOS, macOS review, and visionOS versions.
- Refresh App Store version and verification-date information across all seven localized Pages sites.

Documentation:
- Document iOS/iPadOS v1.5.4 as the current public App Store release, macOS v1.5.4 as under review, and retain the recorded visionOS v0.8.8 listing.

Chores:
- Keep the App Store README synchronization script compatible with the split platform-specific rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release-channel information to reflect the latest App Store versions and review status.
  * iOS/iPadOS availability now shows version 1.5.4 as publicly released.
  * macOS is listed as version 1.5.4 pending Apple review.
  * visionOS remains at version 0.8.8.
  * Updated App Store verification dates across localized landing pages to 28 August 2026.
  * Improved platform-specific release details in English, Danish, German, Spanish, French, Japanese, and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->