### PR TITLE
fix(ios): hide Markdown toolbar during find

### DIFF
--- a/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
@@ -68,6 +68,23 @@ enum MarkdownFormattingAction: CaseIterable, Identifiable {
     }
 }
 
+enum MarkdownFormattingChromePolicy {
+    nonisolated static func shouldShow(
+        isMarkdown: Bool,
+        isReadOnlyPreview: Bool,
+        brainDumpLayoutEnabled: Bool,
+        isLoadingContent: Bool,
+        findPresented: Bool,
+        findOccupiesEditorChrome: Bool
+    ) -> Bool {
+        isMarkdown
+            && !isReadOnlyPreview
+            && !brainDumpLayoutEnabled
+            && !isLoadingContent
+            && !(findPresented && findOccupiesEditorChrome)
+    }
+}
+
 extension ContentView {
     var markdownFormattingOverlayAlignment: Alignment {
 #if os(macOS)
@@ -80,10 +97,19 @@ extension ContentView {
     }
 
     var shouldShowMarkdownFormattingControls: Bool {
-        currentLanguage == "markdown"
-            && viewModel.selectedTab?.isReadOnlyPreview != true
-            && !brainDumpLayoutEnabled
-            && viewModel.selectedTab?.isLoadingContent != true
+#if os(iOS)
+        let findOccupiesEditorChrome = true
+#else
+        let findOccupiesEditorChrome = false
+#endif
+        return MarkdownFormattingChromePolicy.shouldShow(
+            isMarkdown: currentLanguage == "markdown",
+            isReadOnlyPreview: viewModel.selectedTab?.isReadOnlyPreview == true,
+            brainDumpLayoutEnabled: brainDumpLayoutEnabled,
+            isLoadingContent: viewModel.selectedTab?.isLoadingContent == true,
+            findPresented: showFindReplace,
+            findOccupiesEditorChrome: findOccupiesEditorChrome
+        )
     }
 
 #if os(iOS) || os(visionOS)

--- a/Neon Vision EditorTests/ContentViewLayoutTests.swift
+++ b/Neon Vision EditorTests/ContentViewLayoutTests.swift
@@ -66,4 +66,30 @@ final class ContentViewLayoutTests: XCTestCase {
             )
         )
     }
+
+    func testMobileFindChromeSuppressesMarkdownFormattingChrome() {
+        XCTAssertFalse(
+            MarkdownFormattingChromePolicy.shouldShow(
+                isMarkdown: true,
+                isReadOnlyPreview: false,
+                brainDumpLayoutEnabled: false,
+                isLoadingContent: false,
+                findPresented: true,
+                findOccupiesEditorChrome: true
+            )
+        )
+    }
+
+    func testSeparateFindWindowDoesNotSuppressMarkdownFormattingChrome() {
+        XCTAssertTrue(
+            MarkdownFormattingChromePolicy.shouldShow(
+                isMarkdown: true,
+                isReadOnlyPreview: false,
+                brainDumpLayoutEnabled: false,
+                isLoadingContent: false,
+                findPresented: true,
+                findOccupiesEditorChrome: false
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- hide Markdown formatting chrome while the inline iOS Find & Replace bar is presented
- restore Markdown formatting controls immediately when Find closes
- preserve macOS behavior, where Find uses a separate window
- add focused visibility-policy regression coverage

## Verification
- 7 focused ContentView layout tests passed
- iPhone Markdown runtime verified toolbar hide and restore transitions
- iPad build and launch passed
- clean diff validation passed

## Summary by Sourcery

Align Markdown formatting chrome visibility with platform-specific Find presentation behavior.

Bug Fixes:
- Hide Markdown formatting controls while the inline iOS Find & Replace bar occupies the editor chrome, restoring them when Find closes.

Enhancements:
- Preserve Markdown formatting controls when Find is presented in a separate macOS window by centralizing the visibility policy.

Tests:
- Add regression coverage for suppressing Markdown controls on mobile Find and retaining them for separate Find windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Markdown formatting toolbar’s visibility when the Find interface is open on mobile devices.
  * Preserved Markdown formatting controls when Find appears in a separate window or does not occupy the editor area.

* **Tests**
  * Added coverage for mobile Find behavior and separate Find windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->