### PR TITLE
feat: add macOS HEX color previews

### DIFF
--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -3,6 +3,152 @@ import AppKit
 import CoreText
 import SwiftUI
 
+struct VirtualEditorHexColorLiteral: Equatable {
+    let range: NSRange
+    let token: String
+    let color: NSColor
+}
+
+enum VirtualEditorHexColorPreview {
+    private static let supportedLanguages: Set<String> = ["css", "html", "xml", "svg"]
+    private static let literalRegex = try! NSRegularExpression(pattern: "#[0-9A-Fa-f]{3,8}")
+
+    static func isSupported(language: String) -> Bool {
+        supportedLanguages.contains(language.lowercased())
+    }
+
+    static func literals(in line: String, absoluteStart: Int) -> [VirtualEditorHexColorLiteral] {
+        let source = line as NSString
+        let matches = literalRegex.matches(in: line, range: NSRange(location: 0, length: source.length))
+        return matches.compactMap { match in
+            let token = source.substring(with: match.range)
+            let digitCount = token.dropFirst().utf16.count
+            guard [3, 4, 6, 8].contains(digitCount),
+                  isBoundary(source, before: match.range.location),
+                  isBoundary(source, after: NSMaxRange(match.range)),
+                  let color = color(for: token) else { return nil }
+            return VirtualEditorHexColorLiteral(
+                range: NSRange(location: absoluteStart + match.range.location, length: match.range.length),
+                token: token,
+                color: color
+            )
+        }
+    }
+
+    static func replacement(for color: NSColor, preserving token: String) -> String? {
+        guard let rgb = color.usingColorSpace(.deviceRGB) else { return nil }
+        let red = Int((rgb.redComponent * 255).rounded())
+        let green = Int((rgb.greenComponent * 255).rounded())
+        let blue = Int((rgb.blueComponent * 255).rounded())
+        let alpha = Int((rgb.alphaComponent * 255).rounded())
+        let digitCount = token.dropFirst().utf16.count
+        let includesAlpha = [4, 8].contains(digitCount)
+        let full = includesAlpha
+            ? String(format: "#%02X%02X%02X%02X", red, green, blue, alpha)
+            : String(format: "#%02X%02X%02X", red, green, blue)
+        if [3, 4].contains(digitCount),
+           red % 17 == 0, green % 17 == 0, blue % 17 == 0,
+           !includesAlpha || alpha % 17 == 0 {
+            let components = [red, green, blue].map { String(format: "%X", $0 / 17) }
+            return includesAlpha
+                ? "#\(components.joined())\(String(format: "%X", alpha / 17))"
+                : "#\(components.joined())"
+        }
+        return full
+    }
+
+    private static func color(for token: String) -> NSColor? {
+        let digits = Array(token.dropFirst())
+        let values: [Int]
+        switch digits.count {
+        case 3, 4:
+            values = digits.map { Int(String(repeating: String($0), count: 2), radix: 16) ?? 0 }
+        case 6, 8:
+            values = stride(from: 0, to: digits.count, by: 2).map {
+                Int(String(digits[$0..<$0 + 2]), radix: 16) ?? 0
+            }
+        default:
+            return nil
+        }
+        let alpha = values.count == 4 ? values[3] : 255
+        return NSColor(
+            calibratedRed: CGFloat(values[0]) / 255,
+            green: CGFloat(values[1]) / 255,
+            blue: CGFloat(values[2]) / 255,
+            alpha: CGFloat(alpha) / 255
+        )
+    }
+
+    private static func isBoundary(_ source: NSString, before index: Int) -> Bool {
+        guard index > 0 else { return true }
+        return !isHexDigit(source.character(at: index - 1))
+    }
+
+    private static func isBoundary(_ source: NSString, after index: Int) -> Bool {
+        guard index < source.length else { return true }
+        return !isHexDigit(source.character(at: index))
+    }
+
+    private static func isHexDigit(_ codeUnit: unichar) -> Bool {
+        switch codeUnit {
+        case 48...57, 65...70, 97...102:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+@MainActor
+private final class VirtualEditorColorPickerState {
+    var literal: VirtualEditorHexColorLiteral
+
+    init(literal: VirtualEditorHexColorLiteral) {
+        self.literal = literal
+    }
+}
+
+@MainActor
+private final class VirtualEditorColorPickerViewController: NSViewController {
+    let colorWell: NSColorWell
+    var onColorChange: ((NSColor) -> Void)?
+
+    init(color: NSColor, token: String, isReadOnly: Bool) {
+        colorWell = NSColorWell(style: .expanded)
+        super.init(nibName: nil, bundle: nil)
+        colorWell.color = color
+        colorWell.isEnabled = !isReadOnly
+        colorWell.toolTip = "Edit \(token)"
+        colorWell.setAccessibilityLabel("Color for \(token)")
+        colorWell.target = self
+        colorWell.action = #selector(colorChanged(_:))
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func loadView() {
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 280, height: 220))
+        let stack = NSStackView(views: [colorWell])
+        stack.orientation = .vertical
+        stack.alignment = .centerX
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -12),
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -12),
+            colorWell.widthAnchor.constraint(equalToConstant: 256),
+            colorWell.heightAnchor.constraint(equalToConstant: 196)
+        ])
+        view = container
+    }
+
+    @objc private func colorChanged(_ sender: NSColorWell) {
+        onColorChange?(sender.color)
+    }
+}
+
 struct VirtualEditorVisualFragment {
     let absoluteStartUTF16: Int
     let lengthUTF16: Int
@@ -760,6 +906,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private var syntaxHighlightTask: Task<Void, Never>?
     private var syntaxHighlightGeneration = 0
     private var visibleColors: [NSRange: NSColor] = [:]
+    private var colorPickerPopover: NSPopover?
     private var viewportSize: CGSize = .zero {
         didSet {
             guard viewportSize != oldValue else { return }
@@ -779,7 +926,11 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private let visualMetricSampleLineLimit = 512
     private var lineHeight: CGFloat { max(1, (editorFont.ascender - editorFont.descender + editorFont.leading + 4) * lineHeightMultiplier) }
     private var editorFont: NSFont { resolvedEditorFont }
-    private var gutterWidth: CGFloat { max(44, CGFloat(max(1, document?.lineCount ?? 1).description.count) * editorFontSize * 0.7 + 18) }
+    private var gutterWidth: CGFloat {
+        let lineNumberWidth = CGFloat(max(1, document?.lineCount ?? 1).description.count) * editorFontSize * 0.7
+        let colorPreviewAllowance: CGFloat = VirtualEditorHexColorPreview.isSupported(language: language) ? 18 : 0
+        return max(44, lineNumberWidth + 18 + colorPreviewAllowance)
+    }
     var minimumUsableViewportWidth: CGFloat {
         let characterWidth = ("m" as NSString).size(withAttributes: [.font: editorFont]).width
         return gutterWidth + 16 + characterWidth * 4
@@ -1079,6 +1230,10 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         self.autoCloseBracketsEnabled = autoCloseBracketsEnabled
         self.onFontSizeChange = onFontSizeChange
         self.onTextMutation = onTextMutation
+        if isNewDocument {
+            colorPickerPopover?.close()
+            colorPickerPopover = nil
+        }
         if abs(editorFontSize - fontSize) > 0.01 {
             editorFontSize = fontSize
             pendingFontSizeDelta = 0
@@ -1167,8 +1322,21 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
             context.restoreGState()
             drawWhitespaceAndIndentationDecorations(for: row, dark: dark)
         }
+        drawHexColorSwatches(rows: rows, dirtyRect: dirtyRect)
         drawMarkedText(rows: rows, context: context)
         drawCaret(rows: rows)
+    }
+
+    private func drawHexColorSwatches(rows: [VisualRow], dirtyRect: NSRect) {
+        guard VirtualEditorHexColorPreview.isSupported(language: language) else { return }
+        for target in hexColorSwatchTargets(rows: rows) where target.rect.intersects(dirtyRect) {
+            target.literal.color.setFill()
+            let path = NSBezierPath(roundedRect: target.rect, xRadius: 2.5, yRadius: 2.5)
+            path.fill()
+            NSColor.separatorColor.withAlphaComponent(0.75).setStroke()
+            path.lineWidth = 0.75
+            path.stroke()
+        }
     }
 
     private func drawMarkedText(rows: [VisualRow], context: CGContext) {
@@ -1517,11 +1685,81 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     override func mouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
         let point = convert(event.locationInWindow, from: nil)
+        if let target = hexColorSwatchTargets(rows: visualRows()).first(where: { $0.rect.contains(point) }) {
+            presentColorPicker(for: target.literal, relativeTo: target.rect)
+            return
+        }
+        colorPickerPopover?.close()
+        colorPickerPopover = nil
         absoluteCaret = documentOffset(at: point)
         selection = NSRange(location: absoluteCaret, length: 0)
         selectionAnchor = absoluteCaret
         publishCaret()
         needsDisplay = true
+    }
+
+    private struct HexColorSwatchTarget {
+        let literal: VirtualEditorHexColorLiteral
+        let rect: NSRect
+    }
+
+    private func hexColorSwatchTargets(rows: [VisualRow]) -> [HexColorSwatchTarget] {
+        guard VirtualEditorHexColorPreview.isSupported(language: language) else { return [] }
+        var targets: [HexColorSwatchTarget] = []
+        var linesWithSwatches: Set<Int> = []
+        for row in rows where row.isFirstFragment {
+            let localLine = row.logicalLine - viewportLineOrigin
+            guard viewportLines.indices.contains(localLine) else { continue }
+            let viewportLine = viewportLines[localLine]
+            let literals = VirtualEditorHexColorPreview.literals(
+                in: viewportLine.text,
+                absoluteStart: viewportLine.startUTF16
+            )
+            guard !literals.isEmpty, !linesWithSwatches.contains(row.logicalLine) else { continue }
+            let lineNumber = "\(row.logicalLine + 1)" as NSString
+            let numberWidth = lineNumber.size(withAttributes: [.font: editorFont]).width
+            let swatchSize: CGFloat = 10
+            let rect = NSRect(
+                x: max(2, gutterWidth - numberWidth - Geometry.lineNumberTrailingInset - 14),
+                y: row.baseline - lineHeight + 5,
+                width: swatchSize,
+                height: swatchSize
+            )
+            targets.append(HexColorSwatchTarget(literal: literals[0], rect: rect))
+            linesWithSwatches.insert(row.logicalLine)
+        }
+        return targets
+    }
+
+    private func presentColorPicker(for literal: VirtualEditorHexColorLiteral, relativeTo rect: NSRect) {
+        colorPickerPopover?.close()
+        let state = VirtualEditorColorPickerState(literal: literal)
+        let picker = VirtualEditorColorPickerViewController(
+            color: literal.color,
+            token: literal.token,
+            isReadOnly: isReadOnly
+        )
+        picker.onColorChange = { [weak self, weak picker] color in
+            guard let self,
+                  let replacement = VirtualEditorHexColorPreview.replacement(for: color, preserving: state.literal.token),
+                  replacement != state.literal.token else { return }
+            self.selection = state.literal.range
+            self.absoluteCaret = state.literal.range.location
+            guard self.replaceSelection(with: replacement) else { return }
+            state.literal = VirtualEditorHexColorLiteral(
+                range: NSRange(location: state.literal.range.location, length: replacement.utf16.count),
+                token: replacement,
+                color: color
+            )
+            picker?.view.window?.makeFirstResponder(picker?.colorWell)
+        }
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.animates = true
+        popover.contentViewController = picker
+        popover.contentSize = NSSize(width: 280, height: 220)
+        colorPickerPopover = popover
+        popover.show(relativeTo: rect, of: self, preferredEdge: .maxX)
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -1716,8 +1954,9 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     }
     func characterIndex(for point: NSPoint) -> Int { documentOffset(at: convert(point, from: nil)) }
 
-    private func replaceSelection(with value: String) {
-        guard let document, let documentID else { return }
+    @discardableResult
+    private func replaceSelection(with value: String) -> Bool {
+        guard let document, let documentID else { return false }
         let selectionEnd = NSMaxRange(selection)
         let viewportContainsSelection = viewport != nil &&
             selection.location >= viewportStartUTF16 &&
@@ -1727,16 +1966,16 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
             let location = min(max(0, selection.location), source.length)
             let length = min(max(0, selection.length), source.length - location)
             let original = source.substring(with: NSRange(location: location, length: length))
-            guard onTextMutation?(EditorTextMutation(documentID: documentID, range: NSRange(location: location, length: length), replacement: value)) == true else { return }
+            guard onTextMutation?(EditorTextMutation(documentID: documentID, range: NSRange(location: location, length: length), replacement: value)) == true else { return false }
             registerUndo(replacement: original, range: NSRange(location: location, length: value.utf16.count), inverseReplacement: value)
             absoluteCaret = location + value.utf16.count
             selection = NSRange(location: absoluteCaret, length: 0)
             selectionAnchor = nil
             publishCaret()
             publishTextChange()
-            return
+            return true
         }
-        guard let viewport else { return }
+        guard let viewport else { return false }
         let local = max(0, min(selection.location - viewportStartUTF16, viewportText.utf16.count))
         let length = min(selection.length, max(0, viewportText.utf16.count - local))
         let range = NSRange(location: local, length: length)
@@ -1744,7 +1983,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         let absoluteRange = NSRange(location: selection.location, length: length)
         guard onTextMutation?(EditorTextMutation(documentID: documentID, range: range, replacement: value, viewport: viewport)) == true else {
             reloadViewport(anchorLine: viewportLineOrigin)
-            return
+            return false
         }
         registerUndo(
             replacement: original,
@@ -1757,6 +1996,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         _ = document
         publishCaret()
         publishTextChange()
+        return true
     }
 
     private func autoClosingPair(for value: String) -> String? {

--- a/Neon Vision EditorTests/WindowTranslucencyTests.swift
+++ b/Neon Vision EditorTests/WindowTranslucencyTests.swift
@@ -114,6 +114,28 @@ final class WindowTranslucencyTests: XCTestCase {
         XCTAssertFalse(scrollView.contentView.drawsBackground)
     }
 
+    func testVirtualEditorHexColorPreviewParsesSupportedFormsAndRejectsPartialTokens() {
+        let literals = VirtualEditorHexColorPreview.literals(
+            in: "color: #abc; background: #12345678; invalid: #12345;",
+            absoluteStart: 10
+        )
+
+        XCTAssertEqual(literals.map(\.token), ["#abc", "#12345678"])
+        XCTAssertEqual(literals.map(\.range.location), [17, 35])
+        XCTAssertEqual(literals.map(\.range.length), [4, 9])
+        XCTAssertTrue(VirtualEditorHexColorPreview.isSupported(language: "HTML"))
+        XCTAssertFalse(VirtualEditorHexColorPreview.isSupported(language: "swift"))
+    }
+
+    func testVirtualEditorHexColorPreviewPreservesShortFormOnlyWhenRepresentable() {
+        let white = NSColor.white
+        let black = NSColor.black
+
+        XCTAssertEqual(VirtualEditorHexColorPreview.replacement(for: white, preserving: "#fff"), "#FFF")
+        XCTAssertEqual(VirtualEditorHexColorPreview.replacement(for: black, preserving: "#ffff"), "#000F")
+        XCTAssertEqual(VirtualEditorHexColorPreview.replacement(for: white, preserving: "#abcd"), "#FFFF")
+    }
+
     func testVirtualEditorCoreTextDrawingOwnsCoordinateState() {
         let bitmap = NSBitmapImageRep(
             bitmapDataPlanes: nil,


### PR DESCRIPTION
## Summary
- show clickable HEX color swatches in the macOS editor gutter for CSS/HTML/XML/SVG
- open an in-editor native Color Picker and apply edits through the existing mutation/undo path
- keep ranges synchronized when short HEX values expand
- add parser and formatting regression tests

Closes #244

## Verification
- focused macOS WindowTranslucencyTests: 11/11 passed
- macOS-only implementation; no shared/iOS/iPadOS code changed

## Summary by Sourcery

Add macOS HEX color previews with editable native color picking for supported markup and stylesheet languages.

New Features:
- Add clickable HEX color swatches to the macOS editor gutter for CSS, HTML, XML, and SVG files.
- Provide an in-editor native color picker for editing detected HEX literals.

Bug Fixes:
- Keep color literal ranges synchronized when edits change the token length.

Enhancements:
- Preserve representable short HEX notation while formatting color picker replacements and route edits through existing mutation and undo behavior.

Tests:
- Add regression coverage for supported HEX parsing, token boundaries, ranges, language support, and short-form color formatting.