### PR TITLE
chore: synchronize develop with main

### DIFF
--- a/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
@@ -68,6 +68,23 @@ enum MarkdownFormattingAction: CaseIterable, Identifiable {
     }
 }
 
+enum MarkdownFormattingChromePolicy {
+    nonisolated static func shouldShow(
+        isMarkdown: Bool,
+        isReadOnlyPreview: Bool,
+        brainDumpLayoutEnabled: Bool,
+        isLoadingContent: Bool,
+        findPresented: Bool,
+        findOccupiesEditorChrome: Bool
+    ) -> Bool {
+        isMarkdown
+            && !isReadOnlyPreview
+            && !brainDumpLayoutEnabled
+            && !isLoadingContent
+            && !(findPresented && findOccupiesEditorChrome)
+    }
+}
+
 extension ContentView {
     var markdownFormattingOverlayAlignment: Alignment {
 #if os(macOS)
@@ -80,10 +97,19 @@ extension ContentView {
     }
 
     var shouldShowMarkdownFormattingControls: Bool {
-        currentLanguage == "markdown"
-            && viewModel.selectedTab?.isReadOnlyPreview != true
-            && !brainDumpLayoutEnabled
-            && viewModel.selectedTab?.isLoadingContent != true
+#if os(iOS)
+        let findOccupiesEditorChrome = true
+#else
+        let findOccupiesEditorChrome = false
+#endif
+        return MarkdownFormattingChromePolicy.shouldShow(
+            isMarkdown: currentLanguage == "markdown",
+            isReadOnlyPreview: viewModel.selectedTab?.isReadOnlyPreview == true,
+            brainDumpLayoutEnabled: brainDumpLayoutEnabled,
+            isLoadingContent: viewModel.selectedTab?.isLoadingContent == true,
+            findPresented: showFindReplace,
+            findOccupiesEditorChrome: findOccupiesEditorChrome
+        )
     }
 
 #if os(iOS) || os(visionOS)

--- a/Neon Vision EditorTests/ContentViewLayoutTests.swift
+++ b/Neon Vision EditorTests/ContentViewLayoutTests.swift
@@ -66,4 +66,30 @@ final class ContentViewLayoutTests: XCTestCase {
             )
         )
     }
+
+    func testMobileFindChromeSuppressesMarkdownFormattingChrome() {
+        XCTAssertFalse(
+            MarkdownFormattingChromePolicy.shouldShow(
+                isMarkdown: true,
+                isReadOnlyPreview: false,
+                brainDumpLayoutEnabled: false,
+                isLoadingContent: false,
+                findPresented: true,
+                findOccupiesEditorChrome: true
+            )
+        )
+    }
+
+    func testSeparateFindWindowDoesNotSuppressMarkdownFormattingChrome() {
+        XCTAssertTrue(
+            MarkdownFormattingChromePolicy.shouldShow(
+                isMarkdown: true,
+                isReadOnlyPreview: false,
+                brainDumpLayoutEnabled: false,
+                isLoadingContent: false,
+                findPresented: true,
+                findOccupiesEditorChrome: false
+            )
+        )
+    }
 }


### PR DESCRIPTION
Synchronize develop with production main after merging PR #255.

This brings the verified iOS Markdown/Find toolbar exclusivity fix into the integration branch without changing the resulting source tree beyond current main.

## Summary by Sourcery

Synchronize Markdown formatting and Find toolbar visibility behavior across platforms.

Bug Fixes:
- Prevent the iOS Find/Replace toolbar from appearing simultaneously with Markdown formatting controls.

Enhancements:
- Centralize Markdown formatting toolbar visibility rules and preserve independent toolbar behavior on platforms where Find uses separate chrome.

Tests:
- Add coverage for iOS toolbar suppression and separate Find-window behavior.