### PR TITLE
Editor polish for v1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to **Neon Vision Editor** are documented in this file.
 
 The format follows *Keep a Changelog*. Versions use semantic versioning with prerelease tags.
 
+## [v1.5.6] - 2026-08-29
+
+### Why Upgrade
+
+- Makes the iPhone and iPad editor toolbar more compact and language-aware without hiding full menu names or accessibility context.
+- Restores predictable Markdown list continuation and native text-selection commands across mobile and macOS editors.
+- Keeps collapsed and expanded Markdown formatting controls readable without wasting editor space or covering actions.
+
+### Highlights
+
+- Uses icon-only mobile toolbar presets and language-specific symbols or initials for the current document language.
+- Adds a horizontally scrollable mobile Markdown formatting row while keeping the collapsed control in a compact opaque pill over a transparent surrounding area.
+- Treats explicit language choices as tab-level overrides so automatic detection does not immediately replace the user's selection.
+
+### Fixes
+
+- Makes Settings and Help toolbar visibility follow their configured switches in standard, all-actions, and custom presets.
+- Increments ordered Markdown markers such as `1.` to `2.` and `9)` to `10)` when continuing lists, including in the macOS virtual editor.
+- Restores the system edit menu for caret-only interactions so Select and Select All remain available while preserving snapshot actions for selected ranges.
+- Prevents editor characters from bleeding through the collapsed Markdown formatting pill and keeps the expanded action row reachable by horizontal scrolling.
+
+### Breaking changes
+
+- None.
+
+### Migration
+
+- None.
+
 ## [v1.5.5] - 2026-08-29
 
 ### Why Upgrade

--- a/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
@@ -83,6 +83,29 @@ enum MarkdownFormattingChromePolicy {
             && !isLoadingContent
             && !(findPresented && findOccupiesEditorChrome)
     }
+
+    nonisolated static func shouldReserveMobileFormattingRow(
+        isPhone: Bool,
+        shouldShow: Bool,
+        isCollapsed: Bool
+    ) -> Bool {
+        isPhone && shouldShow && !isCollapsed
+    }
+
+    nonisolated static func shouldRenderInEditorStack(
+        shouldShow: Bool,
+        overlaysEditor: Bool,
+        reservesChromeRow: Bool
+    ) -> Bool {
+        shouldShow && !overlaysEditor && !reservesChromeRow
+    }
+
+    nonisolated static func usesTranslucentControlSurface(
+        isCollapsed: Bool,
+        liquidGlassEnabled: Bool
+    ) -> Bool {
+        liquidGlassEnabled && !isCollapsed
+    }
 }
 
 extension ContentView {
@@ -125,9 +148,14 @@ extension ContentView {
 
     var iPhoneMarkdownFormattingChrome: some View {
         GlassSurface(
-            enabled: shouldUseLiquidGlass,
+            enabled: MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
+                isCollapsed: markdownFormattingToolbarCollapsed,
+                liquidGlassEnabled: shouldUseLiquidGlass
+            ),
             material: primaryGlassMaterial,
-            fallbackColor: toolbarFallbackColor,
+            fallbackColor: markdownFormattingToolbarCollapsed
+                ? Color(uiColor: .secondarySystemBackground)
+                : toolbarFallbackColor,
             shape: .capsule,
             chromeStyle: .single
         ) {
@@ -153,10 +181,11 @@ extension ContentView {
 
     var shouldPlaceMarkdownFormattingBelowTabs: Bool {
 #if os(iOS)
-        // Both iPhone and iPad overlay the capsule on the editor. Placing it
-        // inside the top safe-area host reserves an opaque-looking row and
-        // prevents the document from remaining visible underneath.
-        return false
+        MarkdownFormattingChromePolicy.shouldReserveMobileFormattingRow(
+            isPhone: UIDevice.current.userInterfaceIdiom == .phone,
+            shouldShow: shouldShowMarkdownFormattingControls,
+            isCollapsed: markdownFormattingToolbarCollapsed
+        )
         #elseif os(visionOS)
         return shouldShowMarkdownFormattingControls
         #else
@@ -179,8 +208,7 @@ extension ContentView {
            shouldEmbedMarkdownFormattingInMobileStatusRow {
             EmptyView()
         } else {
-            // iPad uses the same glass capsule as iPhone even though its
-            // control is positioned by the editor overlay.
+            // iPad uses the same control treatment as iPhone.
             iPhoneMarkdownFormattingChrome
         }
 #else
@@ -224,6 +252,16 @@ extension ContentView {
     }
 
     private var markdownFormattingCapsule: some View {
+#if os(iOS) || os(visionOS)
+        ScrollView(.horizontal, showsIndicators: false) {
+            markdownFormattingCapsuleContent
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .defaultScrollAnchor(.leading)
+        .accessibilityHint("Scroll horizontally for additional Markdown formatting controls.")
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+#else
         ViewThatFits(in: .horizontal) {
             markdownFormattingCapsuleContent
                 .fixedSize(horizontal: true, vertical: false)
@@ -231,11 +269,12 @@ extension ContentView {
             ScrollView(.horizontal, showsIndicators: false) {
                 markdownFormattingCapsuleContent
             }
-            .defaultScrollAnchor(.trailing)
+            .defaultScrollAnchor(.leading)
             .accessibilityHint("Scroll horizontally for additional Markdown formatting controls.")
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
+#endif
     }
 
     private var markdownFormattingCapsuleContent: some View {

--- a/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
+++ b/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
@@ -152,9 +152,9 @@ extension ContentView {
         // both use the same glass capsule, tint, padding, and accessibility
         // treatment instead of exposing the unwrapped toolbar directly.
         iPhoneMarkdownFormattingChrome
-            // Keep the glass surface sized to its controls. A full-width
-            // proposal makes the fallback material look like an opaque bar.
-            .fixedSize(horizontal: true, vertical: false)
+            // Collapsed chrome stays compact. Expanded chrome accepts the
+            // available width so its action row can scroll horizontally.
+            .fixedSize(horizontal: markdownFormattingToolbarCollapsed, vertical: false)
             .frame(maxWidth: .infinity, alignment: .trailing)
             .tint(iOSToolbarForegroundColor)
     }

--- a/Neon Vision Editor/UI/ContentView+Toolbar.swift
+++ b/Neon Vision Editor/UI/ContentView+Toolbar.swift
@@ -78,6 +78,15 @@ struct ToolbarActionSelection {
         preset == .custom
     }
 
+    static func shouldIncludeConfiguredAction(
+        actionID: String,
+        isConfiguredVisible: Bool,
+        preset: ToolbarPreset
+    ) -> Bool {
+        let alwaysHonorsVisibility = actionID == "settings" || actionID == "help"
+        return !(honorsSectionVisibility(preset: preset) || alwaysHonorsVisibility) || isConfiguredVisible
+    }
+
     static func toggledSelectionRawValue(
         toggledID: String,
         currentRawValue: String,
@@ -93,6 +102,38 @@ struct ToolbarActionSelection {
         return orderedIDs
             .filter { selected.contains($0) }
             .joined(separator: ",")
+    }
+}
+
+enum ToolbarLanguageGlyph: Equatable {
+    case systemImage(String)
+    case initial(String)
+
+    static func resolve(language: String, displayName: String) -> ToolbarLanguageGlyph {
+        switch language.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "swift":
+            return .systemImage("swift")
+        case "markdown":
+            return .initial("M")
+        case "rst", "typst", "tex":
+            return .systemImage("doc.richtext")
+        case "plain", "standard", "log", "crashlog":
+            return .systemImage("doc.plaintext")
+        case "html", "xml":
+            return .systemImage("chevron.left.forwardslash.chevron.right")
+        case "json", "graphql":
+            return .systemImage("curlybraces")
+        case "bash", "zsh", "fish", "powershell":
+            return .systemImage("terminal")
+        case "css":
+            return .systemImage("paintbrush")
+        default:
+            let initial = displayName
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .first
+                .map { String($0).uppercased() }
+            return initial.map(ToolbarLanguageGlyph.initial) ?? .systemImage("doc")
+        }
     }
 }
 
@@ -526,13 +567,8 @@ extension ContentView {
             .fixedSize(horizontal: true, vertical: false)
             .frame(minWidth: 64, alignment: .center)
 #else
-            HStack(spacing: 4) {
-                Image(systemName: currentToolbarPreset.icon)
-                Text(currentToolbarPreset.compactTitle)
-                    .lineLimit(1)
-            }
+            Image(systemName: currentToolbarPreset.icon)
                 .foregroundStyle(currentToolbarPreset.tint)
-                .fixedSize()
 #endif
         }
         .help("Choose Toolbar Preset")
@@ -631,18 +667,6 @@ extension ContentView {
         return true
     }
 
-    private var iPhoneToolbarWidth: CGFloat {
-        max(liveContainerWidth, 320)
-    }
-
-    private var iPhoneLanguagePickerWidth: CGFloat {
-        switch iPhoneToolbarWidth {
-        case 430...: return 108
-        case 395...: return 100
-        default: return 94
-        }
-    }
-
     private enum IOSPrimaryToolbarAction: String, CaseIterable, Hashable {
         case openFile
         case undo
@@ -692,7 +716,16 @@ extension ContentView {
         var actions: [IOSPrimaryToolbarAction] = []
         if !honorsSectionVisibility || toolbarShowOpenFileIOS { actions.append(.openFile) }
         if !honorsSectionVisibility || toolbarShowUndoIOS { actions.append(.undo) }
-        actions.append(contentsOf: [.settings, .help])
+        if ToolbarActionSelection.shouldIncludeConfiguredAction(
+            actionID: IOSPrimaryToolbarAction.settings.rawValue,
+            isConfiguredVisible: toolbarShowSettingsIOS,
+            preset: preset
+        ) { actions.append(.settings) }
+        if ToolbarActionSelection.shouldIncludeConfiguredAction(
+            actionID: IOSPrimaryToolbarAction.help.rawValue,
+            isConfiguredVisible: toolbarShowHelpIOS,
+            preset: preset
+        ) { actions.append(.help) }
         if !honorsSectionVisibility || toolbarShowEditorUtilityIOS {
             actions.append(contentsOf: [.clearEditor, .insertTemplate])
         }
@@ -931,9 +964,12 @@ extension ContentView {
 
     private var enabledIPadActionPriority: [IPadToolbarAction] {
         let preset = effectiveIOSToolbarPreset
-        let honorsSectionVisibility = ToolbarActionSelection.honorsSectionVisibility(preset: preset)
         return iPadActionPriority.filter {
-            (!honorsSectionVisibility || toolbarActionIsEnabled($0)) && ToolbarActionSelection.isAllowedByPreset(
+            ToolbarActionSelection.shouldIncludeConfiguredAction(
+                actionID: $0.rawValue,
+                isConfiguredVisible: toolbarActionIsEnabled($0),
+                preset: preset
+            ) && ToolbarActionSelection.isAllowedByPreset(
                 actionID: $0.rawValue,
                 preset: preset,
                 customIDsRawValue: toolbarCustomFiveIDsIOS,
@@ -954,6 +990,10 @@ extension ContentView {
             return toolbarShowEditorUtilityIOS
         case .fontDecrease, .fontIncrease, .markdownPreview, .markdownProjectPreview, .markdownPreviewExport, .markdownPreviewStyle, .codeMinimap, .indentationGuides, .lineWrap, .translucentWindow:
             return toolbarShowAppearanceIOS
+        case .settings:
+            return toolbarShowSettingsIOS
+        case .help:
+            return toolbarShowHelpIOS
         default:
             return true
         }
@@ -1071,6 +1111,21 @@ extension ContentView {
     }
 
     @ViewBuilder
+    private var languagePickerGlyph: some View {
+        let language = currentLanguagePickerBinding.wrappedValue
+        switch ToolbarLanguageGlyph.resolve(
+            language: language,
+            displayName: languageLabel(for: language)
+        ) {
+        case .systemImage(let name):
+            Image(systemName: name)
+        case .initial(let initial):
+            Text(initial)
+                .font(.system(size: 16, weight: .bold, design: .rounded))
+        }
+    }
+
+    @ViewBuilder
     private var languagePickerControl: some View {
         Menu {
             let selectedLanguage = currentLanguagePickerBinding.wrappedValue
@@ -1092,10 +1147,7 @@ extension ContentView {
                 }
             }
         } label: {
-            Text(toolbarLanguageLabel(for: currentLanguagePickerBinding.wrappedValue))
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .fixedSize(horizontal: true, vertical: false)
+            languagePickerGlyph
 #if os(visionOS)
                 .foregroundStyle(Color.white.opacity(0.96))
                 .padding(.horizontal, 12)
@@ -1107,19 +1159,12 @@ extension ContentView {
                 )
                 .frame(width: 74)
 #elseif os(iOS)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 5)
-                .background(.ultraThinMaterial, in: Capsule())
-                .overlay(
-                    Capsule()
-                        .stroke(iOSToolbarTintColor.opacity(0.35), lineWidth: 1)
-                )
-                .frame(minWidth: isIPadToolbarLayout ? 120 : iPhoneLanguagePickerWidth)
+                .frame(width: 24, height: 24)
 #endif
         }
         .labelsHidden()
 #if os(iOS)
-        .frame(minWidth: isIPadToolbarLayout ? 132 : iPhoneLanguagePickerWidth)
+        .frame(minWidth: 44, minHeight: 44)
 #endif
         .help("Language")
         .accessibilityLabel("Language picker")

--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -4764,8 +4764,11 @@ struct ContentView: View {
                 }
 #endif
 
-                    if shouldShowMarkdownFormattingControls
-                        && (!shouldOverlayMarkdownFormattingControls || shouldPlaceMarkdownFormattingBelowTabs) {
+                    if MarkdownFormattingChromePolicy.shouldRenderInEditorStack(
+                        shouldShow: shouldShowMarkdownFormattingControls,
+                        overlaysEditor: shouldOverlayMarkdownFormattingControls,
+                        reservesChromeRow: shouldPlaceMarkdownFormattingBelowTabs
+                    ) {
                         HStack(spacing: 0) {
                             Spacer(minLength: 0)
                             markdownFormattingControlBar

--- a/Neon Vision Editor/UI/EditorTextView+iOS.swift
+++ b/Neon Vision Editor/UI/EditorTextView+iOS.swift
@@ -92,6 +92,12 @@ enum EditorLineStartIndex {
     }
 }
 
+enum EditorEditMenuPolicy {
+    static func shouldUseDefaultMenu(for range: NSRange) -> Bool {
+        range.length == 0
+    }
+}
+
 enum EditorLargeTextFormatting {
     static func updateRange(visibleRange: NSRange, textLength: Int, padding: Int = 8_000) -> NSRange {
         guard textLength > 0 else { return NSRange(location: 0, length: 0) }
@@ -3346,7 +3352,7 @@ struct CustomTextEditor: UIViewRepresentable {
             editMenuForTextIn range: NSRange,
             suggestedActions: [UIMenuElement]
         ) -> UIMenu? {
-            guard range.length > 0 else { return UIMenu(children: suggestedActions) }
+            guard !EditorEditMenuPolicy.shouldUseDefaultMenu(for: range) else { return nil }
             let snapshotAction = UIAction(
                 title: "Create Code Snapshot",
                 image: UIImage(systemName: "camera.viewfinder")

--- a/Neon Vision Editor/UI/EditorTextView.swift
+++ b/Neon Vision Editor/UI/EditorTextView.swift
@@ -180,7 +180,14 @@ func continuedMarkdownListPrefix(for linePrefix: String, normalizedIndent: Strin
     guard !trailingContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
     let marker = nsLine.substring(with: match.range(at: 2))
     let spacer = nsLine.substring(with: match.range(at: 3))
-    return normalizedIndent + marker + spacer
+    let continuedMarker: String
+    if let delimiter = marker.last, delimiter == "." || delimiter == ")",
+       let value = Int(marker.dropLast()), value < Int.max {
+        continuedMarker = "\(value + 1)\(delimiter)"
+    } else {
+        continuedMarker = marker
+    }
+    return normalizedIndent + continuedMarker + spacer
 }
 
 func autoIndentReturnContext(

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -1799,7 +1799,12 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
             return
         }
         let indentation = context.linePrefix.prefix { $0 == " " || $0 == "\t" }
-        replaceSelection(with: "\n" + indentation)
+        let normalizedIndent = String(indentation)
+        let listPrefix = continuedMarkdownListPrefix(
+            for: context.linePrefix,
+            normalizedIndent: normalizedIndent
+        )
+        replaceSelection(with: "\n" + (listPrefix ?? normalizedIndent))
     }
 
     private func registerUndo(replacement: String, range: NSRange, inverseReplacement: String) {

--- a/Neon Vision EditorTests/ContentViewLayoutTests.swift
+++ b/Neon Vision EditorTests/ContentViewLayoutTests.swift
@@ -92,4 +92,56 @@ final class ContentViewLayoutTests: XCTestCase {
             )
         )
     }
+
+    func testCollapsedPhoneFormattingChromeOverlaysEditorWithoutReservingARow() {
+        XCTAssertFalse(
+            MarkdownFormattingChromePolicy.shouldReserveMobileFormattingRow(
+                isPhone: true,
+                shouldShow: true,
+                isCollapsed: true
+            )
+        )
+        XCTAssertTrue(
+            MarkdownFormattingChromePolicy.shouldReserveMobileFormattingRow(
+                isPhone: true,
+                shouldShow: true,
+                isCollapsed: false
+            )
+        )
+        XCTAssertFalse(
+            MarkdownFormattingChromePolicy.shouldReserveMobileFormattingRow(
+                isPhone: false,
+                shouldShow: true,
+                isCollapsed: false
+            )
+        )
+        XCTAssertFalse(
+            MarkdownFormattingChromePolicy.shouldRenderInEditorStack(
+                shouldShow: true,
+                overlaysEditor: true,
+                reservesChromeRow: true
+            )
+        )
+    }
+
+    func testCollapsedFormattingControlUsesOpaqueSurfaceWhileExpandedControlMayUseGlass() {
+        XCTAssertFalse(
+            MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
+                isCollapsed: true,
+                liquidGlassEnabled: true
+            )
+        )
+        XCTAssertTrue(
+            MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
+                isCollapsed: false,
+                liquidGlassEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
+                isCollapsed: false,
+                liquidGlassEnabled: false
+            )
+        )
+    }
 }

--- a/Neon Vision EditorTests/EditorViewModelTabTests.swift
+++ b/Neon Vision EditorTests/EditorViewModelTabTests.swift
@@ -4,6 +4,16 @@ import XCTest
 
 @MainActor
 final class EditorViewModelTabTests: XCTestCase {
+    func testManualLanguageSelectionLocksCurrentTab() throws {
+        let viewModel = EditorViewModel()
+        let tab = try XCTUnwrap(viewModel.selectedTab)
+
+        viewModel.updateTabLanguage(tabID: tab.id, language: "python")
+
+        XCTAssertEqual(viewModel.selectedTab?.language, "python")
+        XCTAssertTrue(try XCTUnwrap(viewModel.selectedTab).languageLocked)
+    }
+
     func testDraftSnapshotPreservesLineEndingAndDecodesOlderSnapshots() throws {
         let snapshot = ContentView.SavedDraftTabSnapshot(
             name: "Windows.txt",

--- a/Neon Vision EditorTests/MarkdownListReturnTests.swift
+++ b/Neon Vision EditorTests/MarkdownListReturnTests.swift
@@ -37,6 +37,23 @@ final class MarkdownListReturnTests: XCTestCase {
         XCTAssertEqual(context?.linePrefix, "- ")
     }
 
+    func testOrderedMarkdownListContinuationIncrementsNumber() {
+        XCTAssertEqual(continuedMarkdownListPrefix(for: "1. First", normalizedIndent: ""), "2. ")
+        XCTAssertEqual(continuedMarkdownListPrefix(for: "  9) Ninth", normalizedIndent: "  "), "  10) ")
+    }
+
+    func testUnorderedMarkdownListContinuationPreservesMarker() {
+        XCTAssertEqual(continuedMarkdownListPrefix(for: "- First", normalizedIndent: ""), "- ")
+        XCTAssertEqual(continuedMarkdownListPrefix(for: "  * First", normalizedIndent: "  "), "  * ")
+    }
+
+#if os(iOS) || os(visionOS)
+    func testCollapsedSelectionUsesSystemEditMenu() {
+        XCTAssertTrue(EditorEditMenuPolicy.shouldUseDefaultMenu(for: NSRange(location: 4, length: 0)))
+        XCTAssertFalse(EditorEditMenuPolicy.shouldUseDefaultMenu(for: NSRange(location: 4, length: 3)))
+    }
+#endif
+
     func testMoveCurrentLineUpPreservesCaretColumn() throws {
         let source = "first\nsecond\nthird"
         let result = try XCTUnwrap(

--- a/Neon Vision EditorTests/ToolbarActionSelectionTests.swift
+++ b/Neon Vision EditorTests/ToolbarActionSelectionTests.swift
@@ -19,6 +19,39 @@ final class ToolbarActionSelectionTests: XCTestCase {
         XCTAssertEqual(ToolbarActionSelection.visibleLimit(requestedCount: 7, fallback: TestAction.allCases.count), 7)
     }
 
+    func testLanguageGlyphUsesRecognizableSymbolsForCommonFormats() {
+        XCTAssertEqual(
+            ToolbarLanguageGlyph.resolve(language: "swift", displayName: "Swift"),
+            .systemImage("swift")
+        )
+        XCTAssertEqual(
+            ToolbarLanguageGlyph.resolve(language: "markdown", displayName: "Markdown"),
+            .initial("M")
+        )
+        XCTAssertEqual(
+            ToolbarLanguageGlyph.resolve(language: "json", displayName: "JSON"),
+            .systemImage("curlybraces")
+        )
+    }
+
+    func testLanguageGlyphFallsBackToUppercaseDisplayNameInitial() {
+        XCTAssertEqual(
+            ToolbarLanguageGlyph.resolve(language: "python", displayName: "Python"),
+            .initial("P")
+        )
+        XCTAssertEqual(
+            ToolbarLanguageGlyph.resolve(language: " objective-c ", displayName: "Objective-C"),
+            .initial("O")
+        )
+    }
+
+    func testLanguageGlyphUsesFileSymbolForMissingDisplayName() {
+        XCTAssertEqual(
+            ToolbarLanguageGlyph.resolve(language: "unknown", displayName: "  "),
+            .systemImage("doc")
+        )
+    }
+
     func testCustomVisibleActionsRespectSelectedCountAndToolbarOrder() {
         let visible = ToolbarActionSelection.visibleActions(
             enabledActions: TestAction.allCases,
@@ -160,6 +193,30 @@ final class ToolbarActionSelectionTests: XCTestCase {
         XCTAssertFalse(ToolbarActionSelection.honorsSectionVisibility(preset: .standard))
         XCTAssertFalse(ToolbarActionSelection.honorsSectionVisibility(preset: .all))
         XCTAssertTrue(ToolbarActionSelection.honorsSectionVisibility(preset: .custom))
+    }
+
+    func testSettingsAndHelpAlwaysHonorTheirVisibilitySettings() {
+        XCTAssertFalse(
+            ToolbarActionSelection.shouldIncludeConfiguredAction(
+                actionID: "settings",
+                isConfiguredVisible: false,
+                preset: .standard
+            )
+        )
+        XCTAssertFalse(
+            ToolbarActionSelection.shouldIncludeConfiguredAction(
+                actionID: "help",
+                isConfiguredVisible: false,
+                preset: .all
+            )
+        )
+        XCTAssertTrue(
+            ToolbarActionSelection.shouldIncludeConfiguredAction(
+                actionID: "openFile",
+                isConfiguredVisible: false,
+                preset: .standard
+            )
+        )
     }
 
     func testPresetFilteringControlsPrimaryAndOverflowActions() {

--- a/scripts/prepare_release_docs.py
+++ b/scripts/prepare_release_docs.py
@@ -577,6 +577,7 @@ def rebuild_changelog_page(page: str, changelog: str, current_tag: str) -> str:
 
 LOCALIZED_TIMELINE_COPY = {
     "de": {
+        "v1.5.6": ("Kompaktere, verlässlichere Editorwerkzeuge", "Macht mobile Symbolleisten übersichtlicher, setzt Markdown-Nummerierungen korrekt fort und schützt die eingeklappte Formatierungspille vor durchscheinendem Text.", ["Symbolleiste", "Markdown", "Auswahl"]),
         "v1.5.5": ("Präzise Bearbeitung mit Apple Pencil", "Zeigt auf dem iPad beim Schweben die Caret-Position, ermöglicht die direkte Bereichsauswahl mit dem Pencil und korrigiert die macOS-Editorzeichnung.", ["Editor", "Apple Pencil", "iPad"]),
         "v1.5.4": ("Alle Editorzeilen bleiben erreichbar", "Stellt sicher, dass umbrochene Zeilen nach Änderungen an Seitenleiste oder Vorschau bis zum Dokumentende erreichbar bleiben.", ["Editor", "Zeilenumbruch", "macOS"]),
         "v1.5.3": ("Große Dokumente reagieren schneller", "Beschleunigt Bearbeitung und Scrollen, reduziert unnötige Aktualisierungen und ergänzt einen ablenkungsfreien Fokusmodus.", ["Editor", "Leistung", "Fokusmodus"]),
@@ -593,6 +594,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor und Snapshots werden verlässlicher", "Verbessert Auswahl, Tastaturnavigation und Themes im macOS-Editor und erweitert den Code-Snapshot-Export.", ["Editor", "Themes", "Snapshots"]),
     },
     "da": {
+        "v1.5.6": ("Mere kompakte og pålidelige editorværktøjer", "Gør mobile værktøjslinjer tydeligere, fortsætter Markdown-nummerering korrekt og beskytter den sammenklappede formateringsknap mod gennemskinnende tekst.", ["Værktøjslinje", "Markdown", "Markering"]),
         "v1.5.5": ("Præcis redigering med Apple Pencil", "Viser markørens placering ved svævning på iPad, vælger tekstområder direkte med Pencil og retter tegningen i macOS-editoren.", ["Editor", "Apple Pencil", "iPad"]),
         "v1.5.4": ("Alle editorlinjer forbliver tilgængelige", "Sikrer, at ombrudte linjer kan nås helt til dokumentets slutning efter ændringer i sidepanel eller forhåndsvisning.", ["Editor", "Linjeombrydning", "macOS"]),
         "v1.5.3": ("Store dokumenter reagerer hurtigere", "Gør redigering og rulning hurtigere, reducerer unødvendige opdateringer og tilføjer en fokustilstand uden forstyrrelser.", ["Editor", "Ydeevne", "Fokustilstand"]),
@@ -609,6 +611,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor og snapshots bliver mere pålidelige", "Forbedrer markering, tastaturnavigation og temaer i macOS-editoren og udvider eksporten af kodesnapshots.", ["Editor", "Temaer", "Snapshots"]),
     },
     "fr": {
+        "v1.5.6": ("Des outils d’édition plus compacts et fiables", "Clarifie les barres d’outils mobiles, poursuit correctement la numérotation Markdown et empêche le texte de traverser la pastille de formatage repliée.", ["Barre d’outils", "Markdown", "Sélection"]),
         "v1.5.5": ("Édition précise avec Apple Pencil", "Affiche la position du curseur au survol sur iPad, sélectionne directement des plages avec le Pencil et corrige le rendu de l’éditeur macOS.", ["Éditeur", "Apple Pencil", "iPad"]),
         "v1.5.4": ("Toutes les lignes restent accessibles", "Garantit l’accès aux lignes renvoyées à la ligne jusqu’à la fin du document après un changement de barre latérale ou d’aperçu.", ["Éditeur", "Retour à la ligne", "macOS"]),
         "v1.5.3": ("Les grands documents répondent plus vite", "Accélère l’édition et le défilement, réduit les actualisations inutiles et ajoute un mode concentration sans distraction.", ["Éditeur", "Performances", "Concentration"]),
@@ -625,6 +628,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Éditeur et instantanés plus fiables", "Améliore la sélection, la navigation au clavier et les thèmes dans l’éditeur macOS, tout en enrichissant l’export d’instantanés de code.", ["Éditeur", "Thèmes", "Instantanés"]),
     },
     "es": {
+        "v1.5.6": ("Herramientas de edición más compactas y fiables", "Aclara las barras móviles, continúa correctamente la numeración Markdown e impide que el texto atraviese la píldora de formato contraída.", ["Barra", "Markdown", "Selección"]),
         "v1.5.5": ("Edición precisa con Apple Pencil", "Muestra la posición del cursor al pasar el Pencil en iPad, permite seleccionar rangos directamente y corrige el dibujo del editor de macOS.", ["Editor", "Apple Pencil", "iPad"]),
         "v1.5.4": ("Todas las líneas siguen accesibles", "Garantiza el acceso a las líneas ajustadas hasta el final del documento tras cambiar la barra lateral o la vista previa.", ["Editor", "Ajuste de línea", "macOS"]),
         "v1.5.3": ("Los documentos grandes responden más rápido", "Acelera la edición y el desplazamiento, reduce actualizaciones innecesarias y añade un modo de concentración sin distracciones.", ["Editor", "Rendimiento", "Concentración"]),
@@ -641,6 +645,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor y capturas más fiables", "Mejora la selección, la navegación por teclado y los temas del editor de macOS, y amplía la exportación de capturas de código.", ["Editor", "Temas", "Capturas"]),
     },
     "ja": {
+        "v1.5.6": ("よりコンパクトで確実な編集ツール", "モバイルのツールバーを整理し、Markdown の番号付きリストを正しく継続し、折りたたんだ書式ピルへの文字の透過を防ぎます。", ["ツールバー", "Markdown", "選択"]),
         "v1.5.5": ("Apple Pencil で正確に編集", "iPad でホバー時にキャレット位置を表示し、Pencil で範囲を直接選択できるようにして、macOS エディタの描画も修正します。", ["エディタ", "Apple Pencil", "iPad"]),
         "v1.5.4": ("すべての行に最後までアクセス", "サイドバーやプレビューの変更後も、折り返された行を文書の末尾まで確実に表示できるようにします。", ["エディタ", "行の折り返し", "macOS"]),
         "v1.5.3": ("大きな書類をさらに高速に操作", "編集とスクロールを高速化し、不要な更新を減らして、集中できるフォーカスモードを追加します。", ["エディタ", "パフォーマンス", "フォーカス"]),
@@ -657,6 +662,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("エディタとスナップショットをさらに信頼性向上", "macOS エディタの選択、キーボード操作、テーマを改善し、コードスナップショットの書き出しを拡充します。", ["エディタ", "テーマ", "スナップショット"]),
     },
     "zh-Hans": {
+        "v1.5.6": ("更紧凑、更可靠的编辑工具", "简化移动工具栏，正确续排 Markdown 编号列表，并防止编辑器文字透过折叠的格式工具胶囊。", ["工具栏", "Markdown", "选择"]),
         "v1.5.5": ("使用 Apple Pencil 精确编辑", "在 iPad 悬停时预览插入点，使用 Pencil 直接选择文本范围，并修复 macOS 编辑器绘制问题。", ["编辑器", "Apple Pencil", "iPad"]),
         "v1.5.4": ("所有编辑器行均可访问", "在切换侧边栏或预览后，确保自动换行内容一直可以滚动到文档末尾。", ["编辑器", "自动换行", "macOS"]),
         "v1.5.3": ("大型文档响应更快", "加快编辑和滚动，减少不必要的刷新，并加入无干扰的专注模式。", ["编辑器", "性能", "专注模式"]),


### PR DESCRIPTION
## Summary
- compact and language-aware iPhone/iPad toolbar actions
- correct Markdown ordered-list continuation and restore native selection menus
- make the mobile Markdown formatting row scrollable with an opaque collapsed pill
- add focused cross-platform regression coverage and v1.5.6 release notes

## Verification
- focused mobile/layout tests: 9/9 passed
- toolbar tests: 20/20 passed
- macOS, iPhone Simulator, and iPad Simulator platform matrix passed
- runtime iPhone/iPad visual QA passed
- v1.5.6 release-notes preflight passed

## Summary by Sourcery

Polish editor toolbars and Markdown editing behavior across mobile and macOS platforms for the v1.5.6 release.

New Features:
- Add compact, language-aware mobile toolbar controls with recognizable language glyphs.
- Make mobile Markdown formatting controls horizontally scrollable with a compact opaque collapsed state.
- Preserve explicit document-language selections as tab-level overrides.

Bug Fixes:
- Correct ordered Markdown list continuation on iOS and macOS by incrementing numeric markers.
- Restore native selection menus for caret-only text interactions while retaining snapshot actions for selected text.
- Respect Settings and Help visibility preferences across toolbar presets.
- Prevent editor content from showing through the collapsed Markdown formatting control.

Enhancements:
- Refine Markdown formatting chrome placement across iPhone, iPad, and other platforms.

Documentation:
- Add v1.5.6 changelog and localized release-note timeline entries.

Tests:
- Add regression coverage for mobile formatting layout, language glyphs, language locking, Markdown list continuation, selection menus, and toolbar visibility.