### PR TITLE
Update visionOS version to v1.5.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ The iOS/iPadOS App Store listing is currently aligned with the direct GitHub rel
 | **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.5.4** | Current direct download |
 | **Store** | iOS / iPadOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.5.4** | Current public App Store listing |
 | **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.5.4** | In Apple review |
-| **Store** | visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v0.8.8** | Current recorded visionOS listing |
+| **Store** | visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.5.0** | Current recorded visionOS listing |
 | **Beta** | iOS / iPadOS / macOS | Testing upcoming changes before stable | [TestFlight Invite](https://testflight.apple.com/join/YWB2fGAP) | **v1.5.4** | Early access builds for feedback; availability may vary by review state |
 
 ## Install


### PR DESCRIPTION
## Summary

- What changed:
- Why:
- Scope: Bugfix / Feature / Docs / Release
- Linked issue/milestone:

## Validation

- [ ] Built on macOS
- [ ] Built on iOS simulator
- [ ] Built on iPad simulator
- [ ] Tested key flow manually
- [ ] Repro steps included (for bug/regression fixes)
- [ ] Expected vs actual behavior documented (for bug/regression fixes)

## Checklist

- [ ] Accessibility checked (labels, focus order, no traps)
- [ ] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [ ] VoiceOver impact evaluated (if UI touched)
- [ ] Changelog updated (if user-facing change)
- [ ] Documentation updated (if behavior/UI changed)
- [ ] No unrelated refactors

## Risk

- Risk level: Low / Medium / High
- User-facing risk:
- Rollback plan:

## Summary by Sourcery

Documentation:
- Update the README to record visionOS version v1.5.0 for the current App Store listing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Download table to list visionOS Store release track **v1.5.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->