### PR TITLE
fix(ci): handle existing metrics PR race

### DIFF
--- a/.github/workflows/update-download-metrics.yml
+++ b/.github/workflows/update-download-metrics.yml
@@ -96,20 +96,38 @@ jobs:
           git commit -S -m "docs: refresh download metrics chart"
           git push --force-with-lease origin "HEAD:${METRICS_BRANCH}"
 
-          metrics_sha="$(git rev-parse HEAD)"
           metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
-            --json number,headRefOid --jq ".[] | select(.headRefOid == \"${metrics_sha}\") | .number" | head -n1)"
+            --json number --jq '.[0].number // empty')"
           if [[ -n "${metrics_pr}" ]]; then
-            echo "Updated existing metrics pull request."
+            echo "Updated existing metrics pull request #${metrics_pr}."
           else
-            gh pr create \
-              --repo "${GITHUB_REPOSITORY}" \
-              --base main \
-              --head "${METRICS_BRANCH}" \
-              --title "docs: refresh daily download metrics" \
-              --body "Automated refresh of README download and traffic metrics."
-            metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
-              --json number,headRefOid --jq ".[] | select(.headRefOid == \"${metrics_sha}\") | .number" | head -n1)"
+            # GitHub can lag briefly after the force-push. Give the existing
+            # branch PR time to appear before attempting creation, otherwise
+            # gh pr create races the already-open PR and exits with an error.
+            for attempt in {1..10}; do
+              metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
+                --json number --jq '.[0].number // empty')"
+              [[ -n "${metrics_pr}" ]] && break
+              sleep 2
+            done
+
+            if [[ -z "${metrics_pr}" ]]; then
+              if ! gh pr create \
+                --repo "${GITHUB_REPOSITORY}" \
+                --base main \
+                --head "${METRICS_BRANCH}" \
+                --title "docs: refresh daily download metrics" \
+                --body "Automated refresh of README download and traffic metrics."; then
+                echo "PR creation raced another metrics workflow; resolving the existing PR." >&2
+              fi
+
+              for attempt in {1..10}; do
+                metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
+                  --json number --jq '.[0].number // empty')"
+                [[ -n "${metrics_pr}" ]] && break
+                sleep 2
+              done
+            fi
           fi
 
           if [[ -z "${metrics_pr}" ]]; then


### PR DESCRIPTION
## Root cause
The scheduled metrics workflow force-updates `automation/daily-metrics`, then compares the PR head SHA immediately. GitHub can return stale PR indexing data, so the workflow incorrectly attempts to create a duplicate PR and fails.

## Fix
- resolve the existing open PR by branch, not exact SHA
- retry PR lookup after force-push for eventual consistency
- recover and re-resolve if PR creation races another workflow

## Verification
- workflow shell block passes `bash -n`
- workflow YAML parses successfully
- existing metrics PR #264 remains resolvable by branch

## Summary by Sourcery

Make the daily metrics workflow reliably update or create a single pull request despite GitHub indexing delays and concurrent runs.

Bug Fixes:
- Prevent duplicate daily metrics pull requests when GitHub returns stale data after a branch force-push or concurrent workflow run.

Enhancements:
- Resolve existing metrics pull requests by branch and retry lookups to accommodate GitHub’s eventual consistency.

CI:
- Make the scheduled metrics workflow resilient to races during pull request creation.