### PR TITLE
ci: auto-merge documentation pull requests

### DIFF
--- a/.github/workflows/post-release-documentation-sync.yml
+++ b/.github/workflows/post-release-documentation-sync.yml
@@ -194,7 +194,5 @@ jobs:
             echo "Could not resolve the open documentation PR for ${docs_sha}." >&2
             exit 1
           fi
-          if ! gh pr merge "${docs_pr}" --repo "${GITHUB_REPOSITORY}" --merge --delete-branch; then
-            gh pr merge "${docs_pr}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
-              echo "Auto-merge is unavailable; leaving the documentation PR open."
-          fi
+          gh pr merge "${docs_pr}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
+            echo "Auto-merge is unavailable; leaving the documentation PR open."

--- a/.github/workflows/sync-readme-appstore-versions.yml
+++ b/.github/workflows/sync-readme-appstore-versions.yml
@@ -128,7 +128,5 @@ jobs:
             echo "Could not resolve the open App Store synchronization PR for ${sync_sha}." >&2
             exit 1
           fi
-          if ! gh pr merge "${sync_pr}" --repo "${GITHUB_REPOSITORY}" --merge --delete-branch; then
-            gh pr merge "${sync_pr}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
-              echo "Auto-merge is unavailable; leaving the App Store synchronization PR open."
-          fi
+          gh pr merge "${sync_pr}" --repo "${GITHUB_REPOSITORY}" --auto --merge --delete-branch || \
+            echo "Auto-merge is unavailable; leaving the App Store synchronization PR open."

--- a/.github/workflows/update-download-metrics.yml
+++ b/.github/workflows/update-download-metrics.yml
@@ -116,13 +116,8 @@ jobs:
             echo "Could not resolve the open metrics PR for ${metrics_sha}." >&2
             exit 1
           fi
-          if ! gh pr merge "${metrics_pr}" \
+          gh pr merge "${metrics_pr}" \
             --repo "${GITHUB_REPOSITORY}" \
+            --auto \
             --merge \
-            --delete-branch; then
-            gh pr merge "${metrics_pr}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --auto \
-              --merge \
-              --delete-branch || echo "Auto-merge is unavailable; leaving the metrics pull request open."
-          fi
+            --delete-branch || echo "Auto-merge is unavailable; leaving the metrics pull request open."


### PR DESCRIPTION
## Summary\n- make the daily metrics PR use GitHub auto-merge explicitly\n- make post-release documentation PRs use GitHub auto-merge explicitly\n- make App Store version synchronization PRs use GitHub auto-merge explicitly\n- preserve merge-commit strategy and automatic branch deletion\n\n## Verification\n- YAML parsing passed for all three workflows\n- git diff --check passed\n- actionlint unavailable locally

## Summary by Sourcery

Use GitHub auto-merge consistently for automated pull requests across the synchronization workflows.

Enhancements:
- Configure automated metrics, documentation, and App Store synchronization pull requests to use GitHub auto-merge while preserving merge commits and branch cleanup.

CI:
- Simplify the merge commands in the affected GitHub Actions workflows and consistently leave pull requests open when auto-merge is unavailable.