### PR TITLE
chore: synchronize develop with main after v1.5.6

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,11 +1,20 @@
 # Neon Vision Editor Architecture
 
-Last updated: 2026-08-29 (v1.5.5 release-aligned architecture)
+Last updated: 2026-08-29 (v1.5.6 release-aligned architecture)
 
 Neon Vision Editor is a native Swift 6 editor for macOS, iOS, iPadOS, and visionOS. The app favors a small editor-first surface: fast file access, lightweight project navigation, native text editing, syntax highlighting, structured document inspection, Markdown/HTML/SVG/PDF/PNG preview, project-level Markdown/PDF cards, Finder Quick Look previews, PDF highlights and attached Markdown notes, Git and terminal helpers on macOS, remote-session clients on supported Apple platforms, and optional contextual AI assistance.
 
 <!-- RELEASE_ARCHITECTURE_ALIGNMENT:START -->
 ## Current Release Alignment
+
+### v1.5.6 (2026-08-29)
+
+- Uses icon-only mobile toolbar presets and language-specific symbols or initials for the current document language.
+- Adds a horizontally scrollable mobile Markdown formatting row while keeping the collapsed control in a compact opaque pill over a transparent surrounding area.
+- Treats explicit language choices as tab-level overrides so automatic detection does not immediately replace the user's selection.
+- Makes Settings and Help toolbar visibility follow their configured switches in standard, all-actions, and custom presets.
+- Increments ordered Markdown markers such as `1.` to `2.` and `9)` to `10)` when continuing lists, including in the macOS virtual editor.
+- Restores the system edit menu for caret-only interactions so Select and Select All remain available while preserving snapshot actions for selected ranges.
 
 ### v1.5.5 (2026-08-29)
 
@@ -15,13 +24,6 @@ Neon Vision Editor is a native Swift 6 editor for macOS, iOS, iPadOS, and vision
 - Stops line-number, wrapped-row, and marked-text drawing from contaminating subsequent Core Text matrix and position state.
 - Removes the stale macOS regression expectation for the retired `0.96` Markdown preview scale.
 - Prevents false external-refresh and terminal-session failures during heavily parallelized test runs.
-
-### v1.5.4 (2026-08-27)
-
-- Measures a bounded, distributed sample of wrapped rows when calculating the virtual canvas scroll extent.
-- Uses exact row accounting for fully loaded documents and immediate expansion when wrapping increases.
-- Prevents the macOS editor from stopping before the document's final lines when the project sidebar or preview narrows the source pane.
-- Recalculates cached row geometry after sidebar width transitions without reintroducing unbounded layout work.
 
 This block is regenerated from `CHANGELOG.md` after each stable release. The sections below remain the authoritative description of ownership and runtime boundaries.
 <!-- RELEASE_ARCHITECTURE_ALIGNMENT:END -->

--- a/Neon Vision Editor.xcodeproj/project.pbxproj
+++ b/Neon Vision Editor.xcodeproj/project.pbxproj
@@ -752,7 +752,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor App Clip/Neon Vision Editor App Clip.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_PREVIEWS = YES;
@@ -763,7 +763,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -791,7 +791,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_PREVIEWS = YES;
@@ -802,7 +802,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -902,7 +902,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -956,7 +956,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1136,7 +1136,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]" = "Neon Vision Editor/Neon Vision Editor iOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Neon Vision Editor/Neon Vision Editor macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1189,7 +1189,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1302,7 +1302,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1354,7 +1354,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1391,7 +1391,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1405,7 +1405,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				REGISTER_APP_GROUPS = YES;
@@ -1431,7 +1431,7 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Share Extension/Neon Vision Editor Share Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1456,7 +1456,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1486,7 +1486,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = CS727NF72U;
@@ -1512,7 +1512,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1565,7 +1565,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1574,7 +1574,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1595,7 +1595,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1604,7 +1604,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1625,7 +1625,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1633,7 +1633,7 @@
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "h3p.Neon-Vision-Editor";
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1653,7 +1653,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1661,7 +1661,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1681,7 +1681,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1689,7 +1689,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1709,7 +1709,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1717,7 +1717,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1738,13 +1738,13 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				SDKROOT = macosx;
@@ -1763,14 +1763,14 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				SDKROOT = macosx;
@@ -1790,14 +1790,14 @@
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1014;
+				CURRENT_PROJECT_VERSION = 1015;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.5.5;
+				MARKETING_VERSION = 1.5.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -2720,15 +2720,15 @@ struct WelcomeTourView: View {
 
     private let pages: [TourPage] = [
         TourPage(
-            title: "What’s New in v1.5.5",
-            subtitle: "Release highlights for v1.5.5.",
+            title: "What’s New in v1.5.6",
+            subtitle: "Release highlights for v1.5.6.",
             bullets: [
-                "Editor Improvements: Prevents AppKit and Core Text drawing from leaking text state between macOS virtual-editor rows and producing mirrored or…",
-                "Workflow Refinements: Makes Apple Pencil a precision iPad editing input with hover caret preview and direct range selection.",
-                "Performance Updates: Keeps Markdown live-preview text at the exact resolved editor font size on every supported platform.",
-                "Editor Performance: Makes the release regression suite more reliable while parallel performance, filesystem, and PTY tests compete for resources.",
-                "Editor Improvements: Draws every virtual-editor line through an isolated Core Text boundary that derives coordinates from the canvas and…",
-                "Workflow Refinements: Uses Pencil-only hover and drag recognizers for caret preview and range selection, with side tap or squeeze undo that…"
+                "Accessible Controls: Makes the iPhone and iPad editor toolbar more compact and language-aware without hiding full menu names or accessibility…",
+                "Workflow Refinements: Restores predictable Markdown list continuation and native text-selection commands across mobile and macOS editors.",
+                "Performance Updates: Keeps collapsed and expanded Markdown formatting controls readable without wasting editor space or covering actions.",
+                "Usability Updates: Uses icon-only mobile toolbar presets and language-specific symbols or initials for the current document language.",
+                "Editor Improvements: Adds a horizontally scrollable mobile Markdown formatting row while keeping the collapsed control in a compact opaque pill…",
+                "Workflow Refinements: Treats explicit language choices as tab-level overrides so automatic detection does not immediately replace the user's…"
             ],
             iconName: "sparkles.rectangle.stack",
             colors: [Color(red: 0.40, green: 0.28, blue: 0.90), Color(red: 0.96, green: 0.46, blue: 0.55)],

--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ The direct GitHub release is currently ahead of the iOS/iPadOS App Store version
 |---|---|---|---|---|---|
 | **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.5.6** | Current direct download |
 | **Store** | iOS / iPadOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.5.4** | Current public App Store listing |
-| **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.5.5** | In Apple review |
+| **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.5.6** | In Apple review |
 | **Store** | visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.5.0** | Current recorded visionOS listing |
-| **Beta** | iOS / iPadOS / macOS | Testing upcoming changes before stable | [TestFlight Invite](https://testflight.apple.com/join/YWB2fGAP) | **v1.5.5** | Early access builds for feedback; availability may vary by review state |
+| **Beta** | iOS / iPadOS / macOS | Testing upcoming changes before stable | [TestFlight Invite](https://testflight.apple.com/join/YWB2fGAP) | **v1.5.6** | Early access builds for feedback; availability may vary by review state |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9370&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9388&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9340&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9370&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><a href="https://apps-h3p.com"><img alt="Docs on h3p apps" src="https://img.shields.io/badge/Docs-h3p%20apps-111827?style=for-the-badge"></a><a href="https://buymeacoffee.com/h3pdesign"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a-Coffee-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=111827"></a><a href="https://www.patreon.com/h3p"><img alt="Support on Patreon" src="https://img.shields.io/badge/Support%20on-Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white"></a><a href="https://www.paypal.com/paypalme/HilthartPedersen"><img alt="Support via PayPal" src="https://img.shields.io/badge/Support%20via-PayPal-0070BA?style=for-the-badge&logo=paypal&logoColor=white"></a></p>
 
 <p align="center">
-  <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases"><img alt="Latest Release" src="https://img.shields.io/badge/release-v1.5.5-0A84FF"></a>
+  <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases"><img alt="Latest Release" src="https://img.shields.io/badge/release-v1.5.6-0A84FF"></a>
   <a href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965"><img alt="Platforms" src="https://img.shields.io/badge/platforms-macOS%20%7C%20iOS%20%7C%20iPadOS%20%7C%20visionOS-0A84FF"></a>
   <a href="https://github.com/h3pdesign/Neon-Vision-Editor/actions/workflows/release-github-only.yml"><img alt="Primary Release" src="https://img.shields.io/github/actions/workflow/status/h3pdesign/Neon-Vision-Editor/release-github-only.yml?branch=main&label=Primary%20Release"></a>
   <a href="https://github.com/h3pdesign/Neon-Vision-Editor/blob/main/SECURITY.md"><img alt="Security Policy" src="https://img.shields.io/badge/security-policy-22C55E"></a>
@@ -52,16 +52,28 @@
 </p>
 
 > Status: **active release**  
-> Latest release: **v1.5.5**
-> Next release target: **v1.5.6**
+> Latest release: **v1.5.6**
+> Next release target: **v1.5.7**
 > Platform target: **macOS 26 (Tahoe)** compatible with **macOS Sequoia**
 > Apple Silicon: tested / Intel: not tested
-> Direct GitHub release: **v1.5.5** / App Store and TestFlight availability varies by platform and review status
-> Last updated (README): **2026-08-29** for latest release **v1.5.5**
+> Direct GitHub release: **v1.5.6** / App Store and TestFlight availability varies by platform and review status
+> Last updated (README): **2026-08-29** for latest release **v1.5.6**
 
-## What's New in v1.5.4 and v1.5.5
+## What's New in v1.5.5 and v1.5.6
 
 ### Why Upgrade
+
+- v1.5.6: Makes the iPhone and iPad editor toolbar more compact and language-aware without hiding full menu names or accessibility context.
+- v1.5.6: Restores predictable Markdown list continuation and native text-selection commands across mobile and macOS editors.
+- v1.5.6: Keeps collapsed and expanded Markdown formatting controls readable without wasting editor space or covering actions.
+
+### v1.5.6 Highlights
+
+- Uses icon-only mobile toolbar presets and language-specific symbols or initials for the current document language.
+- Adds a horizontally scrollable mobile Markdown formatting row while keeping the collapsed control in a compact opaque pill over a transparent surrounding area.
+- Treats explicit language choices as tab-level overrides so automatic detection does not immediately replace the user's selection.
+
+### v1.5.5 Context
 
 - v1.5.5: Prevents AppKit and Core Text drawing from leaking text state between macOS virtual-editor rows and producing mirrored or upside-down glyphs.
 - v1.5.5: Makes Apple Pencil a precision iPad editing input with hover caret preview and direct range selection.
@@ -72,17 +84,6 @@
 - Draws every virtual-editor line through an isolated Core Text boundary that derives coordinates from the canvas and restores inherited text state.
 - Uses Pencil-only hover and drag recognizers for caret preview and range selection, with side tap or squeeze undo that respects system shortcut preferences.
 - Strengthens cross-platform preview-size coverage and asynchronous release-test deadlines.
-
-### v1.5.4 Context
-
-- v1.5.4: Restores access to every wrapped source row in the macOS editor after project-sidebar or preview width changes.
-- v1.5.4: Keeps the final document lines reachable at both narrow and wide editor widths.
-- v1.5.4: Preserves responsive virtual-editor layout without performing unbounded full-document measurement.
-
-### v1.5.4 Highlights
-
-- Measures a bounded, distributed sample of wrapped rows when calculating the virtual canvas scroll extent.
-- Uses exact row accounting for fully loaded documents and immediate expansion when wrapping increases.
 
 ## Start Here
 
@@ -141,7 +142,7 @@
         <td><img alt="Stable" src="https://img.shields.io/badge/Stable-22C55E?style=flat-square"></td>
         <td>Direct notarized builds and fastest stable updates</td>
         <td><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases">GitHub Releases</a></td>
-        <td>v1.5.5 release docs current; v1.5.5 direct download current</td>
+        <td>v1.5.6 release docs current; v1.5.6 direct download current</td>
       </tr>
       <tr>
         <td><img alt="Store" src="https://img.shields.io/badge/Store-0A84FF?style=flat-square"></td>
@@ -220,7 +221,7 @@ The direct GitHub release is currently ahead of the iOS/iPadOS App Store version
 
 | Channel | Platform | Best For | Download | Release Track | Notes |
 |---|---|---|---|---|---|
-| **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.5.5** | Current direct download |
+| **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.5.6** | Current direct download |
 | **Store** | iOS / iPadOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.5.4** | Current public App Store listing |
 | **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.5.5** | In Apple review |
 | **Store** | visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.5.0** | Current recorded visionOS listing |
@@ -359,7 +360,7 @@ Platform-specific availability is tracked in the [Platform Matrix](#platform-mat
 - **Languages and structured documents:** Swift 6-ready highlighting includes TeX/LaTeX and Typst/CeTZ-aware editing; CSV/TSV, property lists, Apple crash reports, and recognized logs can switch between structured and raw-text views, and plain text can be transformed into validated JSON through an explicit AI-assisted action.
 - **Project and preview workflows:** project-level Markdown/PDF cards reuse the project index for bounded excerpts and thumbnails, while Markdown, HTML, SVG, PDF, and PNG previews remain integrated with the editor.
 - **macOS integration:** the embedded Quick Look extension previews supported Markdown and source files in Finder, and detached Markdown previews can use the same glass treatment without changing editor content.
-- **Latest stable additions (v1.5.5):** Draws every virtual-editor line through an isolated Core Text boundary that derives coordinates from the canvas and restores inherited text state; Uses Pencil-only hover and drag recognizers for caret preview and range selection, with side tap or squeeze undo that respects system shortcut preferences; Strengthens cross-platform preview-size coverage and asynchronous release-test deadlines.
+- **Latest stable additions (v1.5.6):** Uses icon-only mobile toolbar presets and language-specific symbols or initials for the current document language; Adds a horizontally scrollable mobile Markdown formatting row while keeping the collapsed control in a compact opaque pill over a transparent surrounding area; Treats explicit language choices as tab-level overrides so automatic detection does not immediately replace the user's selection.
 <!-- FEATURE_COVERAGE:END -->
 
 ### Editing Core
@@ -661,7 +662,7 @@ More release integrity details: [Release Integrity](#release-integrity)
 
 | Track | Current Focus | Status |
 |---|---|---|
-| Stable direct download | `v1.5.5` notarized GitHub release | Current |
+| Stable direct download | `v1.5.6` notarized GitHub release | Current |
 | App Store rollout | Platform releases are published independently after App Review | Check the relevant App Store listing |
 | Post-1.4 stabilization | Crash triage, docs freshness, platform polish, App Store/Xcode Cloud release checks | Next patch train |
 | Larger workflow work | Remote workflow hardening, minimap polish, project navigation refinements | Later `v1.5+` work |
@@ -669,19 +670,19 @@ More release integrity details: [Release Integrity](#release-integrity)
 ## Roadmap (Near Term)
 
 <p align="center">
-  <img alt="Now" src="https://img.shields.io/badge/NOW-v1.5.5-22C55E?style=for-the-badge">
-  <img alt="Next" src="https://img.shields.io/badge/NEXT-v1.5.6-F59E0B?style=for-the-badge">
+  <img alt="Now" src="https://img.shields.io/badge/NOW-v1.5.6-22C55E?style=for-the-badge">
+  <img alt="Next" src="https://img.shields.io/badge/NEXT-v1.5.7-F59E0B?style=for-the-badge">
   <img alt="Later" src="https://img.shields.io/badge/LATER-v1.5%2B-0A84FF?style=for-the-badge">
 </p>
 
-### Now (v1.5.5)
+### Now (v1.5.6)
 
 - ![v1.4.0](https://img.shields.io/badge/v1.4.0-22C55E?style=flat-square) delivers file-backed large-document editing, bounded live viewport virtualization, reliable ordinary-file installation, and the release workflow hardening shipped alongside the release.
-  Tracking: [Release v1.5.5](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5)
+  Tracking: [Release v1.5.6](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6)
 
-### Next (v1.5.6)
+### Next (v1.5.7)
 
-- ![v1.5.6](https://img.shields.io/badge/v1.5.6-F59E0B?style=flat-square) targets post-1.5.5 stabilization: App Store review follow-up, README/release metadata freshness, preview polish, and small cross-platform editor fixes.
+- ![v1.5.7](https://img.shields.io/badge/v1.5.7-F59E0B?style=flat-square) targets post-1.5.6 stabilization: App Store review follow-up, README/release metadata freshness, preview polish, and small cross-platform editor fixes.
   Tracking: [Milestones](https://github.com/h3pdesign/Neon-Vision-Editor/milestones)
 
 ### Later (v1.5+)
@@ -771,7 +772,7 @@ Vim navigation is also available on iPad with a hardware keyboard after enabling
 
 ## Changelog
 
-Latest stable: **v1.5.5** (2026-08-29)
+Latest stable: **v1.5.6** (2026-08-29)
 
 ### Editor Evolution
 
@@ -779,8 +780,6 @@ Latest stable: **v1.5.5** (2026-08-29)
 ```mermaid
 timeline
     title Neon Vision Editor — recent release story
-    21 August 2026 : v1.5.1 · A more deliberate workflow
-                : Makes Markdown preview themes more vivid, differentiated, and reliable in both light and dark mode.
     22 August 2026 : v1.5.2 · A more deliberate workflow
                 : Keeps Markdown preview body text at the same effective base size as the editor while font zoom changes.
     26 August 2026 : v1.5.3 · Release highlights
@@ -789,6 +788,8 @@ timeline
                 : Restores access to every wrapped source row in the macOS editor after project-sidebar or preview width changes.
     29 August 2026 : v1.5.5 · Safer document transitions
                 : Prevents AppKit and Core Text drawing from leaking text state between macOS virtual-editor rows and producing mirrored or upside-down glyphs.
+    29 August 2026 : v1.5.6 · A more deliberate workflow
+                : Makes the iPhone and iPad editor toolbar more compact and language-aware without hiding full menu names or accessibility context.
 ```
 <!-- RELEASE_TIMELINE:END -->
 
@@ -798,13 +799,13 @@ The recent release arc is about continuity: files that change outside the app, w
 
 | Release | The editor change | What it protects or enables |
 |---|---|---|
+| [`v1.5.6`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6) | **A more deliberate workflow** — Makes the iPhone and iPad editor toolbar more compact and language-aware without hiding full menu names or accessibility context. | Makes Settings and Help toolbar visibility follow their configured switches in standard, all-actions, and custom presets. |
 | [`v1.5.5`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5) | **Safer document transitions** — Prevents AppKit and Core Text drawing from leaking text state between macOS virtual-editor rows and producing mirrored or upside-down glyphs. | Stops line-number, wrapped-row, and marked-text drawing from contaminating subsequent Core Text matrix and position state. |
 | [`v1.5.4`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.4) | **Release highlights** — Restores access to every wrapped source row in the macOS editor after project-sidebar or preview width changes. | Prevents the macOS editor from stopping before the document's final lines when the project sidebar or preview narrows the source pane. |
-| [`v1.5.3`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.3) | **Release highlights** — Makes large-file editing and scrolling more responsive across macOS, iOS, and iPadOS. | Prevents the editor canvas from taking focus merely because it moved into a window. |
 
 - Full release history: [`CHANGELOG.md`](CHANGELOG.md)
-- Latest release: **v1.5.5**
-- Compare recent changes: [v1.5.4...v1.5.5](https://github.com/h3pdesign/Neon-Vision-Editor/compare/v1.5.4...v1.5.5)
+- Latest release: **v1.5.6**
+- Compare recent changes: [v1.5.5...v1.5.6](https://github.com/h3pdesign/Neon-Vision-Editor/compare/v1.5.5...v1.5.6)
 
 ## Known Limitations
 
@@ -826,12 +827,12 @@ The recent release arc is about continuity: files that change outside the app, w
 
 ## Release Integrity
 
-- Tag: `v1.5.5`
+- Tag: `v1.5.6`
 - Tagged commit: release tag target
 - Verify local tag target:
 
 ```bash
-git rev-parse --verify v1.5.5
+git rev-parse --verify v1.5.6
 ```
 
 - Verify downloaded artifact checksum locally:

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,12 +3,12 @@
     <channel>
         <title>Neon Vision Editor</title>
         <item>
-            <title>1.5.5</title>
-            <pubDate>Sat, 29 Aug 2026 08:55:17 +0000</pubDate>
-            <sparkle:version>1014</sparkle:version>
-            <sparkle:shortVersionString>1.5.5</sparkle:shortVersionString>
+            <title>1.5.6</title>
+            <pubDate>Sat, 29 Aug 2026 20:44:28 +0000</pubDate>
+            <sparkle:version>1015</sparkle:version>
+            <sparkle:shortVersionString>1.5.6</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.6</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.zip" length="12175018" type="application/octet-stream" sparkle:edSignature="xfZ1gCx5mWE/v8lY7xmo1adPm0rwJPk/mrSuGo84dLeLAuxH7iB05Uxpb7UZoTyeJUaUI75NTtJ/NujGhBOyCQ=="/>
+            <enclosure url="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.zip" length="12228634" type="application/octet-stream" sparkle:edSignature="EHFsD3v1ENZhLl/xptg9KqTqfi66NGklr56PKvNqOQQVchMjdr+FnAQyP/lWr5HcIWp5NLKXASrMq02NEGU6Aw=="/>
         </item>
     </channel>
 </rss>

--- a/docs/images/release-download-trend-dark.svg
+++ b/docs/images/release-download-trend-dark.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-08-29</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 20 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 49 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">300</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">400</text>
 
-  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 236.5 L 1070.0 310.0 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 236.0 L 1070.0 295.5 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,236.5 1070.0,310.0"
+    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,236.0 1070.0,295.5"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="230.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="667.1" cy="254.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="162.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="236.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="310.0" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="236.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="295.5" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.4</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.6</text>

--- a/docs/images/release-download-trend-dark.svg
+++ b/docs/images/release-download-trend-dark.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-08-29</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 49 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 76 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">300</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">400</text>
 
-  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 236.0 L 1070.0 295.5 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 235.5 L 1070.0 282.0 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,236.0 1070.0,295.5"
+    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,235.5 1070.0,282.0"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="230.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="667.1" cy="254.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="162.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="236.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="295.5" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="235.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="282.0" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.4</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.6</text>

--- a/docs/images/release-download-trend-light.svg
+++ b/docs/images/release-download-trend-light.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-08-29</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="884" y="70" fill="#475569" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 20 downloads</text>
+  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 49 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#94A3B8" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#CBD5E1" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">300</text>
   <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">400</text>
 
-  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 236.5 L 1070.0 310.0 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 236.0 L 1070.0 295.5 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,236.5 1070.0,310.0"
+    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,236.0 1070.0,295.5"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="230.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="667.1" cy="254.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="801.4" cy="162.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="935.7" cy="236.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="1070.0" cy="310.0" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="935.7" cy="236.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="1070.0" cy="295.5" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.4</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.6</text>

--- a/docs/images/release-download-trend-light.svg
+++ b/docs/images/release-download-trend-light.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-08-29</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="884" y="70" fill="#475569" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 49 downloads</text>
+  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 76 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#94A3B8" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#CBD5E1" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">300</text>
   <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">400</text>
 
-  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 236.0 L 1070.0 295.5 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 235.5 L 1070.0 282.0 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,236.0 1070.0,295.5"
+    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,235.5 1070.0,282.0"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="230.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="667.1" cy="254.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="801.4" cy="162.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="935.7" cy="236.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="1070.0" cy="295.5" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="935.7" cy="235.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="1070.0" cy="282.0" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.4</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.6</text>

--- a/docs/images/release-download-trend.svg
+++ b/docs/images/release-download-trend.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-08-29</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 20 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 49 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">300</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">400</text>
 
-  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 236.5 L 1070.0 310.0 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 236.0 L 1070.0 295.5 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,236.5 1070.0,310.0"
+    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,236.0 1070.0,295.5"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="230.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="667.1" cy="254.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="162.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="236.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="310.0" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="236.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="295.5" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.4</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.6</text>

--- a/docs/images/release-download-trend.svg
+++ b/docs/images/release-download-trend.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-08-29</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 49 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.5.5 · 76 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">300</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">400</text>
 
-  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 236.0 L 1070.0 295.5 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 264.5 L 264.3 275.0 L 398.6 139.0 L 532.9 230.0 L 667.1 254.0 L 801.4 162.0 L 935.7 235.5 L 1070.0 282.0 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,236.0 1070.0,295.5"
+    points="130.0,264.5 264.3,275.0 398.6,139.0 532.9,230.0 667.1,254.0 801.4,162.0 935.7,235.5 1070.0,282.0"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="230.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="667.1" cy="254.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="162.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="236.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="295.5" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="235.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="282.0" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.4</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.6</text>

--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -3,12 +3,12 @@
     <channel>
         <title>Neon Vision Editor</title>
         <item>
-            <title>1.5.5</title>
-            <pubDate>Sat, 29 Aug 2026 08:55:17 +0000</pubDate>
-            <sparkle:version>1014</sparkle:version>
-            <sparkle:shortVersionString>1.5.5</sparkle:shortVersionString>
+            <title>1.5.6</title>
+            <pubDate>Sat, 29 Aug 2026 20:44:28 +0000</pubDate>
+            <sparkle:version>1015</sparkle:version>
+            <sparkle:shortVersionString>1.5.6</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.6</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.zip" length="12175018" type="application/octet-stream" sparkle:edSignature="xfZ1gCx5mWE/v8lY7xmo1adPm0rwJPk/mrSuGo84dLeLAuxH7iB05Uxpb7UZoTyeJUaUI75NTtJ/NujGhBOyCQ=="/>
+            <enclosure url="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.zip" length="12228634" type="application/octet-stream" sparkle:edSignature="EHFsD3v1ENZhLl/xptg9KqTqfi66NGklr56PKvNqOQQVchMjdr+FnAQyP/lWr5HcIWp5NLKXASrMq02NEGU6Aw=="/>
         </item>
     </channel>
 </rss>

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -118,7 +118,20 @@
     <section class="timeline" aria-label="Neon Vision Editor changelog">
     <!-- CHANGELOG_ENTRIES:START -->
       <article class="release current">
-        <div class="release-header"><h2>v1.5.5</h2><span class="date">29 August 2026</span><span class="latest">Latest</span></div>
+        <div class="release-header"><h2>v1.5.6</h2><span class="date">29 August 2026</span><span class="latest">Latest</span></div>
+        <div class="items">
+          <div class="item"><span class="badge new">New</span><p>Uses icon-only mobile toolbar presets and language-specific symbols or initials for the current document language.</p></div>
+          <div class="item"><span class="badge new">New</span><p>Adds a horizontally scrollable mobile Markdown formatting row while keeping the collapsed control in a compact opaque pill over a transparent surrounding area.</p></div>
+          <div class="item"><span class="badge new">New</span><p>Treats explicit language choices as tab-level overrides so automatic detection does not immediately replace the user&#x27;s selection.</p></div>
+          <div class="item"><span class="badge fixed">Fixed</span><p>Makes Settings and Help toolbar visibility follow their configured switches in standard, all-actions, and custom presets.</p></div>
+          <div class="item"><span class="badge fixed">Fixed</span><p>Increments ordered Markdown markers such as `1.` to `2.` and `9)` to `10)` when continuing lists, including in the macOS virtual editor.</p></div>
+          <div class="item"><span class="badge fixed">Fixed</span><p>Restores the system edit menu for caret-only interactions so Select and Select All remain available while preserving snapshot actions for selected ranges.</p></div>
+          <div class="item"><span class="badge fixed">Fixed</span><p>Prevents editor characters from bleeding through the collapsed Markdown formatting pill and keeps the expanded action row reachable by horizontal scrolling.</p></div>
+          <div class="item"><span class="badge breaking">Breaking</span><p>None.</p></div>
+        </div>
+      </article>
+      <article class="release">
+        <div class="release-header"><h2>v1.5.5</h2><span class="date">29 August 2026</span></div>
         <div class="items">
           <div class="item"><span class="badge new">New</span><p>Draws every virtual-editor line through an isolated Core Text boundary that derives coordinates from the canvas and restores inherited text state.</p></div>
           <div class="item"><span class="badge new">New</span><p>Uses Pencil-only hover and drag recognizers for caret preview and range selection, with side tap or squeeze undo that respects system shortcut preferences.</p></div>

--- a/site/da/index.html
+++ b/site/da/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="da" data-static-release-version="v1.5.5">
+<html lang="da" data-static-release-version="v1.5.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.5.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
+      "softwareVersion": "1.5.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1372,9 +1372,9 @@
         <h1 id="page-title">En sikrere arbejdsgang til tekst, Markdown og kode.</h1>
         <p class="lede">Til Markdown-forfattere og udviklere bevarer Neon Vision Editor fordelene ved en let editor: hurtige filer, tydelig kildekode, komplette forhåndsvisninger og delte dokumenter uden overraskelser.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">Hent til Mac <span class="sr-only">version </span><span data-latest-version>v1.5.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">Hent til Mac <span class="sr-only">version </span><span data-latest-version>v1.5.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Se i App Store</a>
-          <a class="hero-release-link" href="#release-timeline">Nyt i <span data-latest-version>v1.5.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">Nyt i <span data-latest-version>v1.5.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1427,15 +1427,15 @@
           <h3>Notariseret Mac-download</h3>
           <p>Det nyeste stabile direkte build, signeret og notariseret af Apple, med valgfri kommandolinjehjælper.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
-            <span>Build <strong data-latest-build>1014</strong></span>
+            <span data-latest-version>v1.5.6</span>
+            <span>Build <strong data-latest-build>1015</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">
             Hent DMG
           </a>
         </article>
@@ -1445,7 +1445,7 @@
           <h3>Homebrew</h3>
           <p>Installér samme stabile, notariserede macOS-release via det officielle Homebrew-cask.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
+            <span data-latest-version>v1.5.6</span>
             <span>macOS 15+</span>
             <span>Officielt cask</span>
           </div>
@@ -1484,14 +1484,14 @@
             <span>Udgivet gennem den verificerede macOS-releaseproces.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
-          <strong><span data-latest-version>v1.5.5</span> · Build <span data-latest-build>1014</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
+          <strong><span data-latest-version>v1.5.6</span> · Build <span data-latest-build>1015</span></strong>
           <span>Seneste stabile release</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/SHA256SUMS.txt">
           <strong>SHA-256-kontrolsummer</strong>
           <span>Bekræft både ZIP og DMG</span>
         </a>
@@ -1538,7 +1538,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Nyt i v1.4.0</p><h2 id="large-document-editor-title">Store dokumenter forbliver responsive uden at indlæse alt på én gang.</h2><p>Neons macOS-editor arbejder nu direkte med filen på disken og holder et afgrænset virtuelt udsnit omkring den del, du redigerer. Det undgår at genopbygge en komplet dokumentbuffer ved hver ændring og bevarer den normale redigeringsarbejdsgang.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.5.5</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 på macOS med linjenumre, faner og kompakte værktøjslinjer"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Nyt i v1.4.0</p><h2 id="large-document-editor-title">Store dokumenter forbliver responsive uden at indlæse alt på én gang.</h2><p>Neons macOS-editor arbejder nu direkte med filen på disken og holder et afgrænset virtuelt udsnit omkring den del, du redigerer. Det undgår at genopbygge en komplet dokumentbuffer ved hver ændring og bevarer den normale redigeringsarbejdsgang.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.5.6</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 på macOS med linjenumre, faner og kompakte værktøjslinjer"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Filbaseret editorarkitektur</p><h2>Redigér, scroll, vælg og gem uden at genopbygge hele dokumentet.</h2><p>Det virtuelle udsnit følger scrollpositionen og bevarer markør og markering, når det erstatter det aktive vindue. Syntaksarbejde og linjelayout begrænses til det synlige område.</p><p>Kodning, linjeskift, håndtering af eksterne ændringer og atomiske gemninger forbliver i samme filarbejdsgang. Filer på 100 MB eller mere åbnes som en tydeligt mærket skrivebeskyttet delvis forhåndsvisning.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funktioner til store dokumenter"><div class="markdown-feature-point"><strong>Afgrænset udsnit</strong><span>Kun det aktive redigeringsvindue forbliver aktivt i store filer.</span></div><div class="markdown-feature-point"><strong>Synligt arbejde først</strong><span>Linjelayout og syntaksfarvning fokuserer på indholdet på skærmen.</span></div><div class="markdown-feature-point"><strong>Sikker filarbejdsgang</strong><span>Markeringer, kodning, linjeskift, eksterne ændringer og atomiske gemninger bevares.</span></div><div class="markdown-feature-point"><strong>Delvis visning</strong><span>Filer på 100 MB eller mere kan undersøges uden en overdimensioneret editorbuffer.</span></div></div>
     </section>
@@ -1683,7 +1683,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Ny i v1.2.1</p><h2 id="release-1-2-1-title">En klarere værktøjslinje til enhver Apple-enhed.</h2><p>Version 1.2.1 tilføjer platformoptimerede værktøjslinjeforudindstillinger med kompakte symboler og ensartede kontroller på macOS, iPadOS og iOS. Vælg standard-, fokus-, udvikler-, review- eller komplette arbejdsgange fra Indstillinger, mens iOS bevarer sin gennemsigtige statuslinje.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.5.5</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Åbn skærmbilledet af værktøjslinjen i v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Værktøjslinjeforudindstillinger i Neon Vision Editor"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Ny i v1.2.1</p><h2 id="release-1-2-1-title">En klarere værktøjslinje til enhver Apple-enhed.</h2><p>Version 1.2.1 tilføjer platformoptimerede værktøjslinjeforudindstillinger med kompakte symboler og ensartede kontroller på macOS, iPadOS og iOS. Vælg standard-, fokus-, udvikler-, review- eller komplette arbejdsgange fra Indstillinger, mens iOS bevarer sin gennemsigtige statuslinje.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.5.6</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Åbn skærmbilledet af værktøjslinjen i v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Værktøjslinjeforudindstillinger i Neon Vision Editor"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Værktøjslinjeforudindstillinger og layoutstabilitet</p><h2>Vælg de værktøjer, du skal bruge, uden at miste dokumentet.</h2><p>Kompakte etiketter holder macOS- og iPadOS-værktøjslinjer læselige, mens iPhone bruger ikoner først, hvor pladsen er begrænset. Forudindstillinger gør det nemt at skifte mellem daglig redigering, fokuseret skrivning, udvikling, gennemgang og det komplette arbejdsområde.</p><p>Udgivelsen gendanner også den gennemsigtige iOS-statuslinje og navigationsflade uden at ændre det eksisterende editor- eller preview-layout.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funktioner i version 1.2.1"><div class="markdown-feature-point"><strong>Platformstilpassede værktøjslinjer</strong><span>Kompakte, ensartede kontroller til macOS, iPadOS og iOS.</span></div><div class="markdown-feature-point"><strong>Fem forudindstillinger</strong><span>Standard, fokuseret, udvikler, gennemgang og komplet.</span></div><div class="markdown-feature-point"><strong>Tydeligere tilpasning</strong><span>Konfigurer handlinger i værktøjslinje og projektpanel fra Indstillinger.</span></div><div class="markdown-feature-point"><strong>Stabile iOS-flader</strong><span>Bevar den gennemsigtige statuslinje og det eksisterende layout.</span></div></div>
     </section>
@@ -1693,7 +1693,7 @@
         <p class="eyebrow">Nyt i v1.2.0</p>
         <h2 id="release-1-2-title">PDF'er og projektfiler i den samme gennemgangsworkflow.</h2>
         <p>Version 1.2.0 udvider Neon ud over kildefiler og Markdown. PDF'er og PNG'er kan nu indgå i en responsiv projektoversigt, mens PDF-markeringer og tilknyttede Markdown-noter holder research knyttet til det dokument, du læser.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.5.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.5.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1749,17 +1749,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.5.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.1">v1.5.1 — Mere levende Markdown-temaer</a></h3>
-              <span class="release-date">21 August 2026</span>
-            </div>
-            <p>Forfiner forhåndsvisningens farvepaletter, forbedrer åbning af projektmapper og stabiliserer Sparkle-opdateringer.</p>
-            <div class="release-tags"><span>Markdown</span><span>Temaer</span><span>Opdateringer</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1792,7 +1781,7 @@
             <div class="release-tags"><span>Editor</span><span>Linjeombrydning</span><span>macOS</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1801,6 +1790,17 @@
             </div>
             <p>Viser markørens placering ved svævning på iPad, vælger tekstområder direkte med Pencil og retter tegningen i macOS-editoren.</p>
             <div class="release-tags"><span>Editor</span><span>Apple Pencil</span><span>iPad</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.5.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">v1.5.6 — Mere kompakte og pålidelige editorværktøjer</a></h3>
+              <span class="release-date">29 August 2026</span>
+            </div>
+            <p>Gør mobile værktøjslinjer tydeligere, fortsætter Markdown-nummerering korrekt og beskytter den sammenklappede formateringsknap mod gennemskinnende tekst.</p>
+            <div class="release-tags"><span>Værktøjslinje</span><span>Markdown</span><span>Markering</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1936,7 +1936,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
           <strong>Release notes</strong>
           <span>Hvad er ændret i den seneste stabile version →</span>
         </a>
@@ -2010,7 +2010,7 @@
       <h2 id="closing-title">En let editor, der respekterer dit igangværende arbejde.</h2>
       <p>Hent den seneste direkte macOS-version, følg udviklingen på GitHub, eller prøv App Store- og TestFlight-versionerne på Apple-enheder.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">Seneste release</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">Seneste release</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/de/index.html
+++ b/site/de/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="de" data-static-release-version="v1.5.5">
+<html lang="de" data-static-release-version="v1.5.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -34,9 +34,9 @@
       "applicationCategory": "DeveloperApplication",
       "description": "Ein nativer Apple-Editor für Klartext, Markdown, HTML, SVG und Quellcode mit Live-Vorschauen, KI-Unterstützung und sicherer Dateisynchronisierung.",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.5.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
+      "softwareVersion": "1.5.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1373,9 +1373,9 @@
         <h1 id="page-title">Ein sicherer Workflow für Text, Markdown und Code.</h1>
         <p class="lede">Neon Vision Editor ist ein fokussierter Apple-Editor für Schreiben und Entwicklung: Markdown, Quellcode und Vorschauen bleiben in einem übersichtlichen Arbeitsbereich, während externe Dateiänderungen Ihre ungespeicherte Arbeit nicht überschreiben.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">Für Mac laden <span class="sr-only">Version </span><span data-latest-version>v1.5.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">Für Mac laden <span class="sr-only">Version </span><span data-latest-version>v1.5.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Im App Store ansehen</a>
-          <a class="hero-release-link" href="#release-timeline">Neu in <span data-latest-version>v1.5.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">Neu in <span data-latest-version>v1.5.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1428,15 +1428,15 @@
           <h3>Notarisierter Mac-Herunterladen</h3>
           <p>Der neueste stabile Direkt-Build, von Apple signiert und notarisiert, mit optionalem Kommandozeilenhelfer.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
-            <span>Build <strong data-latest-build>1014</strong></span>
+            <span data-latest-version>v1.5.6</span>
+            <span>Build <strong data-latest-build>1015</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">
             DMG laden
           </a>
         </article>
@@ -1446,7 +1446,7 @@
           <h3>Homebrew</h3>
           <p>Installieren Sie denselben stabilen, notarisierten macOS-Build über das offizielle Homebrew-Cask.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
+            <span data-latest-version>v1.5.6</span>
             <span>macOS 15+</span>
             <span>Offizielles Cask</span>
           </div>
@@ -1485,14 +1485,14 @@
             <span>Über den geprüften macOS-Release-Weg veröffentlicht.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
-          <strong><span data-latest-version>v1.5.5</span> · Build <span data-latest-build>1014</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
+          <strong><span data-latest-version>v1.5.6</span> · Build <span data-latest-build>1015</span></strong>
           <span>Neuester stabiler Release</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/SHA256SUMS.txt">
           <strong>SHA-256-Prüfsummen</strong>
           <span>ZIP und DMG prüfen</span>
         </a>
@@ -1539,7 +1539,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Neu in v1.4.0</p><h2 id="large-document-editor-title">Große Dokumente bleiben reaktionsschnell, ohne alles auf einmal zu laden.</h2><p>Der macOS-Editor von Neon arbeitet direkt mit der Datei auf dem Datenträger und hält einen begrenzten virtuellen Bereich um die gerade bearbeitete Stelle aktiv. So wird nicht bei jeder Änderung ein vollständiger Dokumentpuffer neu aufgebaut, während der normale Bearbeitungsablauf erhalten bleibt.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.5 herunterladen</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 auf macOS mit Zeilennummern, Tabs und kompakten Symbolleisten"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Neu in v1.4.0</p><h2 id="large-document-editor-title">Große Dokumente bleiben reaktionsschnell, ohne alles auf einmal zu laden.</h2><p>Der macOS-Editor von Neon arbeitet direkt mit der Datei auf dem Datenträger und hält einen begrenzten virtuellen Bereich um die gerade bearbeitete Stelle aktiv. So wird nicht bei jeder Änderung ein vollständiger Dokumentpuffer neu aufgebaut, während der normale Bearbeitungsablauf erhalten bleibt.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.6 herunterladen</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 auf macOS mit Zeilennummern, Tabs und kompakten Symbolleisten"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Dateibasierte Editorarchitektur</p><h2>Bearbeiten, scrollen, auswählen und sichern — ohne das ganze Dokument neu aufzubauen.</h2><p>Der virtuelle Bereich folgt der Scrollposition und bewahrt Cursor und Auswahl, wenn er das aktive Fenster ersetzt. Syntaxarbeit und Zeilenlayout bleiben auf den sichtbaren Bereich begrenzt.</p><p>Kodierung, Zeilenenden, externe Änderungen und atomisches Sichern bleiben Teil desselben Dateiablaufs. Dateien ab 100 MB öffnen als klar gekennzeichnete schreibgeschützte Teilvorschau zur sicheren Prüfung.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funktionen für große Dokumente"><div class="markdown-feature-point"><strong>Begrenzter Bereich</strong><span>Nur das aktive Bearbeitungsfenster bleibt beim Navigieren durch große Dateien aktiv.</span></div><div class="markdown-feature-point"><strong>Sichtbares zuerst</strong><span>Zeilenlayout und Syntaxfärbung konzentrieren sich auf den sichtbaren Inhalt.</span></div><div class="markdown-feature-point"><strong>Sicherer Dateiablauf</strong><span>Auswahl, Kodierung, Zeilenenden, externe Änderungen und atomisches Sichern bleiben erhalten.</span></div><div class="markdown-feature-point"><strong>Schutz bei Teilansicht</strong><span>Dateien ab 100 MB bleiben prüfbar, ohne einen übergroßen Editorpuffer zu riskieren.</span></div></div>
     </section>
@@ -1684,7 +1684,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Neu in v1.2.1</p><h2 id="release-1-2-1-title">Eine klarere Symbolleiste für jedes Apple-Gerät.</h2><p>Version 1.2.1 bringt plattformoptimierte Symbolleisten-Voreinstellungen mit kompakten Symbolen und einheitlichen Steuerelementen für macOS, iPadOS und iOS. In den Einstellungen können Sie Standard-, Fokus-, Entwickler-, Review- oder vollständige Workflows konfigurieren; iOS behält dabei seine transparente Statusleiste.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.5 herunterladen</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="v1.4.1-Symbolleisten-Screenshot öffnen"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Symbolleisten-Voreinstellungen in Neon Vision Editor"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Neu in v1.2.1</p><h2 id="release-1-2-1-title">Eine klarere Symbolleiste für jedes Apple-Gerät.</h2><p>Version 1.2.1 bringt plattformoptimierte Symbolleisten-Voreinstellungen mit kompakten Symbolen und einheitlichen Steuerelementen für macOS, iPadOS und iOS. In den Einstellungen können Sie Standard-, Fokus-, Entwickler-, Review- oder vollständige Workflows konfigurieren; iOS behält dabei seine transparente Statusleiste.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.6 herunterladen</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="v1.4.1-Symbolleisten-Screenshot öffnen"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Symbolleisten-Voreinstellungen in Neon Vision Editor"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Symbolleisten-Voreinstellungen und Layoutstabilität</p><h2>Die benötigten Werkzeuge wählen, ohne das Dokument zu verlieren.</h2><p>Kompakte Beschriftungen halten Symbolleisten auf macOS und iPadOS lesbar; auf dem iPhone bleiben sie platzsparend symbolorientiert. Voreinstellungen erleichtern den Wechsel zwischen täglicher Bearbeitung, fokussiertem Schreiben, Entwicklung, Review und dem vollständigen Arbeitsbereich.</p><p>Außerdem stellt das Release die transparente iOS-Statusleiste und Navigationsfläche wieder her, ohne das bestehende Editor- oder Vorschau-Layout zu ändern.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funktionen von Version 1.2.1"><div class="markdown-feature-point"><strong>Plattformoptimierte Symbolleisten</strong><span>Kompakte, einheitliche Steuerelemente für macOS, iPadOS und iOS.</span></div><div class="markdown-feature-point"><strong>Fünf Arbeitsbereichs-Voreinstellungen</strong><span>Standard, Fokus, Entwickler, Review und vollständig.</span></div><div class="markdown-feature-point"><strong>Klarere Anpassung</strong><span>Symbolleisten- und Projektleistenaktionen in den Einstellungen konfigurieren.</span></div><div class="markdown-feature-point"><strong>Stabile iOS-Flächen</strong><span>Transparente Statusleiste und bestehendes Layout beibehalten.</span></div></div>
     </section>
@@ -1694,7 +1694,7 @@
         <p class="eyebrow">Neu in v1.2.0</p>
         <h2 id="release-1-2-title">PDFs und Projektdateien in denselben Review-Workflow integrieren.</h2>
         <p>Version 1.2.0 erweitert Neon über Quelltext und Markdown hinaus. PDFs und PNGs werden Teil einer responsiven Projektübersicht, während PDF-Markierungen und verknüpfte Markdown-Notizen den Kontext beim Lesen erhalten.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.5 herunterladen</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.6 herunterladen</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1754,17 +1754,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.5.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.1">v1.5.1 — Lebendigere Markdown-Themes</a></h3>
-              <span class="release-date">21 August 2026</span>
-            </div>
-            <p>Verfeinert die Farbpaletten der Vorschau, verbessert das Öffnen von Projektordnern und stabilisiert Sparkle-Updates.</p>
-            <div class="release-tags"><span>Markdown</span><span>Themes</span><span>Updates</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1797,7 +1786,7 @@
             <div class="release-tags"><span>Editor</span><span>Zeilenumbruch</span><span>macOS</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1806,6 +1795,17 @@
             </div>
             <p>Zeigt auf dem iPad beim Schweben die Caret-Position, ermöglicht die direkte Bereichsauswahl mit dem Pencil und korrigiert die macOS-Editorzeichnung.</p>
             <div class="release-tags"><span>Editor</span><span>Apple Pencil</span><span>iPad</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.5.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">v1.5.6 — Kompaktere, verlässlichere Editorwerkzeuge</a></h3>
+              <span class="release-date">29 August 2026</span>
+            </div>
+            <p>Macht mobile Symbolleisten übersichtlicher, setzt Markdown-Nummerierungen korrekt fort und schützt die eingeklappte Formatierungspille vor durchscheinendem Text.</p>
+            <div class="release-tags"><span>Symbolleiste</span><span>Markdown</span><span>Auswahl</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1941,7 +1941,7 @@
           <strong>Kommandozeilenhelfer</strong>
           <span>Optionalen <code>nve</code> Befehl installieren und verwenden →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
           <strong>Versionshinweise</strong>
           <span>Änderungen im neuesten stabilen Build →</span>
         </a>
@@ -2015,7 +2015,7 @@
       <h2 id="closing-title">Ein leichter Editor, der Ihre laufende Arbeit respektiert.</h2>
       <p>Laden Sie den neuesten direkten macOS-Build, verfolgen Sie die Entwicklung auf GitHub oder testen Sie die App-Store- und TestFlight-Versionen auf Apple-Geräten.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">Neuester Release</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">Neuester Release</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/es/index.html
+++ b/site/es/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es" data-static-release-version="v1.5.5">
+<html lang="es" data-static-release-version="v1.5.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.5.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
+      "softwareVersion": "1.5.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1372,9 +1372,9 @@
         <h1 id="page-title">Un flujo de trabajo más seguro para texto, Markdown y código.</h1>
         <p class="lede">Para escritores de Markdown y desarrolladores, Neon Vision Editor conserva lo mejor de un editor ligero: archivos rápidos, código claro, vistas completas y documentos compartidos sin sorpresas.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">Descargar para Mac <span class="sr-only">versión </span><span data-latest-version>v1.5.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">Descargar para Mac <span class="sr-only">versión </span><span data-latest-version>v1.5.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">View in App Store</a>
-          <a class="hero-release-link" href="#release-timeline">Novedades de <span data-latest-version>v1.5.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">Novedades de <span data-latest-version>v1.5.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1427,15 +1427,15 @@
           <h3>Descarga de Mac notarizada</h3>
           <p>La última versión estable directa, firmada y notarizada por Apple, con el asistente opcional de línea de comandos.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
-            <span>Build <strong data-latest-build>1014</strong></span>
+            <span data-latest-version>v1.5.6</span>
+            <span>Build <strong data-latest-build>1015</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">
             Descargar DMG
           </a>
         </article>
@@ -1445,7 +1445,7 @@
           <h3>Homebrew</h3>
           <p>Instala la misma versión estable y notarizada de macOS mediante el Cask oficial de Homebrew.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
+            <span data-latest-version>v1.5.6</span>
             <span>macOS 15+</span>
             <span>Cask oficial</span>
           </div>
@@ -1484,14 +1484,14 @@
             <span>Publicada mediante el proceso de release de macOS verificado.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
-          <strong><span data-latest-version>v1.5.5</span> · Build <span data-latest-build>1014</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
+          <strong><span data-latest-version>v1.5.6</span> · Build <span data-latest-build>1015</span></strong>
           <span>Última versión estable</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/SHA256SUMS.txt">
           <strong>SHA-256 checksums</strong>
           <span>Verifica ZIP y DMG</span>
         </a>
@@ -1538,7 +1538,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Novedades de v1.4.0</p><h2 id="large-document-editor-title">Los documentos grandes siguen siendo ágiles sin cargarlo todo a la vez.</h2><p>El editor de macOS de Neon trabaja ahora directamente con el archivo en disco y mantiene una ventana virtual limitada alrededor de la parte que estás editando. Así evita reconstruir un búfer completo en cada cambio y conserva el flujo de edición habitual.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.5.5</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 en macOS con números de línea, pestañas y controles compactos"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Novedades de v1.4.0</p><h2 id="large-document-editor-title">Los documentos grandes siguen siendo ágiles sin cargarlo todo a la vez.</h2><p>El editor de macOS de Neon trabaja ahora directamente con el archivo en disco y mantiene una ventana virtual limitada alrededor de la parte que estás editando. Así evita reconstruir un búfer completo en cada cambio y conserva el flujo de edición habitual.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.5.6</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 en macOS con números de línea, pestañas y controles compactos"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Arquitectura de editor basada en archivos</p><h2>Edita, desplázate, selecciona y guarda sin reconstruir todo el documento.</h2><p>La ventana virtual sigue la posición de desplazamiento y conserva el cursor y la selección al sustituir la ventana activa. El trabajo de sintaxis y el diseño de líneas se limitan al rango visible.</p><p>La codificación, los finales de línea, los cambios externos y los guardados atómicos siguen formando parte del mismo flujo de archivo. Los archivos de 100 MB o más se abren como una vista parcial de solo lectura claramente identificada.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funciones para documentos grandes"><div class="markdown-feature-point"><strong>Ventana limitada</strong><span>Solo la ventana de edición activa permanece cargada al recorrer archivos grandes.</span></div><div class="markdown-feature-point"><strong>Primero lo visible</strong><span>El diseño de líneas y el coloreado de sintaxis se concentran en el contenido en pantalla.</span></div><div class="markdown-feature-point"><strong>Flujo de archivo seguro</strong><span>Se conservan selección, codificación, finales de línea, cambios externos y guardados atómicos.</span></div><div class="markdown-feature-point"><strong>Protección de vista parcial</strong><span>Los archivos de 100 MB o más se pueden inspeccionar sin un búfer sobredimensionado.</span></div></div>
     </section>
@@ -1683,7 +1683,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Novedades de v1.2.1</p><h2 id="release-1-2-1-title">Una barra de herramientas más clara para cada dispositivo Apple.</h2><p>La versión 1.2.1 añade ajustes de barra de herramientas optimizados para cada plataforma, con símbolos compactos y controles coherentes en macOS, iPadOS e iOS. Configura los flujos estándar, centrado, desarrollo, revisión o completo desde Ajustes, mientras iOS conserva su barra de estado transparente.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.5.5</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Abrir la captura de ajustes de barra de herramientas v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Ajustes de barra de herramientas en Neon Vision Editor"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Novedades de v1.2.1</p><h2 id="release-1-2-1-title">Una barra de herramientas más clara para cada dispositivo Apple.</h2><p>La versión 1.2.1 añade ajustes de barra de herramientas optimizados para cada plataforma, con símbolos compactos y controles coherentes en macOS, iPadOS e iOS. Configura los flujos estándar, centrado, desarrollo, revisión o completo desde Ajustes, mientras iOS conserva su barra de estado transparente.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.5.6</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Abrir la captura de ajustes de barra de herramientas v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Ajustes de barra de herramientas en Neon Vision Editor"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Ajustes de barra de herramientas y estabilidad del diseño</p><h2>Elige las herramientas que necesitas sin perder el documento.</h2><p>Las etiquetas compactas mantienen legibles las barras de macOS y iPadOS, mientras que el iPhone prioriza los iconos cuando el espacio es limitado. Los ajustes facilitan cambiar entre edición diaria, escritura enfocada, desarrollo, revisión y el espacio completo.</p><p>La versión también restaura la composición transparente de la barra de estado y la superficie de navegación de iOS sin cambiar el diseño existente.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funciones de la versión 1.2.1"><div class="markdown-feature-point"><strong>Barras optimizadas por plataforma</strong><span>Controles compactos y coherentes para macOS, iPadOS e iOS.</span></div><div class="markdown-feature-point"><strong>Cinco ajustes preestablecidos</strong><span>Estándar, enfocado, desarrollador, revisión y completo.</span></div><div class="markdown-feature-point"><strong>Personalización más clara</strong><span>Configura acciones de la barra y del proyecto desde Ajustes.</span></div><div class="markdown-feature-point"><strong>Superficies estables en iOS</strong><span>Conserva la barra de estado transparente y el diseño existente.</span></div></div>
     </section>
@@ -1693,7 +1693,7 @@
         <p class="eyebrow">Novedades de v1.2.0</p>
         <h2 id="release-1-2-title">Integra PDF y archivos de proyecto en el mismo flujo de revisión.</h2>
         <p>La versión 1.2.0 amplía Neon más allá de los archivos de código y Markdown. Los PDF y PNG pueden formar parte de una vista de proyecto adaptable, mientras que los resaltados PDF y las notas Markdown vinculadas conservan el contexto del documento.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.5.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.5.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1749,17 +1749,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.5.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.1">v1.5.1 — Temas Markdown más vivos</a></h3>
-              <span class="release-date">21 August 2026</span>
-            </div>
-            <p>Perfecciona las paletas de color de la vista previa, mejora la apertura de carpetas de proyecto y estabiliza las actualizaciones de Sparkle.</p>
-            <div class="release-tags"><span>Markdown</span><span>Temas</span><span>Actualizaciones</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1792,7 +1781,7 @@
             <div class="release-tags"><span>Editor</span><span>Ajuste de línea</span><span>macOS</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1801,6 +1790,17 @@
             </div>
             <p>Muestra la posición del cursor al pasar el Pencil en iPad, permite seleccionar rangos directamente y corrige el dibujo del editor de macOS.</p>
             <div class="release-tags"><span>Editor</span><span>Apple Pencil</span><span>iPad</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.5.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">v1.5.6 — Herramientas de edición más compactas y fiables</a></h3>
+              <span class="release-date">29 August 2026</span>
+            </div>
+            <p>Aclara las barras móviles, continúa correctamente la numeración Markdown e impide que el texto atraviese la píldora de formato contraída.</p>
+            <div class="release-tags"><span>Barra</span><span>Markdown</span><span>Selección</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1936,7 +1936,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
           <strong>Release notes</strong>
           <span>Cambios de la última versión estable →</span>
         </a>
@@ -2010,7 +2010,7 @@
       <h2 id="closing-title">Un editor ligero que respeta el trabajo en curso.</h2>
       <p>Get the latest direct macOS build, follow development on GitHub, or try the App Store and TestFlight versións across Apple devices.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">Última versión</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">Última versión</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr" data-static-release-version="v1.5.5">
+<html lang="fr" data-static-release-version="v1.5.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.5.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
+      "softwareVersion": "1.5.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1372,9 +1372,9 @@
         <h1 id="page-title">Un workflow plus sûr pour le texte, Markdown et le code.</h1>
         <p class="lede">Pour les auteurs Markdown et les développeurs, Neon Vision Editor conserve les atouts d’un éditeur léger : fichiers rapides, source claire, aperçus complets et documents partagés sans surprise.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">Télécharger pour Mac <span class="sr-only">version </span><span data-latest-version>v1.5.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">Télécharger pour Mac <span class="sr-only">version </span><span data-latest-version>v1.5.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Voir dans l’App Store</a>
-          <a class="hero-release-link" href="#release-timeline">Nouveautés de <span data-latest-version>v1.5.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">Nouveautés de <span data-latest-version>v1.5.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1427,15 +1427,15 @@
           <h3>Téléchargement Mac notarisé</h3>
           <p>Le dernier build direct stable, signé et notarisé par Apple, avec l’assistant en ligne de commande facultatif.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
-            <span>Build <strong data-latest-build>1014</strong></span>
+            <span data-latest-version>v1.5.6</span>
+            <span>Build <strong data-latest-build>1015</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">
             Télécharger DMG
           </a>
         </article>
@@ -1445,7 +1445,7 @@
           <h3>Homebrew</h3>
           <p>Installez le même build macOS stable et notarisé via le cask Homebrew officiel.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
+            <span data-latest-version>v1.5.6</span>
             <span>macOS 15+</span>
             <span>Cask officiel</span>
           </div>
@@ -1484,14 +1484,14 @@
             <span>Publié via le chemin de release macOS vérifié.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
-          <strong><span data-latest-version>v1.5.5</span> · Build <span data-latest-build>1014</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
+          <strong><span data-latest-version>v1.5.6</span> · Build <span data-latest-build>1015</span></strong>
           <span>Dernière version stable</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/SHA256SUMS.txt">
           <strong>Sommes SHA-256</strong>
           <span>Vérifiez le ZIP et le DMG</span>
         </a>
@@ -1538,7 +1538,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Nouveautés de v1.4.0</p><h2 id="large-document-editor-title">Les documents volumineux restent réactifs sans tout charger d’un coup.</h2><p>L’éditeur macOS de Neon travaille désormais à partir du fichier sur le disque et maintient une fenêtre virtuelle limitée autour de la zone en cours d’édition. Il évite ainsi de reconstruire tout le tampon du document à chaque modification tout en conservant le flux d’édition habituel.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.5.5</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 sur macOS avec numéros de ligne, onglets et commandes compactes"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Nouveautés de v1.4.0</p><h2 id="large-document-editor-title">Les documents volumineux restent réactifs sans tout charger d’un coup.</h2><p>L’éditeur macOS de Neon travaille désormais à partir du fichier sur le disque et maintient une fenêtre virtuelle limitée autour de la zone en cours d’édition. Il évite ainsi de reconstruire tout le tampon du document à chaque modification tout en conservant le flux d’édition habituel.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.5.6</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 sur macOS avec numéros de ligne, onglets et commandes compactes"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Architecture d’éditeur basée sur les fichiers</p><h2>Modifiez, faites défiler, sélectionnez et enregistrez sans reconstruire tout le document.</h2><p>La fenêtre virtuelle suit le défilement et préserve le curseur et la sélection lorsqu’elle remplace la fenêtre active. Le travail de syntaxe et la mise en page des lignes restent limités à la zone visible.</p><p>Encodage, fins de ligne, gestion des modifications externes et enregistrements atomiques restent dans le même flux de fichier. Les fichiers de 100 Mo ou plus s’ouvrent en aperçu partiel clairement signalé, en lecture seule.</p></div></div>
       <div class="markdown-feature-points" aria-label="Fonctionnalités pour documents volumineux"><div class="markdown-feature-point"><strong>Fenêtre limitée</strong><span>Seule la fenêtre d’édition active reste chargée dans les grands fichiers.</span></div><div class="markdown-feature-point"><strong>Priorité au visible</strong><span>La mise en page et la coloration syntaxique se concentrent sur le contenu affiché.</span></div><div class="markdown-feature-point"><strong>Flux de fichier sûr</strong><span>Sélections, encodage, fins de ligne, modifications externes et enregistrements atomiques sont préservés.</span></div><div class="markdown-feature-point"><strong>Protection d’aperçu</strong><span>Les fichiers de 100 Mo ou plus restent inspectables sans tampon surdimensionné.</span></div></div>
     </section>
@@ -1683,7 +1683,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Nouveautés de v1.2.1</p><h2 id="release-1-2-1-title">Une barre d’outils plus claire pour chaque appareil Apple.</h2><p>La version 1.2.1 ajoute des préréglages de barre d’outils optimisés pour chaque plateforme, avec des symboles compacts et des commandes cohérentes sur macOS, iPadOS et iOS. Configurez les flux standard, concentré, développement, révision ou complet depuis Réglages, tandis qu’iOS conserve sa barre d’état transparente.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.5.5</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Ouvrir la capture des préréglages de barre d’outils v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Préréglages de barre d’outils dans Neon Vision Editor"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Nouveautés de v1.2.1</p><h2 id="release-1-2-1-title">Une barre d’outils plus claire pour chaque appareil Apple.</h2><p>La version 1.2.1 ajoute des préréglages de barre d’outils optimisés pour chaque plateforme, avec des symboles compacts et des commandes cohérentes sur macOS, iPadOS et iOS. Configurez les flux standard, concentré, développement, révision ou complet depuis Réglages, tandis qu’iOS conserve sa barre d’état transparente.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.5.6</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Ouvrir la capture des préréglages de barre d’outils v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Préréglages de barre d’outils dans Neon Vision Editor"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Préréglages de barre d’outils et stabilité de la mise en page</p><h2>Choisissez vos outils sans perdre le document.</h2><p>Les libellés compacts gardent les barres d’outils macOS et iPadOS lisibles, tandis que l’iPhone privilégie les icônes lorsque l’espace est limité. Les préréglages facilitent le passage entre édition quotidienne, écriture concentrée, développement, révision et espace complet.</p><p>La version restaure également la composition transparente de la barre d’état et de la surface de navigation iOS sans modifier la mise en page existante.</p></div></div>
       <div class="markdown-feature-points" aria-label="Fonctionnalités de la version 1.2.1"><div class="markdown-feature-point"><strong>Barres d’outils optimisées</strong><span>Des contrôles compacts et cohérents sur macOS, iPadOS et iOS.</span></div><div class="markdown-feature-point"><strong>Cinq préréglages</strong><span>Standard, concentré, développeur, révision et complet.</span></div><div class="markdown-feature-point"><strong>Personnalisation plus claire</strong><span>Configurez les actions de la barre d’outils et du projet depuis les réglages.</span></div><div class="markdown-feature-point"><strong>Surfaces iOS stables</strong><span>Conservez la barre d’état transparente et la mise en page existante.</span></div></div>
     </section>
@@ -1693,7 +1693,7 @@
         <p class="eyebrow">Nouveautés de v1.2.0</p>
         <h2 id="release-1-2-title">Intégrez les PDF et les fichiers de projet au même flux de révision.</h2>
         <p>La version 1.2.0 étend Neon au-delà des fichiers source et du Markdown. Les PDF et les PNG peuvent désormais faire partie d’un aperçu de projet réactif, tandis que les surlignages PDF et les notes Markdown associées conservent le contexte de lecture.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.5.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.5.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1749,17 +1749,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.5.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.1">v1.5.1 — Des thèmes Markdown plus vivants</a></h3>
-              <span class="release-date">21 August 2026</span>
-            </div>
-            <p>Affine les palettes de l’aperçu, améliore l’ouverture des dossiers de projet et stabilise les mises à jour Sparkle.</p>
-            <div class="release-tags"><span>Markdown</span><span>Thèmes</span><span>Mises à jour</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1792,7 +1781,7 @@
             <div class="release-tags"><span>Éditeur</span><span>Retour à la ligne</span><span>macOS</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1801,6 +1790,17 @@
             </div>
             <p>Affiche la position du curseur au survol sur iPad, sélectionne directement des plages avec le Pencil et corrige le rendu de l’éditeur macOS.</p>
             <div class="release-tags"><span>Éditeur</span><span>Apple Pencil</span><span>iPad</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.5.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">v1.5.6 — Des outils d’édition plus compacts et fiables</a></h3>
+              <span class="release-date">29 August 2026</span>
+            </div>
+            <p>Clarifie les barres d’outils mobiles, poursuit correctement la numérotation Markdown et empêche le texte de traverser la pastille de formatage repliée.</p>
+            <div class="release-tags"><span>Barre d’outils</span><span>Markdown</span><span>Sélection</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1936,7 +1936,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
           <strong>Release notes</strong>
           <span>Modifications de la dernière version stable →</span>
         </a>
@@ -2010,7 +2010,7 @@
       <h2 id="closing-title">Un éditeur léger qui respecte votre travail en cours.</h2>
       <p>Téléchargez le dernier build macOS direct, suivez le projet sur GitHub ou essayez les versions App Store et TestFlight sur vos appareils Apple.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">Dernière version</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">Dernière version</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-static-release-version="v1.5.5">
+<html lang="en" data-static-release-version="v1.5.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.5.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
+      "softwareVersion": "1.5.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1417,9 +1417,9 @@
         <h1 id="page-title">A safer workflow for text, Markdown, and code.</h1>
         <p class="lede">For Markdown writers and developers, Neon Vision Editor keeps the useful parts of a lightweight editor: fast files, clear source, full previews, and shared documents that do not surprise you.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">Download for Mac <span class="sr-only">version </span><span data-latest-version>v1.5.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">Download for Mac <span class="sr-only">version </span><span data-latest-version>v1.5.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">View in App Store</a>
-          <a class="hero-release-link" href="#release-timeline">What’s new in <span data-latest-version>v1.5.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">What’s new in <span data-latest-version>v1.5.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1472,15 +1472,15 @@
           <h3>Notarized Mac download</h3>
           <p>The latest stable direct build, signed and notarized by Apple, with the optional command-line helper.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
-            <span>Build <strong data-latest-build>1014</strong></span>
+            <span data-latest-version>v1.5.6</span>
+            <span>Build <strong data-latest-build>1015</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">
             Download DMG
           </a>
         </article>
@@ -1490,7 +1490,7 @@
           <h3>Homebrew</h3>
           <p>Install the same stable, notarized macOS release through the official Homebrew Cask.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
+            <span data-latest-version>v1.5.6</span>
             <span>macOS 15+</span>
             <span>Official cask</span>
           </div>
@@ -1529,14 +1529,14 @@
             <span>Published through the verified macOS release path.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
-          <strong><span data-latest-version>v1.5.5</span> · Build <span data-latest-build>1014</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
+          <strong><span data-latest-version>v1.5.6</span> · Build <span data-latest-build>1015</span></strong>
           <span>Latest stable release</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/SHA256SUMS.txt">
           <strong>SHA-256 checksums</strong>
           <span>Verify both ZIP and DMG</span>
         </a>
@@ -1588,7 +1588,7 @@
           <p class="eyebrow">New in v1.4.0</p>
           <h2 id="large-document-editor-title">Large documents stay responsive without loading everything at once.</h2>
           <p>Neon’s macOS editor now works from the file on disk and keeps a bounded virtual viewport around the part you are editing. That avoids rebuilding a complete document buffer for each edit while preserving the normal editing workflow.</p>
-          <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.5.5</a></p>
+          <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.5.6</a></p>
         </div>
         <figure class="media-card editor-core-shot">
           <img src="docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 macOS editor with line numbers, tabs, and compact toolbar controls">
@@ -1641,7 +1641,7 @@
           <p class="eyebrow">New in v1.2.1</p>
           <h2 id="release-1-2-1-title">A clearer toolbar for every Apple device.</h2>
           <p>Version 1.2.1 adds platform-optimized toolbar presets with compact symbols and consistent controls across macOS, iPadOS, and iOS. Configure standard, focused, developer, review, or complete workflows from Settings, while iOS keeps its transparent status-bar composition.</p>
-          <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.5.5</a></p>
+          <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.5.6</a></p>
         </div>
         <figure class="media-card">
           <a class="screenshot-link" href="docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Open the v1.4.1 toolbar presets screenshot">
@@ -1670,7 +1670,7 @@
         <p class="eyebrow">New in v1.2.0</p>
         <h2 id="release-1-2-title">Bring PDFs and project files into the same review workflow.</h2>
         <p>Version 1.2.0 expands Neon beyond source files and Markdown. PDFs and PNGs can now become part of a responsive project overview, while PDF highlights and attached Markdown notes keep research connected to the document you are reading.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.5.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.5.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1854,17 +1854,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.5.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.1">v1.5.1 — A more deliberate workflow</a></h3>
-              <span class="release-date">21 August 2026</span>
-            </div>
-            <p>Makes Markdown preview themes more vivid, differentiated, and reliable in both light and dark mode.</p>
-            <div class="release-tags"><span>Markdown</span><span>Preview</span><span>Themes</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1897,7 +1886,7 @@
             <div class="release-tags"><span>Preview</span><span>Layout stability</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1906,6 +1895,17 @@
             </div>
             <p>Prevents AppKit and Core Text drawing from leaking text state between macOS virtual-editor rows and producing mirrored or upside-down glyphs.</p>
             <div class="release-tags"><span>Markdown</span><span>Preview</span><span>AppKit stability</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.5.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">v1.5.6 — A more deliberate workflow</a></h3>
+              <span class="release-date">29 August 2026</span>
+            </div>
+            <p>Makes the iPhone and iPad editor toolbar more compact and language-aware without hiding full menu names or accessibility context.</p>
+            <div class="release-tags"><span>Markdown</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -2043,7 +2043,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
           <strong>Release notes</strong>
           <span>What changed in the latest stable build →</span>
         </a>
@@ -2117,7 +2117,7 @@
       <h2 id="closing-title">A lightweight editor that respects the work already in progress.</h2>
       <p>Get the latest direct macOS build, follow development on GitHub, or try the App Store and TestFlight versions across Apple devices.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">Latest release</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">Latest release</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/ja/index.html
+++ b/site/ja/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ja" data-static-release-version="v1.5.5">
+<html lang="ja" data-static-release-version="v1.5.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.5.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
+      "softwareVersion": "1.5.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1372,9 +1372,9 @@
         <h1 id="page-title">テキスト、Markdown、コードのための安全なワークフロー。</h1>
         <p class="lede">Markdownを書く人や開発者のために、Neon Vision Editorは軽量エディタの便利な部分を保ちます。高速なファイル、明快なソース、完全なプレビュー、予期せぬ変更をしない共有ドキュメント。</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">Mac版をダウンロード <span class="sr-only">バージョン </span><span data-latest-version>v1.5.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">Mac版をダウンロード <span class="sr-only">バージョン </span><span data-latest-version>v1.5.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Storeで見る</a>
-          <a class="hero-release-link" href="#release-timeline">新機能 <span data-latest-version>v1.5.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">新機能 <span data-latest-version>v1.5.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1427,15 +1427,15 @@
           <h3>公証済みMacダウンロード</h3>
           <p>Appleが署名・公証した最新の安定版と、任意のコマンドラインヘルパー。</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
-            <span>Build <strong data-latest-build>1014</strong></span>
+            <span data-latest-version>v1.5.6</span>
+            <span>Build <strong data-latest-build>1015</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">
             ダウンロード DMG
           </a>
         </article>
@@ -1445,7 +1445,7 @@
           <h3>Homebrew</h3>
           <p>公式Homebrew Caskから同じ安定した公証済みmacOSリリースをインストールします。</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
+            <span data-latest-version>v1.5.6</span>
             <span>macOS 15+</span>
             <span>公式Cask</span>
           </div>
@@ -1484,14 +1484,14 @@
             <span>確認済みのmacOSリリース経路で公開。</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
-          <strong><span data-latest-version>v1.5.5</span> · Build <span data-latest-build>1014</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
+          <strong><span data-latest-version>v1.5.6</span> · Build <span data-latest-build>1015</span></strong>
           <span>最新の安定版</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/SHA256SUMS.txt">
           <strong>SHA-256 checksums</strong>
           <span>ZIPとDMGを確認</span>
         </a>
@@ -1538,7 +1538,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">v1.4.0 の新機能</p><h2 id="large-document-editor-title">大きな文書も、すべてを一度に読み込まず軽快に操作できます。</h2><p>Neon の macOS エディタはディスク上のファイルを直接扱い、編集中の箇所の周囲だけに限定した仮想ビューポートを維持します。編集のたびに文書全体のバッファを再構築せず、通常の編集ワークフローを保ちます。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.5 をダウンロード</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="行番号、タブ、コンパクトなツールバーを備えた macOS 版 Neon Vision Editor v1.4.1"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">v1.4.0 の新機能</p><h2 id="large-document-editor-title">大きな文書も、すべてを一度に読み込まず軽快に操作できます。</h2><p>Neon の macOS エディタはディスク上のファイルを直接扱い、編集中の箇所の周囲だけに限定した仮想ビューポートを維持します。編集のたびに文書全体のバッファを再構築せず、通常の編集ワークフローを保ちます。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.6 をダウンロード</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="行番号、タブ、コンパクトなツールバーを備えた macOS 版 Neon Vision Editor v1.4.1"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">ファイルベースのエディタアーキテクチャ</p><h2>文書全体を作り直さずに、編集、スクロール、選択、保存。</h2><p>仮想ビューポートはスクロール位置を追い、アクティブなウィンドウを置き換える際にもカーソルと選択を保ちます。構文処理と行レイアウトは表示範囲に限定されます。</p><p>エンコーディング、改行、外部変更の処理、アトミック保存は同じファイルワークフローに残ります。100 MB 以上のファイルは、安全に確認できる明確な読み取り専用の部分プレビューとして開きます。</p></div></div>
       <div class="markdown-feature-points" aria-label="大きな文書の編集機能"><div class="markdown-feature-point"><strong>限定された表示範囲</strong><span>大きなファイルでも、操作中の編集ウィンドウだけを維持します。</span></div><div class="markdown-feature-point"><strong>見えている作業を優先</strong><span>行レイアウトと構文色分けは画面上の内容に集中します。</span></div><div class="markdown-feature-point"><strong>安全なファイル処理</strong><span>選択、エンコーディング、改行、外部変更、アトミック保存を保持します。</span></div><div class="markdown-feature-point"><strong>部分表示の保護</strong><span>100 MB 以上のファイルも過大なバッファを作らずに確認できます。</span></div></div>
     </section>
@@ -1683,7 +1683,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">v1.2.1 の新機能</p><h2 id="release-1-2-1-title">すべての Apple デバイスに、より明快なツールバーを。</h2><p>バージョン 1.2.1 では、macOS、iPadOS、iOS で一貫したコンパクトな操作を提供する、プラットフォームに最適化されたツールバープリセットを追加しました。設定から標準、集中、開発、レビュー、完全なワークフローを選択でき、iOS は透明なステータスバー構成を維持します。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.5 をダウンロード</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="v1.4.1 のツールバープリセット画面を開く"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Neon Vision Editor のツールバープリセット"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">v1.2.1 の新機能</p><h2 id="release-1-2-1-title">すべての Apple デバイスに、より明快なツールバーを。</h2><p>バージョン 1.2.1 では、macOS、iPadOS、iOS で一貫したコンパクトな操作を提供する、プラットフォームに最適化されたツールバープリセットを追加しました。設定から標準、集中、開発、レビュー、完全なワークフローを選択でき、iOS は透明なステータスバー構成を維持します。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.6 をダウンロード</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="v1.4.1 のツールバープリセット画面を開く"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Neon Vision Editor のツールバープリセット"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">ツールバープリセットとレイアウトの安定性</p><h2>必要なツールを選びながら、文書を見失わない。</h2><p>macOS と iPadOS ではコンパクトなラベルでツールバーを読みやすくし、iPhone では限られた空間に合わせてアイコンを優先します。日常の編集、集中した執筆、開発、レビュー、完全なワークスペースを簡単に切り替えられます。</p><p>iOS の透明なステータスバーとナビゲーション面も、既存のエディタやプレビューのレイアウトを変えずに復元しました。</p></div></div>
       <div class="markdown-feature-points" aria-label="v1.2.1 の機能"><div class="markdown-feature-point"><strong>プラットフォーム最適化ツールバー</strong><span>macOS、iPadOS、iOS でコンパクトかつ一貫した操作。</span></div><div class="markdown-feature-point"><strong>5つのワークスペースプリセット</strong><span>標準、集中、開発者、レビュー、完全。</span></div><div class="markdown-feature-point"><strong>分かりやすいカスタマイズ</strong><span>設定からツールバーとプロジェクト操作を構成できます。</span></div><div class="markdown-feature-point"><strong>安定した iOS サーフェス</strong><span>透明なステータスバーと既存のレイアウトを維持します。</span></div></div>
     </section>
@@ -1693,7 +1693,7 @@
         <p class="eyebrow">v1.2.0 の新機能</p>
         <h2 id="release-1-2-title">PDF とプロジェクトファイルを同じレビュー ワークフローに。</h2>
         <p>v1.2.0 では、Neon の対象がソースファイルと Markdown だけでなくなりました。PDF と PNG をレスポンシブなプロジェクト概要に含め、PDF のハイライトと関連付けた Markdown ノートで、読んでいる文書のコンテキストを保てます。</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.5 をダウンロード</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.5.6 をダウンロード</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1749,17 +1749,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.5.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.1">v1.5.1 — Markdown テーマをより鮮やかに</a></h3>
-              <span class="release-date">21 August 2026</span>
-            </div>
-            <p>プレビューのカラーパレットを改善し、プロジェクトフォルダの直接オープンと Sparkle の更新を安定させます。</p>
-            <div class="release-tags"><span>Markdown</span><span>テーマ</span><span>アップデート</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1792,7 +1781,7 @@
             <div class="release-tags"><span>エディタ</span><span>行の折り返し</span><span>macOS</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1801,6 +1790,17 @@
             </div>
             <p>iPad でホバー時にキャレット位置を表示し、Pencil で範囲を直接選択できるようにして、macOS エディタの描画も修正します。</p>
             <div class="release-tags"><span>エディタ</span><span>Apple Pencil</span><span>iPad</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.5.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">v1.5.6 — よりコンパクトで確実な編集ツール</a></h3>
+              <span class="release-date">29 August 2026</span>
+            </div>
+            <p>モバイルのツールバーを整理し、Markdown の番号付きリストを正しく継続し、折りたたんだ書式ピルへの文字の透過を防ぎます。</p>
+            <div class="release-tags"><span>ツールバー</span><span>Markdown</span><span>選択</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1936,7 +1936,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
           <strong>Release notes</strong>
           <span>What changed in the latest stable build →</span>
         </a>
@@ -2010,7 +2010,7 @@
       <h2 id="closing-title">進行中の作業を尊重する軽量エディタ。</h2>
       <p>最新のmacOS直接配布版を入手し、GitHubで開発を追い、Appleデバイス向けApp StoreとTestFlight版を試せます。</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">最新リリース</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">最新リリース</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/zh-Hans/index.html
+++ b/site/zh-Hans/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-Hans" data-static-release-version="v1.5.5">
+<html lang="zh-Hans" data-static-release-version="v1.5.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.5.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5",
+      "softwareVersion": "1.5.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1372,9 +1372,9 @@
         <h1 id="page-title">更安全的文本、Markdown 和代码工作流。</h1>
         <p class="lede">面向 Markdown 作者和开发者，Neon Vision Editor 保留轻量编辑器的实用部分：快速文件、清晰源码、完整预览，以及不会带来意外的共享文档。</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">下载 Mac 版 <span class="sr-only">版本 </span><span data-latest-version>v1.5.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">下载 Mac 版 <span class="sr-only">版本 </span><span data-latest-version>v1.5.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">在 App Store 中查看</a>
-          <a class="hero-release-link" href="#release-timeline">新功能 <span data-latest-version>v1.5.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">新功能 <span data-latest-version>v1.5.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1427,15 +1427,15 @@
           <h3>已公证的 Mac 下载</h3>
           <p>最新稳定的直接版本，由 Apple 签名并公证，包含可选的命令行助手。</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
-            <span>Build <strong data-latest-build>1014</strong></span>
+            <span data-latest-version>v1.5.6</span>
+            <span>Build <strong data-latest-build>1015</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/Neon.Vision.Editor.app.dmg">
             下载 DMG
           </a>
         </article>
@@ -1445,7 +1445,7 @@
           <h3>Homebrew</h3>
           <p>通过官方 Homebrew Cask 安装同一稳定且已公证的 macOS 版本。</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.5.5</span>
+            <span data-latest-version>v1.5.6</span>
             <span>macOS 15+</span>
             <span>官方 Cask</span>
           </div>
@@ -1484,14 +1484,14 @@
             <span>通过经过验证的 macOS 发布流程发布。</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
-          <strong><span data-latest-version>v1.5.5</span> · Build <span data-latest-build>1014</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
+          <strong><span data-latest-version>v1.5.6</span> · Build <span data-latest-build>1015</span></strong>
           <span>最新稳定版</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.5.6/SHA256SUMS.txt">
           <strong>SHA-256 checksums</strong>
           <span>验证 ZIP 和 DMG</span>
         </a>
@@ -1538,7 +1538,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">v1.4.0 新功能</p><h2 id="large-document-editor-title">大型文档无需一次性加载全部内容，也能保持流畅响应。</h2><p>Neon 的 macOS 编辑器现在直接基于磁盘中的文件工作，并在正在编辑的位置周围保留一个有界的虚拟视口。这样无需在每次编辑时重建完整文档缓冲区，同时保留正常的编辑流程。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.5.5</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="带行号、标签页和紧凑工具栏控件的 macOS 版 Neon Vision Editor v1.4.1"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">v1.4.0 新功能</p><h2 id="large-document-editor-title">大型文档无需一次性加载全部内容，也能保持流畅响应。</h2><p>Neon 的 macOS 编辑器现在直接基于磁盘中的文件工作，并在正在编辑的位置周围保留一个有界的虚拟视口。这样无需在每次编辑时重建完整文档缓冲区，同时保留正常的编辑流程。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.5.6</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="带行号、标签页和紧凑工具栏控件的 macOS 版 Neon Vision Editor v1.4.1"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">基于文件的编辑器架构</p><h2>无需重建整篇文档，也能编辑、滚动、选择和保存。</h2><p>虚拟视口会跟随滚动位置，并在替换活动窗口时保留光标和选区。语法处理和行布局仅限于可见范围。</p><p>编码、换行符、外部更改处理和原子保存仍属于同一文件工作流。100 MB 及以上的文件会作为清晰标记的只读部分预览打开，便于安全检查。</p></div></div>
       <div class="markdown-feature-points" aria-label="大型文档编辑功能"><div class="markdown-feature-point"><strong>有界视口</strong><span>浏览大型文件时，只有当前编辑窗口保持活动。</span></div><div class="markdown-feature-point"><strong>优先处理可见内容</strong><span>行布局和语法着色聚焦于屏幕上的内容。</span></div><div class="markdown-feature-point"><strong>安全文件工作流</strong><span>保留选区、编码、换行符、外部更改和原子保存。</span></div><div class="markdown-feature-point"><strong>部分预览保护</strong><span>100 MB 及以上的文件可安全检查，无需超大编辑器缓冲区。</span></div></div>
     </section>
@@ -1683,7 +1683,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">v1.2.1 新功能</p><h2 id="release-1-2-1-title">为每台 Apple 设备提供更清晰的工具栏。</h2><p>1.2.1 版为 macOS、iPadOS 和 iOS 加入了针对平台优化的工具栏预设，提供紧凑的图标和一致的控制项。你可在“设置”中配置标准、专注、开发、审阅或完整工作流，同时 iOS 保留透明状态栏布局。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.5.5</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="打开 v1.4.1 工具栏预设截图"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Neon Vision Editor 中的工具栏预设"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">v1.2.1 新功能</p><h2 id="release-1-2-1-title">为每台 Apple 设备提供更清晰的工具栏。</h2><p>1.2.1 版为 macOS、iPadOS 和 iOS 加入了针对平台优化的工具栏预设，提供紧凑的图标和一致的控制项。你可在“设置”中配置标准、专注、开发、审阅或完整工作流，同时 iOS 保留透明状态栏布局。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.5.6</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="打开 v1.4.1 工具栏预设截图"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Neon Vision Editor 中的工具栏预设"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">工具栏预设与布局稳定性</p><h2>选择需要的工具，同时保留当前文档。</h2><p>紧凑标签让 macOS 和 iPadOS 工具栏更易阅读；在空间有限的 iPhone 上，工具栏优先使用图标。预设让你可以在日常编辑、专注写作、开发、审阅和完整工作区之间快速切换。</p><p>此版本还恢复了 iOS 透明的状态栏和导航表面组合，同时不改变现有的编辑器和预览布局。</p></div></div>
       <div class="markdown-feature-points" aria-label="v1.2.1 功能"><div class="markdown-feature-point"><strong>平台优化工具栏</strong><span>为 macOS、iPadOS 和 iOS 提供紧凑且一致的控件。</span></div><div class="markdown-feature-point"><strong>五种工作区预设</strong><span>标准、专注、开发者、审阅和完整。</span></div><div class="markdown-feature-point"><strong>更清晰的自定义</strong><span>在设置中配置工具栏和项目侧栏操作。</span></div><div class="markdown-feature-point"><strong>稳定的 iOS 表面</strong><span>保留透明状态栏组合和现有布局。</span></div></div>
     </section>
@@ -1693,7 +1693,7 @@
         <p class="eyebrow">v1.2.0 新功能</p>
         <h2 id="release-1-2-title">将 PDF 与项目文件纳入同一套审阅工作流。</h2>
         <p>v1.2.0 将 Neon 的范围从源文件和 Markdown 扩展到更多项目内容。PDF 和 PNG 现在可以加入响应式项目概览，PDF 高亮与关联的 Markdown 笔记则让研究内容始终连接到正在阅读的文档。</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.5.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.5.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1749,17 +1749,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.5.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.1">v1.5.1 — 更鲜明的 Markdown 主题</a></h3>
-              <span class="release-date">21 August 2026</span>
-            </div>
-            <p>改进预览配色，优化直接打开项目文件夹，并提高 Sparkle 更新的稳定性。</p>
-            <div class="release-tags"><span>Markdown</span><span>主题</span><span>更新</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1792,7 +1781,7 @@
             <div class="release-tags"><span>编辑器</span><span>自动换行</span><span>macOS</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.5.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1801,6 +1790,17 @@
             </div>
             <p>在 iPad 悬停时预览插入点，使用 Pencil 直接选择文本范围，并修复 macOS 编辑器绘制问题。</p>
             <div class="release-tags"><span>编辑器</span><span>Apple Pencil</span><span>iPad</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.5.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">v1.5.6 — 更紧凑、更可靠的编辑工具</a></h3>
+              <span class="release-date">29 August 2026</span>
+            </div>
+            <p>简化移动工具栏，正确续排 Markdown 编号列表，并防止编辑器文字透过折叠的格式工具胶囊。</p>
+            <div class="release-tags"><span>工具栏</span><span>Markdown</span><span>选择</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1936,7 +1936,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">
           <strong>Release notes</strong>
           <span>What changed in the latest stable build →</span>
         </a>
@@ -2010,7 +2010,7 @@
       <h2 id="closing-title">尊重现有工作的轻量编辑器。</h2>
       <p>获取最新的 macOS 直接版本，在 GitHub 关注开发，或在 Apple 设备上试用 App Store 和 TestFlight 版本。</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.5">最新版本</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.5.6">最新版本</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>


### PR DESCRIPTION
Synchronizes the finalized v1.5.6 release merge, signed Sparkle appcast, App Store version metadata, release documentation, and post-release metrics from `main` back into `develop`.

## Summary by Sourcery

Synchronize the finalized v1.5.6 release state and post-release metadata from main into develop.

Enhancements:
- Synchronize release documentation, architecture notes, localized site content, and welcome-tour messaging with v1.5.6 and set v1.5.7 as the next target.

Deployment:
- Update Sparkle appcasts and release metadata to publish the signed v1.5.6 build 1015.

Documentation:
- Refresh README, changelog pages, release timelines, download links, and localized release information for v1.5.6.

Chores:
- Update post-release download metrics and project release references to reflect v1.5.6.