### PR TITLE
fix(ci): synchronize recurring metrics workflow fix

### DIFF
--- a/.github/workflows/update-download-metrics.yml
+++ b/.github/workflows/update-download-metrics.yml
@@ -96,20 +96,38 @@ jobs:
           git commit -S -m "docs: refresh download metrics chart"
           git push --force-with-lease origin "HEAD:${METRICS_BRANCH}"
 
-          metrics_sha="$(git rev-parse HEAD)"
           metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
-            --json number,headRefOid --jq ".[] | select(.headRefOid == \"${metrics_sha}\") | .number" | head -n1)"
+            --json number --jq '.[0].number // empty')"
           if [[ -n "${metrics_pr}" ]]; then
-            echo "Updated existing metrics pull request."
+            echo "Updated existing metrics pull request #${metrics_pr}."
           else
-            gh pr create \
-              --repo "${GITHUB_REPOSITORY}" \
-              --base main \
-              --head "${METRICS_BRANCH}" \
-              --title "docs: refresh daily download metrics" \
-              --body "Automated refresh of README download and traffic metrics."
-            metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
-              --json number,headRefOid --jq ".[] | select(.headRefOid == \"${metrics_sha}\") | .number" | head -n1)"
+            # GitHub can lag briefly after the force-push. Give the existing
+            # branch PR time to appear before attempting creation, otherwise
+            # gh pr create races the already-open PR and exits with an error.
+            for attempt in {1..10}; do
+              metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
+                --json number --jq '.[0].number // empty')"
+              [[ -n "${metrics_pr}" ]] && break
+              sleep 2
+            done
+
+            if [[ -z "${metrics_pr}" ]]; then
+              if ! gh pr create \
+                --repo "${GITHUB_REPOSITORY}" \
+                --base main \
+                --head "${METRICS_BRANCH}" \
+                --title "docs: refresh daily download metrics" \
+                --body "Automated refresh of README download and traffic metrics."; then
+                echo "PR creation raced another metrics workflow; resolving the existing PR." >&2
+              fi
+
+              for attempt in {1..10}; do
+                metrics_pr="$(gh pr list --repo "${GITHUB_REPOSITORY}" --state open --base main --head "${METRICS_BRANCH}" \
+                  --json number --jq '.[0].number // empty')"
+                [[ -n "${metrics_pr}" ]] && break
+                sleep 2
+              done
+            fi
           fi
 
           if [[ -z "${metrics_pr}" ]]; then


### PR DESCRIPTION
Promotes the verified metrics PR race fix from develop to main so scheduled runs use branch-based PR resolution and retry GitHub eventual consistency before creating a PR.

## Summary by Sourcery

Make scheduled metrics pull request updates resilient to branch synchronization delays and concurrent creation races.

Bug Fixes:
- Prevent the recurring metrics workflow from failing when GitHub briefly delays reflecting a force-pushed branch or when concurrent runs race to create the pull request.

Enhancements:
- Resolve the open metrics pull request by its branch rather than matching the latest commit, and report the existing pull request number.

CI:
- Add retries around pull request discovery and creation to handle GitHub eventual consistency and concurrent workflow runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating download-metrics pull requests.
  * Added handling for delays after force-pushes and concurrent workflow runs.
  * Prevented failures when a pull request is created by another workflow simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->