### PR TITLE
Fix large-file editor regressions for 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to **Neon Vision Editor** are documented in this file.
 
 The format follows *Keep a Changelog*. Versions use semantic versioning with prerelease tags.
 
+## [v1.6.0] - 2026-09-03
+
+### Why Upgrade
+
+- Opens and edits large Markdown and source files with less blocking work and bounded viewport rendering.
+- Keeps scrolling, rapid typing, Unicode edits, and saving reliable in large documents.
+- Adds native macOS HEX color previews and a color picker directly in the source editor.
+
+### Highlights
+
+- Prepares large-file indexes in the background and limits rendering to visible rows and bounded document windows.
+- Shows color swatches for supported HEX literals and preserves their format when editing colors.
+- Coalesces recent-file and performance-history persistence so repeated editor actions do not queue obsolete preference writes.
+
+### Fixes
+
+- Prevents blank scrolling after editor-width changes and preserves forward content in bounded viewports.
+- Refreshes edit coordinates before consecutive keystrokes, preserving typed text and accurate caret positions.
+- Keeps independent document views valid until the underlying content changes.
+- Uses exact document positions for navigation across uneven line lengths and offscreen accessibility reporting.
+- Preserves UTF-8 and UTF-16 boundaries, byte-order marks, surrogate pairs, and precise line counts.
+- Saves user-selected files through the system replacement directory while retaining atomic replacement and external-change protection.
+- Avoids full-document work for hidden editor confirmation messages and restores accessibility exposure of the source canvas.
+
+### Breaking changes
+
+- None.
+
+### Migration
+
+- None.
+
 ## [v1.5.6] - 2026-08-29
 
 ### Why Upgrade

--- a/Neon Vision Editor/App/NeonVisionEditorApp.swift
+++ b/Neon Vision Editor/App/NeonVisionEditorApp.swift
@@ -164,6 +164,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        EditorPreferenceWriter.shared.flushBeforeTermination()
         MacEditorWindowSessionStore.shared.beginTermination()
         appUpdateManager?.applicationWillTerminate()
         RuntimeReliabilityMonitor.shared.markGracefulTermination()
@@ -979,6 +980,7 @@ struct NeonVisionEditorApp: App {
                     }
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.willTerminateNotification)) { _ in
+                    EditorPreferenceWriter.shared.flushBeforeTermination()
                     RuntimeReliabilityMonitor.shared.markGracefulTermination()
                 }
                 .onChange(of: appearance) { _, _ in applyIOSAppearanceOverride() }

--- a/Neon Vision Editor/Core/EditorPerformanceMonitor.swift
+++ b/Neon Vision Editor/Core/EditorPerformanceMonitor.swift
@@ -41,12 +41,12 @@ final class EditorPerformanceMonitor {
     private var previewReloadExecutedCount = 0
     private(set) var lastMinimapViewportLatencyMilliseconds: Int?
     private(set) var lastTabSwitchLatencyMilliseconds: Int?
-    private let defaults = UserDefaults.standard
+    private let defaults: UserDefaults
     private let eventsDefaultsKey = "PerformanceRecentFileOpenEventsV1"
     private let tabSwitchEventsDefaultsKey = "PerformanceRecentTabSwitchEventsV1"
     private let maxEvents = 30
 
-    private init() {}
+    init(defaults: UserDefaults = .standard) { self.defaults = defaults }
 
     func markLaunchConfigured() {
 #if DEBUG
@@ -194,7 +194,7 @@ final class EditorPerformanceMonitor {
     }
 
     func recentFileOpenEvents(limit: Int = 10) -> [FileOpenEvent] {
-        guard let data = defaults.data(forKey: eventsDefaultsKey),
+        guard let data = EditorPreferenceWriter.shared.object(forKey: eventsDefaultsKey, defaults: defaults) as? Data,
               let decoded = try? JSONDecoder().decode([FileOpenEvent].self, from: data) else {
             return []
         }
@@ -203,11 +203,11 @@ final class EditorPerformanceMonitor {
     }
 
     func clearRecentFileOpenEvents() {
-        defaults.removeObject(forKey: eventsDefaultsKey)
+        EditorPreferenceWriter.shared.set(.removed, forKey: eventsDefaultsKey, defaults: defaults)
     }
 
     func recentTabSwitchEvents(limit: Int = 10) -> [TabSwitchEvent] {
-        guard let data = defaults.data(forKey: tabSwitchEventsDefaultsKey),
+        guard let data = EditorPreferenceWriter.shared.object(forKey: tabSwitchEventsDefaultsKey, defaults: defaults) as? Data,
               let decoded = try? JSONDecoder().decode([TabSwitchEvent].self, from: data) else {
             return []
         }
@@ -216,7 +216,7 @@ final class EditorPerformanceMonitor {
     }
 
     func clearRecentTabSwitchEvents() {
-        defaults.removeObject(forKey: tabSwitchEventsDefaultsKey)
+        EditorPreferenceWriter.shared.set(.removed, forKey: tabSwitchEventsDefaultsKey, defaults: defaults)
     }
 
     private func storeFileOpenEvent(_ event: FileOpenEvent) {
@@ -226,7 +226,7 @@ final class EditorPerformanceMonitor {
             existing.removeFirst(existing.count - maxEvents)
         }
         guard let encoded = try? JSONEncoder().encode(existing) else { return }
-        defaults.set(encoded, forKey: eventsDefaultsKey)
+        EditorPreferenceWriter.shared.set(.data(encoded), forKey: eventsDefaultsKey, defaults: defaults)
     }
 
     private func storeTabSwitchEvent(_ event: TabSwitchEvent) {
@@ -236,7 +236,7 @@ final class EditorPerformanceMonitor {
             existing.removeFirst(existing.count - maxEvents)
         }
         guard let encoded = try? JSONEncoder().encode(existing) else { return }
-        defaults.set(encoded, forKey: tabSwitchEventsDefaultsKey)
+        EditorPreferenceWriter.shared.set(.data(encoded), forKey: tabSwitchEventsDefaultsKey, defaults: defaults)
     }
 
     private static func elapsedMilliseconds(since startUptime: TimeInterval) -> Int {

--- a/Neon Vision Editor/Core/RecentFilesStore.swift
+++ b/Neon Vision Editor/Core/RecentFilesStore.swift
@@ -19,8 +19,8 @@ struct RecentFilesStore {
         limit: Int = maximumItemCount,
         defaults: UserDefaults = .standard
     ) -> [Item] {
-        let recentPaths = sanitizedPaths(from: defaults.stringArray(forKey: recentPathsKey) ?? [])
-        let pinnedPaths = sanitizedPaths(from: defaults.stringArray(forKey: pinnedPathsKey) ?? [])
+        let recentPaths = sanitizedPaths(from: (EditorPreferenceWriter.shared.object(forKey: recentPathsKey, defaults: defaults) as? [String]) ?? [])
+        let pinnedPaths = sanitizedPaths(from: (EditorPreferenceWriter.shared.object(forKey: pinnedPathsKey, defaults: defaults) as? [String]) ?? [])
         let pinnedSet = Set(pinnedPaths)
         let bookmarkMap = loadBookmarkMap(from: defaults)
 
@@ -31,11 +31,11 @@ struct RecentFilesStore {
 
     static func remember(_ url: URL, defaults: UserDefaults = .standard) {
         let standardizedPath = url.standardizedFileURL.path
-        var recentPaths = sanitizedPaths(from: defaults.stringArray(forKey: recentPathsKey) ?? [])
+        var recentPaths = sanitizedPaths(from: (EditorPreferenceWriter.shared.object(forKey: recentPathsKey, defaults: defaults) as? [String]) ?? [])
         recentPaths.removeAll { $0 == standardizedPath }
         recentPaths.insert(standardizedPath, at: 0)
 
-        let pinnedPaths = sanitizedPaths(from: defaults.stringArray(forKey: pinnedPathsKey) ?? [])
+        let pinnedPaths = sanitizedPaths(from: (EditorPreferenceWriter.shared.object(forKey: pinnedPathsKey, defaults: defaults) as? [String]) ?? [])
         let pinnedSet = Set(pinnedPaths)
         let retainedUnpinned = recentPaths.filter { !pinnedSet.contains($0) }
         let availableUnpinnedSlots = max(0, maximumItemCount - pinnedPaths.count)
@@ -59,8 +59,8 @@ struct RecentFilesStore {
 
     static func togglePinned(_ url: URL, defaults: UserDefaults = .standard) {
         let standardizedPath = url.standardizedFileURL.path
-        var pinnedPaths = sanitizedPaths(from: defaults.stringArray(forKey: pinnedPathsKey) ?? [])
-        var recentPaths = sanitizedPaths(from: defaults.stringArray(forKey: recentPathsKey) ?? [])
+        var pinnedPaths = sanitizedPaths(from: (EditorPreferenceWriter.shared.object(forKey: pinnedPathsKey, defaults: defaults) as? [String]) ?? [])
+        var recentPaths = sanitizedPaths(from: (EditorPreferenceWriter.shared.object(forKey: recentPathsKey, defaults: defaults) as? [String]) ?? [])
 
         if let existingIndex = pinnedPaths.firstIndex(of: standardizedPath) {
             pinnedPaths.remove(at: existingIndex)
@@ -90,7 +90,7 @@ struct RecentFilesStore {
     }
 
     static func clearUnpinned(defaults: UserDefaults = .standard) {
-        let pinnedPaths = sanitizedPaths(from: defaults.stringArray(forKey: pinnedPathsKey) ?? [])
+        let pinnedPaths = sanitizedPaths(from: (EditorPreferenceWriter.shared.object(forKey: pinnedPathsKey, defaults: defaults) as? [String]) ?? [])
         var bookmarkMap = loadBookmarkMap(from: defaults)
         pruneBookmarks(&bookmarkMap, keeping: Set(pinnedPaths))
         if persist(
@@ -123,7 +123,7 @@ struct RecentFilesStore {
     }
 
     private static func loadBookmarkMap(from defaults: UserDefaults) -> [String: Data] {
-        guard let raw = defaults.dictionary(forKey: bookmarkMapKey) else { return [:] }
+        guard let raw = (EditorPreferenceWriter.shared.object(forKey: bookmarkMapKey, defaults: defaults) as? [String: Any]) else { return [:] }
         var output: [String: Data] = [:]
         output.reserveCapacity(raw.count)
         for (path, value) in raw {
@@ -141,19 +141,19 @@ struct RecentFilesStore {
     ) -> Bool {
         var didChange = false
 
-        if let recentPaths, defaults.stringArray(forKey: recentPathsKey) != recentPaths {
-            defaults.set(recentPaths, forKey: recentPathsKey)
+        if let recentPaths, (EditorPreferenceWriter.shared.object(forKey: recentPathsKey, defaults: defaults) as? [String]) != recentPaths {
+            EditorPreferenceWriter.shared.set(.paths(recentPaths), forKey: recentPathsKey, defaults: defaults)
             didChange = true
-        } else if recentPaths == nil, defaults.object(forKey: recentPathsKey) != nil {
-            defaults.removeObject(forKey: recentPathsKey)
+        } else if recentPaths == nil, EditorPreferenceWriter.shared.object(forKey: recentPathsKey, defaults: defaults) != nil {
+            EditorPreferenceWriter.shared.set(.removed, forKey: recentPathsKey, defaults: defaults)
             didChange = true
         }
-        if defaults.stringArray(forKey: pinnedPathsKey) != pinnedPaths {
-            defaults.set(pinnedPaths, forKey: pinnedPathsKey)
+        if (EditorPreferenceWriter.shared.object(forKey: pinnedPathsKey, defaults: defaults) as? [String]) != pinnedPaths {
+            EditorPreferenceWriter.shared.set(.paths(pinnedPaths), forKey: pinnedPathsKey, defaults: defaults)
             didChange = true
         }
         if !bookmarkMapMatchesStoredValue(bookmarkMap, in: defaults) {
-            defaults.set(bookmarkMap, forKey: bookmarkMapKey)
+            EditorPreferenceWriter.shared.set(.bookmarks(bookmarkMap), forKey: bookmarkMapKey, defaults: defaults)
             didChange = true
         }
 
@@ -161,7 +161,7 @@ struct RecentFilesStore {
     }
 
     private static func bookmarkMapMatchesStoredValue(_ map: [String: Data], in defaults: UserDefaults) -> Bool {
-        guard let raw = defaults.dictionary(forKey: bookmarkMapKey) else {
+        guard let raw = (EditorPreferenceWriter.shared.object(forKey: bookmarkMapKey, defaults: defaults) as? [String: Any]) else {
             return map.isEmpty
         }
         guard raw.count == map.count else { return false }
@@ -225,5 +225,109 @@ struct RecentFilesStore {
         #else
         return []
         #endif
+    }
+}
+
+/// Keep preference reads immediately consistent while serializing disk writes and
+/// synchronous UserDefaults observers away from editor activation and drawing.
+@MainActor
+final class EditorPreferenceWriter {
+    static let shared = EditorPreferenceWriter()
+
+    nonisolated enum Value: Sendable {
+        case paths([String])
+        case bookmarks([String: Data])
+        case data(Data)
+        case removed
+
+        var object: Any? {
+            switch self {
+            case .paths(let value): return value
+            case .bookmarks(let value): return value
+            case .data(let value): return value
+            case .removed: return nil
+            }
+        }
+    }
+
+    private nonisolated struct Key: Hashable, Sendable {
+        let defaultsID: ObjectIdentifier
+        let name: String
+    }
+
+    // Foundation supports concurrent UserDefaults access. The wrapper transfers
+    // that reference to the serial writer without transferring UI-owned state.
+    private nonisolated struct Store: @unchecked Sendable {
+        let defaults: UserDefaults
+    }
+
+    private nonisolated struct Write: Sendable {
+        let revision: UUID
+        let value: Value
+        let store: Store
+    }
+
+    private nonisolated final class PendingWrites: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [Key: Write] = [:]
+
+        func replace(_ value: Write, for key: Key) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            let needsWorker = values[key] == nil
+            values[key] = value
+            return needsWorker
+        }
+
+        func take(_ key: Key) -> Write? {
+            lock.lock()
+            defer { lock.unlock() }
+            return values.removeValue(forKey: key)
+        }
+    }
+
+    private let queue = DispatchQueue(label: "editor.preferences.persistence", qos: .utility)
+    private let pendingWrites = PendingWrites()
+    private var pending: [Key: (revision: UUID, value: Value, defaults: UserDefaults)] = [:]
+
+    func object(forKey name: String, defaults: UserDefaults = .standard) -> Any? {
+        let key = Key(defaultsID: ObjectIdentifier(defaults), name: name)
+        if let value = pending[key]?.value { return value.object }
+        return defaults.object(forKey: name)
+    }
+
+    func set(_ value: Value, forKey name: String, defaults: UserDefaults = .standard) {
+        let key = Key(defaultsID: ObjectIdentifier(defaults), name: name)
+        let revision = UUID()
+        pending[key] = (revision, value, defaults)
+        let write = Write(revision: revision, value: value, store: Store(defaults: defaults))
+        // Repeated opens can supersede the same preference while an observer is
+        // still handling its prior write. Persist the latest queued value rather
+        // than accumulating obsolete snapshots that delay shutdown.
+        guard pendingWrites.replace(write, for: key) else { return }
+        let pendingWrites = pendingWrites
+        queue.async {
+            guard let write = pendingWrites.take(key) else { return }
+            if let object = write.value.object {
+                write.store.defaults.set(object, forKey: name)
+            } else {
+                write.store.defaults.removeObject(forKey: name)
+            }
+            Task { @MainActor [self] in
+                if pending[key]?.revision == write.revision { pending.removeValue(forKey: key) }
+            }
+        }
+    }
+
+    func flushBeforeTermination() {
+        // The worker never waits for the main actor; only app termination waits
+        // for persistence, so an immediate quit cannot lose the latest recents.
+        queue.sync {}
+    }
+
+    func flush() async {
+        await withCheckedContinuation { continuation in
+            queue.async { continuation.resume() }
+        }
     }
 }

--- a/Neon Vision Editor/Data/EditorDocument.swift
+++ b/Neon Vision Editor/Data/EditorDocument.swift
@@ -33,11 +33,15 @@ protocol EditorDocument: AnyObject {
     func replace(utf16Range: NSRange, with replacement: String) throws
     func replaceAll(with text: String) throws
     func markClean()
-    func viewport(aroundLine line: Int, maximumByteCount: Int) throws -> EditorDocumentViewport
+    func viewport(aroundLine line: Int, maximumByteCount: Int, maximumLineCount: Int) throws -> EditorDocumentViewport
     func replace(in viewport: EditorDocumentViewport, utf16Range: NSRange, with replacement: String) throws
 }
 
 extension EditorDocument {
+    func viewport(aroundLine line: Int, maximumByteCount: Int) throws -> EditorDocumentViewport {
+        try viewport(aroundLine: line, maximumByteCount: maximumByteCount, maximumLineCount: .max)
+    }
+
     var supportsBoundedWindows: Bool { true }
     var lineCount: Int { 1 }
 }

--- a/Neon Vision Editor/Data/EditorDocument.swift
+++ b/Neon Vision Editor/Data/EditorDocument.swift
@@ -24,6 +24,8 @@ protocol EditorDocument: AnyObject {
     var isDirty: Bool { get }
     var supportsBoundedWindows: Bool { get }
     var lineCount: Int { get }
+    /// Zero-based logical line and UTF-16 column, independent of visible windows.
+    func position(atUTF16Offset offset: Int) throws -> (line: Int, column: Int)
 
     func string() -> String
     func replace(range: NSRange, with replacement: String) throws

--- a/Neon Vision Editor/Data/EditorViewModel.swift
+++ b/Neon Vision Editor/Data/EditorViewModel.swift
@@ -330,6 +330,7 @@ private struct EditorFileLoadResult: Sendable {
     let byteCount: Int
     let isPartialPreview: Bool
     let fileBackedEncoding: TextEncodingDescriptor?
+    let fileBackedDocument: FileBackedTextDocument?
 }
 
 private struct EditorFileSavePayload: Sendable {
@@ -3012,7 +3013,8 @@ class EditorViewModel {
                     isLargeCandidate: false,
                     byteCount: totalByteCount,
                     isPartialPreview: true,
-                    fileBackedEncoding: nil
+                    fileBackedEncoding: nil,
+                    fileBackedDocument: nil
                 )
             }
             let boundedPreviewLimit = EditorLoadHelper.boundedPreviewLimit(
@@ -3023,7 +3025,7 @@ class EditorViewModel {
 
             if isLargeCandidate, !isPartialPreview {
                 let prefix = try EditorLoadHelper.partialFileData(from: url, maximumByteCount: 64_000)
-                let encoding = preferredEncoding ?? FileBackedTextDocument.boundedEncoding(from: prefix)
+                let encoding = preferredEncoding ?? FileBackedTextDocument.boundedEncoding(from: prefix, allowsIncompleteUTF8Sequence: totalByteCount > prefix.count)
                 if let encoding,
                    Self.isFileBackedEligible(
                        url: url,
@@ -3043,7 +3045,8 @@ class EditorViewModel {
                         isLargeCandidate: true,
                         byteCount: totalByteCount,
                         isPartialPreview: false,
-                        fileBackedEncoding: encoding
+                        fileBackedEncoding: encoding,
+                        fileBackedDocument: try Self.prepareFileBackedDocument(from: url, encoding: encoding)
                     )
                 }
                 let preview = String(decoding: prefix, as: UTF8.self)
@@ -3059,7 +3062,8 @@ class EditorViewModel {
                     isLargeCandidate: true,
                     byteCount: totalByteCount,
                     isPartialPreview: true,
-                    fileBackedEncoding: nil
+                    fileBackedEncoding: nil,
+                    fileBackedDocument: nil
                 )
             }
 
@@ -3105,6 +3109,16 @@ class EditorViewModel {
                 ? nil
                 : Self.contentFingerprintValue(content)
 
+            // Also handle a file that grew past the threshold after openFile's
+            // metadata check. Preparation remains inside this detached loader.
+            let fileBackedDocument: FileBackedTextDocument?
+            if max(totalByteCount, data.count) >= EditorLoadHelper.largeFileCandidateByteThreshold,
+               Self.isFileBackedEligible(url: url, encoding: raw.encoding, isRemote: false, isPartialPreview: isPartialPreview) {
+                fileBackedDocument = try? Self.prepareFileBackedDocument(from: url, encoding: nil)
+            } else {
+                fileBackedDocument = nil
+            }
+
             return EditorFileLoadResult(
                 content: content,
                 fileEncodingRawValue: raw.encodingRawValue,
@@ -3117,9 +3131,22 @@ class EditorViewModel {
                 isLargeCandidate: isPartialPreview || data.count >= EditorLoadHelper.largeFileCandidateByteThreshold,
                 byteCount: max(totalByteCount, data.count),
                 isPartialPreview: isPartialPreview,
-                fileBackedEncoding: nil
+                fileBackedEncoding: nil,
+                fileBackedDocument: fileBackedDocument
             )
         }.value
+    }
+
+    private nonisolated static func prepareFileBackedDocument(
+        from url: URL,
+        encoding: TextEncodingDescriptor?
+    ) throws -> FileBackedTextDocument {
+        let document = try encoding.map { try FileBackedTextDocument(url: url, knownEncoding: $0) }
+            ?? FileBackedTextDocument(url: url)
+        // Finish before transferring ownership to the main actor. The editor's
+        // synchronous viewport callbacks must never extend the whole-file index.
+        try document.prepareViewportIndex()
+        return document
     }
 
     nonisolated static func normalizedSaveText(
@@ -3175,44 +3202,7 @@ class EditorViewModel {
         result: EditorFileLoadResult,
         isExternalRefresh: Bool = false
     ) async {
-    cancelPendingLanguageDetection(for: tabID)
-
-    let loadedTab = tabs.first(where: { $0.id == tabID })
-    let fileBackedURL: URL? = {
-        guard Self.isFileBackedEligible(
-            url: loadedTab?.fileURL,
-            encoding: result.fileEncoding,
-            isRemote: loadedTab?.isRemoteDocument ?? false,
-            isPartialPreview: result.isPartialPreview
-        ),
-        result.byteCount >= EditorLoadHelper.largeFileCandidateByteThreshold,
-        let fileURL = loadedTab?.fileURL else { return nil }
-        return fileURL
-    }()
-
-    let fileBackedDocument: FileBackedTextDocument? = {
-        guard let fileBackedURL else { return nil }
-        do {
-            let document: FileBackedTextDocument
-            if let fileBackedEncoding = result.fileBackedEncoding {
-                document = try FileBackedTextDocument(url: fileBackedURL, knownEncoding: fileBackedEncoding)
-            } else {
-                document = try FileBackedTextDocument(url: fileBackedURL)
-            }
-            // Complete indexing before publishing this document to the virtual
-            // editor. Its synchronous viewport callbacks now only read a bounded
-            // window and never grow the index on the scrolling path.
-            try document.prepareViewportIndex()
-            return document
-        } catch {
-            return nil
-        }
-    }()
-
-    if result.fileBackedEncoding != nil, fileBackedDocument == nil {
-        await markTabLoadFailed(tabID: tabID)
-        return
-    }
+        cancelPendingLanguageDetection(for: tabID)
 
         _ = await dispatchTabCommandSerialized(
             .applyLoadedTabState(
@@ -3229,7 +3219,7 @@ class EditorViewModel {
                 isPartialPreview: result.isPartialPreview,
                 byteCount: result.byteCount,
                 isExternalRefresh: isExternalRefresh,
-                fileBackedDocument: fileBackedDocument
+                fileBackedDocument: result.fileBackedDocument
             )
         )
         EditorPerformanceMonitor.shared.markLoadedTabStateApplied(tabID: tabID)

--- a/Neon Vision Editor/Data/FileBackedTextDocument.swift
+++ b/Neon Vision Editor/Data/FileBackedTextDocument.swift
@@ -3,8 +3,8 @@ import Foundation
 /// An encoding-aware text document whose unchanged source stays range-backed on disk.
 ///
 /// Edits are represented as small replacement pieces. The original file is never
-/// copied into a `String`, and saving streams source and edit pieces to a temporary
-/// sibling before atomically replacing the source file.
+/// copied into a `String`, and saving streams source and edit pieces to the system
+/// replacement directory before atomically replacing the source file.
 /// The loader owns this mutable storage exclusively until its prepared index is
 /// transferred to the main actor; it must never be accessed concurrently.
 nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
@@ -244,15 +244,32 @@ nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Senda
     var supportsBoundedWindows: Bool { true }
     var isViewportIndexReady: Bool { lazyFileHandle == nil || lazyIndexComplete }
 
+    func position(atUTF16Offset offset: Int) throws -> (line: Int, column: Int) {
+        if lazyFileHandle != nil {
+            if !lazyIndexComplete { try prepareViewportIndex() }
+            guard offset >= 0, offset <= utf16Length else { throw Error.invalidRange }
+            var low = 0
+            var high = lazyLineUTF16Starts.count
+            while low < high {
+                let middle = (low + high) / 2
+                if lazyLineUTF16Starts[middle] <= offset { low = middle + 1 } else { high = middle }
+            }
+            let line = max(0, low - 1)
+            return (line, offset - lazyLineUTF16Starts[line])
+        }
+        guard offset >= 0, offset <= utf16Length,
+              let byte = byteOffset(forUTF16Offset: offset) else { throw Error.invalidRange }
+        let line = max(0, firstLineStart(after: byte) - 1)
+        return (line, offset - utf16Offset(atByteOffset: lineStarts[line]))
+    }
+
 
     func viewport(aroundLine line: Int, maximumByteCount: Int, maximumLineCount: Int = .max) throws -> EditorDocumentViewport {
         if lazyFileHandle != nil {
             let window = try lazyWindow(aroundLine: line, maximumByteCount: maximumByteCount, maximumLineCount: maximumLineCount)
-            viewportGeneration &+= 1
             return EditorDocumentViewport(text: window.text, startByteOffset: window.startByteOffset, startUTF16Offset: window.startUTF16Offset, lineRange: window.lineRange, generation: viewportGeneration)
         }
         let window = try self.window(aroundLine: line, maximumByteCount: maximumByteCount, maximumLineCount: maximumLineCount)
-        viewportGeneration &+= 1
         return EditorDocumentViewport(
             text: window.text,
             startByteOffset: window.startByteOffset,

--- a/Neon Vision Editor/Data/FileBackedTextDocument.swift
+++ b/Neon Vision Editor/Data/FileBackedTextDocument.swift
@@ -5,7 +5,9 @@ import Foundation
 /// Edits are represented as small replacement pieces. The original file is never
 /// copied into a `String`, and saving streams source and edit pieces to a temporary
 /// sibling before atomically replacing the source file.
-final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
+/// The loader owns this mutable storage exclusively until its prepared index is
+/// transferred to the main actor; it must never be accessed concurrently.
+nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
     enum Error: Swift.Error, Equatable {
         case unsupportedEncoding
         case invalidRange
@@ -104,22 +106,15 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
     private var savedFileMetadata: FileMetadata?
     let encodingDescriptor: TextEncodingDescriptor
     private var edits: [SessionState.Edit] = []
-    private(set) var isDirty = false
+    private var dirty = false
+    var isDirty: Bool { dirty }
     private var viewportGeneration: UInt64 = 0
+    private(set) var viewportIndexPreparedOnMainThread: Bool?
 
     convenience init(url: URL) throws {
         let prefix = try Self.readPrefix(from: url, maximumByteCount: 64 * 1024)
-        let prefixDescriptor: TextEncodingDescriptor?
-        if prefix.starts(with: [0xEF, 0xBB, 0xBF]) {
-            prefixDescriptor = TextEncodingDescriptor(identifier: .utf8WithBOM)
-        } else if prefix.starts(with: [0xFF, 0xFE]) || prefix.starts(with: [0xFE, 0xFF]) {
-            prefixDescriptor = Self.detectEncoding(in: prefix)
-        } else if !prefix.isEmpty,
-                  Self.completeUTF8PrefixLength(in: prefix, maximumLength: prefix.count).map({ $0 > 0 }) == true {
-            prefixDescriptor = .utf8
-        } else {
-            prefixDescriptor = Self.detectEncoding(in: prefix)
-        }
+        let byteCount = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? prefix.count
+        let prefixDescriptor = Self.boundedEncoding(from: prefix, allowsIncompleteUTF8Sequence: byteCount > prefix.count)
         if let prefixDescriptor {
             let values = try url.resourceValues(forKeys: [.fileSizeKey])
             guard let byteCount = values.fileSize, byteCount >= 0 else { throw Error.invalidRange }
@@ -244,19 +239,19 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
 
     var byteCount: Int { lazyFileHandle == nil ? pieces.reduce(0) { $0 + $1.length } : lazyFileByteCount }
     var utf16Length: Int { lazyFileHandle == nil ? cachedUTF16Length : max(cachedUTF16Length, lazyIndexedUTF16Length) }
-    var lineCount: Int { lazyFileHandle == nil ? lineStarts.count : max(lazyEstimatedLineCount, lazyLineStarts.count) }
+    var lineCount: Int { lazyFileHandle == nil ? lineStarts.count : (lazyIndexComplete ? lazyLineStarts.count : max(lazyEstimatedLineCount, lazyLineStarts.count)) }
     var storageKind: EditorDocumentStorageKind { .fileBacked }
     var supportsBoundedWindows: Bool { true }
     var isViewportIndexReady: Bool { lazyFileHandle == nil || lazyIndexComplete }
 
 
-    func viewport(aroundLine line: Int, maximumByteCount: Int) throws -> EditorDocumentViewport {
+    func viewport(aroundLine line: Int, maximumByteCount: Int, maximumLineCount: Int = .max) throws -> EditorDocumentViewport {
         if lazyFileHandle != nil {
-            let window = try lazyWindow(aroundLine: line, maximumByteCount: maximumByteCount)
+            let window = try lazyWindow(aroundLine: line, maximumByteCount: maximumByteCount, maximumLineCount: maximumLineCount)
             viewportGeneration &+= 1
             return EditorDocumentViewport(text: window.text, startByteOffset: window.startByteOffset, startUTF16Offset: window.startUTF16Offset, lineRange: window.lineRange, generation: viewportGeneration)
         }
-        let window = try self.window(aroundLine: line, maximumByteCount: maximumByteCount)
+        let window = try self.window(aroundLine: line, maximumByteCount: maximumByteCount, maximumLineCount: maximumLineCount)
         viewportGeneration &+= 1
         return EditorDocumentViewport(
             text: window.text,
@@ -271,6 +266,7 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
     /// Viewport reloads then only perform their bounded read/decode work.
     func prepareViewportIndex() throws {
         guard lazyFileHandle != nil else { return }
+        viewportIndexPreparedOnMainThread = Thread.isMainThread
         try extendLazyIndex(throughByte: lazyFileByteCount)
     }
 
@@ -318,7 +314,7 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
         )
     }
 
-    func markClean() { isDirty = false }
+    func markClean() { dirty = false }
     var restoreRecord: RestoreRecord {
         try? materializeLazyStorageIfNeeded()
         return RestoreRecord(
@@ -380,8 +376,12 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
         return text
     }
 
-    func window(aroundLine requestedLine: Int, maximumByteCount: Int) throws -> Window {
-        guard maximumByteCount > 0, !lineStarts.isEmpty else { throw Error.invalidRange }
+    func window(aroundLine requestedLine: Int, maximumByteCount: Int, maximumLineCount: Int = .max) throws -> Window {
+        if lazyFileHandle != nil {
+            let result = try lazyWindow(aroundLine: requestedLine, maximumByteCount: maximumByteCount, maximumLineCount: maximumLineCount)
+            return Window(text: result.text, startByteOffset: result.startByteOffset, lineRange: result.lineRange)
+        }
+        guard maximumByteCount > 0, maximumLineCount > 0, !lineStarts.isEmpty else { throw Error.invalidRange }
         let centerLine = min(max(0, requestedLine), lineStarts.count - 1)
         var firstLine = centerLine
         var lastLine = centerLine
@@ -390,15 +390,18 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
             ? lineStarts[centerLine + 1]
             : byteCount
 
-        // Prefer nearby preceding lines so the requested line is not pinned to the
-        // top edge, but never exceed the TextKit window's byte budget.
-        while firstLine > 0 {
+        end = min(end, start + maximumByteCount)
+
+        // Reserve forward context for the visible rows after the scroll anchor.
+        // Consuming the entire budget on preceding lines leaves prefetched
+        // anchors above the viewport with nothing available to draw below them.
+        while firstLine > 0 && lastLine - firstLine + 1 < max(1, maximumLineCount / 2) {
             let candidateStart = lineStarts[firstLine - 1]
-            guard end - candidateStart <= maximumByteCount else { break }
+            guard end - candidateStart <= maximumByteCount / 2 else { break }
             firstLine -= 1
             start = candidateStart
         }
-        while lastLine + 1 < lineStarts.count {
+        while lastLine + 1 < lineStarts.count && lastLine - firstLine + 1 < maximumLineCount {
             let candidateEnd = lastLine + 2 < lineStarts.count
                 ? lineStarts[lastLine + 2]
                 : byteCount
@@ -406,12 +409,15 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
             lastLine += 1
             end = candidateEnd
         }
-        let text = try text(inByteRange: NSRange(location: start, length: end - start))
+        let rawData = try data(inByteRange: NSRange(location: start, length: end - start))
+        let length = Self.completeSegmentLength(in: rawData, encoding: encodingDescriptor,
+            isFinal: end == byteCount, atDocumentStart: start == 0, prefersLineBoundary: false)
+        guard let text = decode(Data(rawData.prefix(length)), beginsAtDocumentStart: start == 0) else { throw Error.unsupportedEncoding }
         return Window(text: text, startByteOffset: start, lineRange: firstLine...lastLine)
     }
 
-    private func lazyWindow(aroundLine requestedLine: Int, maximumByteCount: Int) throws -> (text: String, startByteOffset: Int, startUTF16Offset: Int, lineRange: ClosedRange<Int>) {
-        guard maximumByteCount > 0 else { throw Error.invalidRange }
+    private func lazyWindow(aroundLine requestedLine: Int, maximumByteCount: Int, maximumLineCount: Int) throws -> (text: String, startByteOffset: Int, startUTF16Offset: Int, lineRange: ClosedRange<Int>) {
+        guard maximumByteCount > 0, maximumLineCount > 0 else { throw Error.invalidRange }
         // Activation completes this index before the document can reach the
         // virtual editor. Never revive the former on-scroll indexing fallback.
         guard lazyIndexComplete else { throw Error.invalidRange }
@@ -419,15 +425,17 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
         var first = center
         var last = center
         var start = lazyLineStarts[center]
-        var end = min(lazyFileByteCount, start + maximumByteCount)
-        if Self.utf16Endianness(for: encodingDescriptor) != nil {
-            end -= (end - start) % 2
-            if end <= start { end = min(lazyFileByteCount, start + 2) }
-        }
-        while first > 0 && end - lazyLineStarts[first - 1] <= maximumByteCount { first -= 1; start = lazyLineStarts[first] }
+        let lineLimit = center + min(maximumLineCount, lazyLineStarts.count - center)
+        var end = min(lineLimit < lazyLineStarts.count ? lazyLineStarts[lineLimit] : lazyFileByteCount, start + maximumByteCount)
         while last + 1 < lazyLineStarts.count && lazyLineStarts[last + 1] < end { last += 1 }
-        let data = try lazyRead(NSRange(location: start, length: end - start))
-        guard let text = decode(data, beginsAtDocumentStart: start == 0) else { throw Error.unsupportedEncoding }
+        while first > 0 && last - first + 1 < maximumLineCount && end - lazyLineStarts[first - 1] <= maximumByteCount { first -= 1; start = lazyLineStarts[first] }
+        let rawData = try lazyRead(NSRange(location: start, length: end - start))
+        let length = Self.completeSegmentLength(in: rawData, encoding: encodingDescriptor,
+            isFinal: end == lazyFileByteCount, atDocumentStart: start == 0, prefersLineBoundary: false)
+        end = start + length
+        last = center
+        while last + 1 < lazyLineStarts.count && lazyLineStarts[last + 1] < end { last += 1 }
+        guard let text = decode(Data(rawData.prefix(length)), beginsAtDocumentStart: start == 0) else { throw Error.unsupportedEncoding }
         return (text, start, lazyUTF16Offset(atByteOffset: start), first...max(first, last))
     }
 
@@ -470,12 +478,19 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
 
     private func lazyUTF16Offset(atByteOffset target: Int) -> Int {
         if target <= 0 { return 0 }
-        if let index = lazyLineStarts.lastIndex(where: { $0 <= target }), index < lazyLineUTF16Starts.count {
+        var low = 0
+        var high = lazyLineStarts.count
+        while low < high {
+            let middle = (low + high) / 2
+            if lazyLineStarts[middle] <= target { low = middle + 1 } else { high = middle }
+        }
+        let index = max(0, low - 1)
+        if index < lazyLineUTF16Starts.count {
             let lineByteStart = lazyLineStarts[index]
             let lineUTF16Start = lazyLineUTF16Starts[index]
             guard target > lineByteStart,
                   let data = try? lazyRead(NSRange(location: lineByteStart, length: target - lineByteStart)),
-                  let text = String(data: data, encoding: .utf8) else { return lineUTF16Start }
+                  let text = decode(data, beginsAtDocumentStart: lineByteStart == 0) else { return lineUTF16Start }
             return lineUTF16Start + text.utf16.count
         }
         return lazyIndexedUTF16Length
@@ -555,27 +570,31 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
         cachedUTF16Length += insertedUTF16Length - removedUTF16Length
         updateLineStarts(replacingByteRange: rawRange, with: replacementData)
         edits.append(.init(location: rawRange.location, length: rawRange.length, replacement: replacement))
-        isDirty = true
+        dirty = true
         viewportGeneration &+= 1
     }
 
     func saveAtomically(allowExternalOverwrite: Bool = false) throws {
-        try materializeLazyStorageIfNeeded()
-        guard isDirty else { return }
+        guard dirty else { return }
         guard let url, savedFileMetadata != nil else { throw Error.externalConflict }
+        let didAccess = url.startAccessingSecurityScopedResource()
+        defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+        try materializeLazyStorageIfNeeded()
         guard allowExternalOverwrite || !hasExternalConflict() else { throw Error.externalConflict }
-        let temporaryURL = url.deletingLastPathComponent()
-            .appendingPathComponent(".\(url.lastPathComponent).neon-save-\(UUID().uuidString)")
-        FileManager.default.createFile(atPath: temporaryURL.path, contents: nil)
+        let replacementDirectory = try FileManager.default.url(
+            for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: url, create: true)
+        defer { try? FileManager.default.removeItem(at: replacementDirectory) }
+        let temporaryURL = replacementDirectory.appendingPathComponent(url.lastPathComponent)
+        try Data().write(to: temporaryURL, options: .withoutOverwriting)
         let output = try FileHandle(forWritingTo: temporaryURL)
         do {
             for piece in pieces {
-                output.write(piece.data)
+                try output.write(contentsOf: piece.data)
             }
             try output.synchronize()
             try output.close()
             _ = try FileManager.default.replaceItemAt(url, withItemAt: temporaryURL)
-            isDirty = false
+            dirty = false
             lineStarts = lineStartsFromPieceMetadata()
             let savedData = try Data(contentsOf: url, options: [.alwaysMapped])
             self.savedFileMetadata = try Self.fileMetadata(at: url, fingerprint: Self.fingerprint(of: savedData))
@@ -591,14 +610,18 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
     /// a whole-document string. Transcoding and normalization are intentionally
     /// unavailable on this virtual-document path.
     func saveAtomically(to destinationURL: URL) throws {
+        let didAccess = destinationURL.startAccessingSecurityScopedResource()
+        defer { if didAccess { destinationURL.stopAccessingSecurityScopedResource() } }
         try materializeLazyStorageIfNeeded()
-        let temporaryURL = destinationURL.deletingLastPathComponent()
-            .appendingPathComponent(".\(destinationURL.lastPathComponent).neon-save-\(UUID().uuidString)")
-        FileManager.default.createFile(atPath: temporaryURL.path, contents: nil)
+        let replacementDirectory = try FileManager.default.url(
+            for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: destinationURL, create: true)
+        defer { try? FileManager.default.removeItem(at: replacementDirectory) }
+        let temporaryURL = replacementDirectory.appendingPathComponent(destinationURL.lastPathComponent)
+        try Data().write(to: temporaryURL, options: .withoutOverwriting)
         let output = try FileHandle(forWritingTo: temporaryURL)
         do {
             for piece in pieces {
-                output.write(piece.data)
+                try output.write(contentsOf: piece.data)
             }
             try output.synchronize()
             try output.close()
@@ -677,7 +700,7 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
 
     /// Performs encoding detection using only a bounded prefix. UTF-8 and
     /// UTF-16 BOM encodings are eligible for the bounded editor path.
-    nonisolated static func boundedEncoding(from prefix: Data) -> TextEncodingDescriptor? {
+    nonisolated static func boundedEncoding(from prefix: Data, allowsIncompleteUTF8Sequence: Bool = false) -> TextEncodingDescriptor? {
         if prefix.starts(with: [0xEF, 0xBB, 0xBF]) {
             return TextEncodingDescriptor(identifier: .utf8WithBOM)
         }
@@ -688,7 +711,8 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
             return TextEncodingDescriptor(identifier: .utf16BigEndianWithBOM)
         }
         if !prefix.isEmpty,
-           completeUTF8PrefixLength(in: prefix, maximumLength: prefix.count) == prefix.count {
+           (String(data: prefix, encoding: .utf8) != nil ||
+            (allowsIncompleteUTF8Sequence && hasIncompleteUTF8Suffix(prefix))) {
             return .utf8
         }
         let legacyCandidates: [TextEncodingDescriptor] = [
@@ -762,6 +786,9 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
             var lineUTF16Starts = [0]
             var newlineOffsets: [Int] = []
             var fingerprint = UInt64(0xcbf29ce484222325)
+            for offset in 0..<start {
+                fingerprint = (fingerprint ^ UInt64(bytes[offset])) &* 0x100000001b3
+            }
             while index < data.count {
                 let first = bytes[index]
                 if first < 0x80 {
@@ -803,21 +830,48 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
         }
     }
 
+    private static func hasIncompleteUTF8Suffix(_ data: Data) -> Bool {
+        guard !data.isEmpty else { return false }
+        var start = data.count - 1
+        while start > 0 && data[start] & 0xC0 == 0x80 { start -= 1 }
+        let lead = data[start]
+        let width: Int
+        switch lead {
+        case 0xC2...0xDF: width = 2
+        case 0xE0...0xEF: width = 3
+        case 0xF0...0xF4: width = 4
+        default: return false
+        }
+        guard data.count - start < width,
+              String(data: data.prefix(start), encoding: .utf8) != nil else { return false }
+        if start + 1 < data.count {
+            let second = data[start + 1]
+            if lead == 0xE0 && second < 0xA0 { return false }
+            if lead == 0xED && second > 0x9F { return false }
+            if lead == 0xF0 && second < 0x90 { return false }
+            if lead == 0xF4 && second > 0x8F { return false }
+        }
+        return true
+    }
+
     private nonisolated static func completeUTF8PrefixLength(in data: Data, maximumLength: Int) -> Int? {
         let limit = min(maximumLength, data.count)
         guard limit > 0 else { return 0 }
         if String(data: data.prefix(limit), encoding: .utf8) != nil { return limit }
-        let lowerBound = max(0, limit - 4)
-        for candidate in stride(from: limit - 1, through: lowerBound, by: -1) {
-            if String(data: data.prefix(candidate), encoding: .utf8) != nil { return candidate }
+        let prefix = Data(data.prefix(limit))
+        if hasIncompleteUTF8Suffix(prefix) {
+            var start = limit - 1
+            while start > 0 && prefix[start] & 0xC0 == 0x80 { start -= 1 }
+            return start
         }
         return nil
     }
 
 
 
-    private static func completeSegmentLength(in data: Data, encoding: TextEncodingDescriptor, isFinal: Bool, atDocumentStart: Bool = true) -> Int {
+    private static func completeSegmentLength(in data: Data, encoding: TextEncodingDescriptor, isFinal: Bool, atDocumentStart: Bool = true, prefersLineBoundary: Bool = true) -> Int {
         if isFinal { return data.count }
+        if atDocumentStart && data.count < byteOrderMarkLength(for: encoding) { return 0 }
         if let endianness = utf16Endianness(for: encoding) {
             let bom = atDocumentStart ? byteOrderMarkLength(for: encoding) : 0
             var length = bom + max(0, data.count - bom) / 2 * 2
@@ -835,10 +889,10 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
             return length
         }
         if encoding.identifier == .utf8 || encoding.identifier == .utf8WithBOM {
-            let newlineEnd = data.lastIndex(of: 0x0A).map { data.distance(from: data.startIndex, to: $0) + 1 } ?? data.count
+            let newlineEnd = (prefersLineBoundary ? data.lastIndex(of: 0x0A) : nil).map { data.distance(from: data.startIndex, to: $0) + 1 } ?? data.count
             return completeUTF8PrefixLength(in: data, maximumLength: newlineEnd) ?? 0
         }
-        return data.lastIndex(of: 0x0A).map { data.distance(from: data.startIndex, to: $0) + 1 } ?? data.count
+        return (prefersLineBoundary ? data.lastIndex(of: 0x0A) : nil).map { data.distance(from: data.startIndex, to: $0) + 1 } ?? data.count
     }
 
     private static func indexSegment(in data: Data, baseByteOffset: Int, encoding: TextEncodingDescriptor, atDocumentStart: Bool) throws -> UTF8Index {
@@ -849,22 +903,36 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
         let bom = atDocumentStart ? byteOrderMarkLength(for: encoding) : 0
         let payload = Data(data.dropFirst(min(bom, data.count)))
         guard let text = String(data: payload, encoding: encoding.encoding) else { throw Error.unsupportedEncoding }
-        var starts = [baseByteOffset]
-        var utf16Starts = [0]
-        var newlines: [Int] = []
-        var utf16 = 0
-        var byteOffset = bom
-        for scalar in text.unicodeScalars {
-            byteOffset += (String(scalar).data(using: encoding.encoding) ?? Data()).count
-            utf16 += scalar.utf16.count
-            if scalar.value == 10 {
-                let absolute = baseByteOffset + byteOffset
-                starts.append(absolute)
-                utf16Starts.append(utf16)
-                newlines.append(absolute)
+        // The remaining supported encodings use either two bytes per UTF-16
+        // unit or one byte per character. Decode once for validation, then index
+        // the original units instead of allocating and re-encoding each scalar.
+        return data.withUnsafeBytes { rawBuffer in
+            let bytes = rawBuffer.bindMemory(to: UInt8.self)
+            let endianness = utf16Endianness(for: encoding)
+            let unitWidth = endianness == nil ? 1 : 2
+            var starts = [baseByteOffset]
+            var utf16Starts = [0]
+            var newlines: [Int] = []
+            var byteOffset = bom
+            while byteOffset + unitWidth <= bytes.count {
+                let isNewline: Bool
+                if let endianness {
+                    isNewline = endianness == .littleEndian
+                        ? bytes[byteOffset] == 0x0A && bytes[byteOffset + 1] == 0
+                        : bytes[byteOffset] == 0 && bytes[byteOffset + 1] == 0x0A
+                } else {
+                    isNewline = bytes[byteOffset] == 0x0A
+                }
+                byteOffset += unitWidth
+                if isNewline {
+                    let absolute = baseByteOffset + byteOffset
+                    starts.append(absolute)
+                    utf16Starts.append((byteOffset - bom) / unitWidth)
+                    newlines.append(absolute)
+                }
             }
+            return UTF8Index(utf16Length: text.utf16.count, lineStarts: starts, lineUTF16Starts: utf16Starts, newlineOffsets: newlines, fingerprint: fingerprint(of: data))
         }
-        return UTF8Index(utf16Length: utf16, lineStarts: starts, lineUTF16Starts: utf16Starts, newlineOffsets: newlines, fingerprint: fingerprint(of: data))
     }
 
     private static func readPrefix(from url: URL, maximumByteCount: Int) throws -> Data {
@@ -905,10 +973,13 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
 
     private func slice(_ piece: Piece, _ range: Range<Int>) -> Piece {
         let data = Data(piece.data[range])
-        if let sourceOffset = piece.sourceOffset {
-            return .source(data, offset: sourceOffset + range.lowerBound, encoding: encodingDescriptor)
-        }
-        return .inserted(data, encoding: encodingDescriptor)
+        let sourceOffset = piece.sourceOffset.map { $0 + range.lowerBound }
+        return Piece(sourceOffset: sourceOffset, data: data,
+            utf16Length: Self.utf16Length(in: data, encoding: encodingDescriptor,
+                includesByteOrderMark: sourceOffset == 0),
+            newlineOffsets: piece.newlineOffsets.lazy
+                .filter { $0 > range.lowerBound && $0 <= range.upperBound }
+                .map { $0 - range.lowerBound })
     }
 
     func hasExternalConflict() -> Bool {
@@ -935,11 +1006,11 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
             let data = try handle.readToEnd() ?? Data()
             let index = try Self.indexSegment(in: data, baseByteOffset: 0, encoding: encodingDescriptor, atDocumentStart: true)
             originalData = data
-            pieces = [Piece.source(data, offset: 0, encoding: encodingDescriptor)]
+            pieces = [Piece(sourceOffset: 0, data: data, utf16Length: index.utf16Length, newlineOffsets: index.newlineOffsets)]
             lineStarts = index.lineStarts
             cachedUTF16Length = index.utf16Length
             if savedFileMetadata?.fingerprint == 0 {
-                savedFileMetadata = try? Self.fileMetadata(at: url!, fingerprint: Self.fingerprint(of: data))
+                savedFileMetadata = try? Self.fileMetadata(at: url!, fingerprint: index.fingerprint)
             }
         } catch {
             throw error
@@ -1075,6 +1146,9 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
             let bomLength = includesByteOrderMark ? utf16BOMLength(for: encoding, data: data) : 0
             return max(0, data.count - bomLength) / 2
         }
+        if encoding.identifier == .utf8WithBOM, !includesByteOrderMark {
+            return String(decoding: data, as: UTF8.self).utf16.count
+        }
         return encoding.decode(data)?.utf16.count ?? String(decoding: data, as: UTF8.self).utf16.count
     }
 
@@ -1096,7 +1170,7 @@ final class FileBackedTextDocument: EditorDocument, @unchecked Sendable {
                 let width = (unit >= 0xD800 && unit <= 0xDBFF && offset + 3 < data.count) ? 2 : 1
                 if units + width > target { return offset }
                 units += width
-                offset += 2
+                offset += width * 2
                 if units == target { return offset }
             }
             return data.count

--- a/Neon Vision Editor/UI/ContentView+Actions.swift
+++ b/Neon Vision Editor/UI/ContentView+Actions.swift
@@ -641,7 +641,16 @@ extension ContentView {
     }
 
     var clearEditorPreviewDescription: String {
-        let content = currentContentBinding.wrappedValue
+        Self.clearEditorPreviewDescription(isPresented: showClearEditorConfirmDialog) {
+            currentContentBinding.wrappedValue
+        }
+    }
+
+    static func clearEditorPreviewDescription(isPresented: Bool, content: () -> String) -> String {
+        // SwiftUI evaluates dialog messages while the dialog is hidden. Keep
+        // that normal render path from projecting and counting the whole file.
+        guard isPresented else { return "" }
+        let content = content()
         let lineCount = max(1, content.reduce(into: 1) { count, character in
             if character == "\n" { count += 1 }
         })

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -910,6 +910,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private var viewportSize: CGSize = .zero {
         didSet {
             guard viewportSize != oldValue else { return }
+            if viewportSize.width != oldValue.width { hasValidVisualMetrics = false }
             visualFragmentCache.removeAll(keepingCapacity: true)
             visualRowsSnapshot = nil
             invalidateIntrinsicContentSize()
@@ -919,6 +920,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     var lastScrollY: CGFloat = -1
     var lastReloadAnchorLine = -1
     private var estimatedRowsPerLogicalLine: CGFloat = 1
+    private var hasValidVisualMetrics = false
     private var configuredContentRevision: Int?
     private var configuredExternalContentRevision: Int?
     private let viewportMaximumByteCount = 256_000
@@ -950,6 +952,9 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     }
 
     func recalculateVisualMetrics() {
+        // A one-point fallback width is not a measurement of this viewport.
+        // Wait for allocation, and never blend estimates from different widths.
+        guard viewportSize.width >= minimumUsableViewportWidth else { return }
         guard lineWrapEnabled, !viewportText.isEmpty else {
             estimatedRowsPerLogicalLine = 1
             contentWidth = max(viewportSize.width, 1)
@@ -960,12 +965,13 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
             measuredRowsPerLogicalLine()
         }
         let observed = measurement.rowsPerLogicalLine
-        if abs(observed - estimatedRowsPerLogicalLine) > 0.05 {
+        if !hasValidVisualMetrics || abs(observed - estimatedRowsPerLogicalLine) > 0.05 {
             estimatedRowsPerLogicalLine = VirtualEditorVisualRowIndex.scrollExtentEstimate(
                 previous: estimatedRowsPerLogicalLine,
                 observed: observed,
-                measurementIsComplete: measurement.isComplete
+                measurementIsComplete: measurement.isComplete || !hasValidVisualMetrics
             )
+            hasValidVisualMetrics = true
             visualRowsSnapshot = nil
         }
         contentWidth = max(viewportSize.width, 1)
@@ -1003,6 +1009,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     override var acceptsFirstResponder: Bool { true }
     override var undoManager: UndoManager? { documentUndoManager }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+    override func isAccessibilityElement() -> Bool { true }
     override func accessibilityRole() -> NSAccessibility.Role? { .textArea }
     override func accessibilityLabel() -> String? { accessibilityContext.label }
     override func accessibilityValue() -> Any? { viewportText }
@@ -1252,6 +1259,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         }
         guard key != lastConfigurationKey else { return }
         lastConfigurationKey = key
+        hasValidVisualMetrics = false
         configuredContentRevision = contentRevision
         configuredExternalContentRevision = externalContentRevision
         viewport = nil
@@ -1280,10 +1288,12 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     }
 
     override func draw(_ dirtyRect: NSRect) {
-        if let documentID {
-            EditorPerformanceMonitor.shared.markTabSwitchFirstDraw(tabID: documentID)
-        }
         guard let context = NSGraphicsContext.current?.cgContext else { return }
+        defer {
+            if let documentID {
+                EditorPerformanceMonitor.shared.markTabSwitchFirstDraw(tabID: documentID)
+            }
+        }
         context.saveGState()
         context.clip(to: dirtyRect)
         defer { context.restoreGState() }
@@ -1447,7 +1457,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
             String(configuredExternalContentRevision ?? 0),
             String(viewportLineOrigin),
             String(Int((availableWidth * 2).rounded())),
-            String(Int((bounds.maxY * 2).rounded())),
+            String(Int(((enclosingScrollView?.contentView.bounds.maxY ?? viewportSize.height) * 2).rounded())),
             String(Int((lineHeight * 100).rounded()))
         ].joined(separator: "|")
         if let visualRowsSnapshot, visualRowsSnapshot.key == snapshotKey {
@@ -1461,7 +1471,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         )
         for viewportLine in viewportLines {
             let estimatedBaseline = baseline
-            let viewportMaxY = bounds.maxY + lineHeight * 2
+            let viewportMaxY = (enclosingScrollView?.contentView.bounds.maxY ?? viewportSize.height) + lineHeight * 2
             if estimatedBaseline > viewportMaxY {
                 break
             }
@@ -1971,6 +1981,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
             absoluteCaret = location + value.utf16.count
             selection = NSRange(location: absoluteCaret, length: 0)
             selectionAnchor = nil
+            reloadViewport(anchorLine: lineForAbsoluteOffset(absoluteCaret), maximumByteCount: editRefreshMaximumByteCount)
             publishCaret()
             publishTextChange()
             return true
@@ -1990,10 +2001,12 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
             range: NSRange(location: absoluteRange.location, length: value.utf16.count),
             inverseReplacement: value
         )
-        absoluteCaret = selection.location + value.utf16.count
+        absoluteCaret = absoluteRange.location + value.utf16.count
         selection = NSRange(location: absoluteCaret, length: 0)
         selectionAnchor = nil
-        _ = document
+        // The next native key event can arrive before SwiftUI configures again.
+        // Refresh byte/UTF-16 coordinates before publishing or accepting input.
+        reloadViewport(anchorLine: lineForAbsoluteOffset(absoluteRange.location), maximumByteCount: editRefreshMaximumByteCount)
         publishCaret()
         publishTextChange()
         return true
@@ -2079,6 +2092,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         absoluteCaret = location + replacement.utf16.count
         selection = NSRange(location: absoluteCaret, length: 0)
         selectionAnchor = nil
+        reloadViewport(anchorLine: lineForAbsoluteOffset(location), maximumByteCount: editRefreshMaximumByteCount)
         publishCaret()
         publishTextChange()
     }
@@ -2345,7 +2359,8 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private func reloadViewport(anchorLine: Int, maximumByteCount: Int? = nil) {
         guard let document, let next = try? document.viewport(
             aroundLine: max(0, anchorLine),
-            maximumByteCount: maximumByteCount ?? viewportMaximumByteCount
+            maximumByteCount: maximumByteCount ?? viewportMaximumByteCount,
+            maximumLineCount: 512
         ) else { return }
         if let documentID {
             EditorPerformanceMonitor.shared.markViewportLoaded(tabID: documentID)

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -1016,6 +1016,12 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     override func accessibilityHelp() -> String? { accessibilityContext.help }
 
     private var accessibilityContext: VirtualEditorAccessibilityContext {
+        if (absoluteCaret < viewportLineOriginStartUTF16 || absoluteCaret > viewportLineOriginStartUTF16 + viewportText.utf16.count),
+           let position = try? document?.position(atUTF16Offset: absoluteCaret) {
+            return VirtualEditorAccessibilityContext(
+                documentName: documentDisplayName, line: position.line + 1,
+                column: position.column + 1, isReadOnly: isReadOnly, selectionLength: selection.length)
+        }
         let localCaret = max(0, min(viewportText.utf16.count, absoluteCaret - viewportLineOriginStartUTF16))
         let localLine = newlineCount(inUTF16PrefixOf: viewportText, length: localCaret)
         let lineStart = lineStarts[min(localLine, max(0, lineStarts.count - 1))]
@@ -1191,7 +1197,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         if offset >= viewportLineOriginStartUTF16 && offset <= viewportLineOriginStartUTF16 + viewportText.utf16.count {
             return viewportLineOrigin + newlineCount(inUTF16PrefixOf: viewportText, length: offset - viewportLineOriginStartUTF16)
         }
-        return min(document.lineCount - 1, max(0, Int(Double(offset) / Double(max(1, document.utf16Length)) * Double(document.lineCount))))
+        return (try? document.position(atUTF16Offset: offset).line) ?? 0
     }
 
     func configure(
@@ -1285,6 +1291,14 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         recalculateVisualMetrics()
         setFrameSize(NSSize(width: contentWidth, height: logicalHeight))
         needsDisplay = true
+        if isNewDocument {
+            // Publish after the representable update so the status bar reflects
+            // the selected document without mutating SwiftUI during configure.
+            Task { @MainActor [weak self] in
+                guard let self, self.documentID == documentID else { return }
+                self.publishCaret()
+            }
+        }
     }
 
     override func draw(_ dirtyRect: NSRect) {

--- a/Neon Vision EditorTests/EditorViewModelFileOpenTests.swift
+++ b/Neon Vision EditorTests/EditorViewModelFileOpenTests.swift
@@ -147,6 +147,86 @@ final class EditorViewModelFileOpenTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedTab?.id, loadedTab.id)
     }
 
+    func testHiddenClearDialogDoesNotProjectDocumentContent() {
+        var projectedContent = false
+        let hidden = ContentView.clearEditorPreviewDescription(isPresented: false) {
+            projectedContent = true
+            return "unused"
+        }
+        XCTAssertFalse(projectedContent)
+        XCTAssertEqual(hidden, "")
+        XCTAssertEqual(ContentView.clearEditorPreviewDescription(isPresented: true) { "😀\nx" },
+            "This will remove 3 characters across 2 lines in the current editor. You can undo this change.")
+    }
+
+    func testLargeMarkdownActivationKeepsMainActorResponsive() async throws {
+        // Measure opening in a ready app, independently of the host's deferred
+        // startup diagnostics and their persisted launch markers.
+        let launchDeadline = Date().addingTimeInterval(20)
+        while RuntimeReliabilityMonitor.shared.diagnosticSnapshot().lastLaunchPhase != "launchCompleted",
+              Date() < launchDeadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        let url = temporaryDirectoryURL.appendingPathComponent("responsive-markdown.md")
+        let line = "## Title **bold** `code` [link](https://example.com) 😀 café "
+            + String(repeating: "Markdown text ", count: 8) + "\n"
+        try String(repeating: line, count: 220_000).write(to: url, atomically: true, encoding: .utf8)
+        let viewModel = EditorViewModel()
+        viewModel.resetTabsForSessionRestore()
+        let heartbeat = Task { @MainActor () -> TimeInterval in
+            var previous = ProcessInfo.processInfo.systemUptime
+            var longestGap: TimeInterval = 0
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+                let now = ProcessInfo.processInfo.systemUptime
+                longestGap = max(longestGap, now - previous)
+                previous = now
+            }
+            return longestGap
+        }
+        defer { heartbeat.cancel() }
+        await Task.yield()
+        let start = ProcessInfo.processInfo.systemUptime
+        XCTAssertTrue(viewModel.openFile(url: url))
+        _ = try await waitForLoadedTab(in: viewModel, matching: url, timeout: 20)
+        let elapsed = ProcessInfo.processInfo.systemUptime - start
+        try await Task.sleep(nanoseconds: 20_000_000)
+        heartbeat.cancel()
+        let longestGap = await heartbeat.value
+        print("LARGE_MARKDOWN_ACTIVATION elapsed_ms=\(elapsed * 1000) main_gap_ms=\(longestGap * 1000)")
+        XCTAssertLessThan(longestGap, 0.25, "File activation must not monopolize the main actor")
+        await EditorPreferenceWriter.shared.flush()
+    }
+
+    func testLargeMarkdownOpenAndReloadPrepareIndexOffMainThread() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("large-markdown.md")
+        let line = "## Heading **bold** `code`\n"
+        let source = String(repeating: line, count: 220_000)
+        try source.write(to: url, atomically: true, encoding: .utf8)
+        let viewModel = EditorViewModel()
+        viewModel.resetTabsForSessionRestore()
+        XCTAssertTrue(viewModel.openFile(url: url))
+        let tab = try await waitForLoadedTab(in: viewModel, matching: url, timeout: 20)
+        XCTAssertTrue(tab.usesFileBackedStorage)
+        XCTAssertFalse(tab.isReadOnlyPreview)
+        XCTAssertEqual(tab.language, "markdown")
+        XCTAssertEqual(tab.fileBackedDocument?.viewportIndexPreparedOnMainThread, false)
+
+        // The same ownership handoff must hold for external refreshes as well.
+        let revision = tab.externalContentRevision
+        try (source + "tail").write(to: url, atomically: true, encoding: .utf8)
+        viewModel.handleObservedLocalFileChange(at: url)
+        let started = Date()
+        while tab.externalContentRevision == revision, Date().timeIntervalSince(started) < 10 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertGreaterThan(tab.externalContentRevision, revision)
+        XCTAssertTrue(try XCTUnwrap(tab.fileBackedDocument).isViewportIndexReady)
+        XCTAssertEqual(tab.fileBackedDocument?.viewportIndexPreparedOnMainThread, false)
+        let lastViewport = try tab.document.viewport(aroundLine: 220_000, maximumByteCount: 64 * 1024)
+        XCTAssertTrue(lastViewport.text.hasSuffix("tail"))
+    }
+
     func testSupportedTextExtensionMatrixOpensTenAndFiftyMegabytesBounded() async throws {
         let extensions = [
             "swift", "py", "pyi", "js", "mjs", "cjs", "ts", "tsx", "php", "phtml",
@@ -688,10 +768,11 @@ final class EditorViewModelFileOpenTests: XCTestCase {
     private func waitForLoadedTab(
         in viewModel: EditorViewModel,
         matching url: URL,
-        requireDirty: Bool? = nil
+        requireDirty: Bool? = nil,
+        timeout: TimeInterval = 5
     ) async throws -> TabData {
-        let timeout = Date().addingTimeInterval(5)
-        while Date() < timeout {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
             if let tab = viewModel.selectedTab,
                tab.fileURL?.standardizedFileURL == url.standardizedFileURL,
                !tab.isLoadingContent,

--- a/Neon Vision EditorTests/FileBackedTextDocumentTests.swift
+++ b/Neon Vision EditorTests/FileBackedTextDocumentTests.swift
@@ -15,6 +15,83 @@ final class FileBackedTextDocumentTests: XCTestCase {
         try? FileManager.default.removeItem(at: directory)
     }
 
+    func testBoundedEncodingProbeAcceptsOnlyValidTruncatedUTF8() {
+        for scalar in ["é", "ह", "😀"] {
+            let bytes = Array(scalar.utf8)
+            for length in 1..<bytes.count {
+                let prefix = Data("Markdown ".utf8) + Data(bytes.prefix(length))
+                XCTAssertEqual(FileBackedTextDocument.boundedEncoding(from: prefix,
+                    allowsIncompleteUTF8Sequence: true), .utf8)
+                XCTAssertNotEqual(FileBackedTextDocument.boundedEncoding(from: prefix), .utf8)
+            }
+        }
+        for tail in [[UInt8(0xFF)], [0x80], [0xE0, 0x80], [0xED, 0xA0], [0xF4, 0x90], [0xF0, 0x28]] {
+            XCTAssertNotEqual(FileBackedTextDocument.boundedEncoding(from: Data("abc".utf8) + Data(tail),
+                allowsIncompleteUTF8Sequence: true), .utf8)
+        }
+    }
+
+    func testViewportByteBoundariesAndUTF16EditsPreserveUnicode() throws {
+        let source = "abc😀हé" + String(repeating: "x", count: 100) + "\nnext"
+        for identifier in [TextEncodingDescriptor.Identifier.utf8, .utf8WithBOM,
+                           .utf16LittleEndianWithBOM, .utf16BigEndianWithBOM] {
+            let encoding = TextEncodingDescriptor(identifier: identifier)
+            let url = directory.appendingPathComponent("boundary-\(identifier).md")
+            try XCTUnwrap(encoding.encodedData(for: source)).write(to: url)
+            for lazy in [true, false] {
+                let document = try lazy ? FileBackedTextDocument(url: url, knownEncoding: encoding)
+                    : FileBackedTextDocument(content: source, encoding: encoding)
+                try document.prepareViewportIndex()
+                for budget in 8...24 {
+                    let viewport = try document.viewport(aroundLine: 0, maximumByteCount: budget)
+                    XCTAssertTrue(source.hasPrefix(viewport.text))
+                    XCTAssertLessThanOrEqual(try XCTUnwrap(encoding.encodedData(for: viewport.text)).count, budget)
+                }
+                try document.replace(utf16Range: NSRange(location: 5, length: 1), with: "Y")
+                XCTAssertEqual(document.string(), source.replacingOccurrences(of: "ह", with: "Y"))
+                XCTAssertEqual(document.utf16Length, source.utf16.count)
+                try document.replace(utf16Range: NSRange(location: 6, length: 1), with: "Z")
+                XCTAssertEqual(document.string(), source.replacingOccurrences(of: "हé", with: "YZ"))
+            }
+        }
+    }
+
+    func testPreparedDenseMarkdownIndexAndLineBoundedViewportsRemainExactAfterEditing() throws {
+        let source = String(repeating: "# x\n", count: 220_000)
+        let url = directory.appendingPathComponent("dense.md")
+        try source.write(to: url, atomically: true, encoding: .utf8)
+        let document = try FileBackedTextDocument(url: url, knownEncoding: .utf8)
+        try document.prepareViewportIndex()
+        XCTAssertEqual(document.lineCount, 220_001)
+        for edited in [false, true] {
+            if edited { try document.replace(utf16Range: NSRange(location: 440_002, length: 1), with: "Y") }
+            for anchor in [0, 110_000, 219_999, 220_000, 0] {
+                let viewport = try document.viewport(aroundLine: anchor, maximumByteCount: 256_000, maximumLineCount: 512)
+                XCTAssertTrue(viewport.lineRange.contains(anchor))
+                XCTAssertLessThanOrEqual(viewport.lineRange.count, 512)
+                XCTAssertLessThanOrEqual(viewport.text.utf8.count, 2048)
+                XCTAssertEqual(viewport.startUTF16Offset, viewport.startByteOffset)
+            }
+        }
+        XCTAssertTrue(try document.viewport(aroundLine: 110_000, maximumByteCount: 64).text.contains("Y"))
+        XCTAssertThrowsError(try document.viewport(aroundLine: 0, maximumByteCount: 10, maximumLineCount: 0))
+    }
+
+    func testFailedSaveAsPreservesOriginalAndUnsavedEdits() throws {
+        let url = directory.appendingPathComponent("source.md")
+        try "original\n".write(to: url, atomically: true, encoding: .utf8)
+        let document = try FileBackedTextDocument(url: url)
+        try document.replace(utf16Range: NSRange(location: 0, length: 8), with: "edited")
+        let unavailable = directory.appendingPathComponent("missing/target.md")
+        XCTAssertThrowsError(try document.saveAtomically(to: unavailable))
+        XCTAssertTrue(document.isDirty)
+        XCTAssertEqual(document.string(), "edited\n")
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "original\n")
+        try document.saveAtomically()
+        XCTAssertFalse(document.isDirty)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "edited\n")
+    }
+
     func testIndexesAndReadsOnlyRequestedLinesFromUTF8File() throws {
         let url = directory.appendingPathComponent("large.txt")
         try "zero\none\ntwo\nthree\n".write(to: url, atomically: true, encoding: .utf8)
@@ -215,8 +292,9 @@ final class FileBackedTextDocumentTests: XCTestCase {
             XCTAssertEqual(error as? FileBackedTextDocument.Error, .externalConflict)
         }
 
-        try XCTUnwrap(encoding.encodedData(for: source)).write(to: url)
-        try document.saveAtomically()
+        // Restoring bytes does not restore the original modification date.
+        // Overwriting a file changed externally must remain an explicit choice.
+        try document.saveAtomically(allowExternalOverwrite: true)
         let saved = try Data(contentsOf: url)
         XCTAssertEqual(Array(saved.prefix(2)), [0xFF, 0xFE])
         XCTAssertTrue(encoding.decode(saved)?.contains("utf16-20000 🚀") == true)
@@ -266,6 +344,37 @@ final class FileBackedTextDocumentTests: XCTestCase {
                 )
             } catch {
                 XCTFail("bounded viewport failed for \(encoding.identifier.rawValue): \(error)")
+            }
+        }
+    }
+
+    func testSegmentedIndexPreservesCoordinatesAcrossSupportedEncodings() throws {
+        for identifier in TextEncodingDescriptor.Identifier.allCases {
+            let encoding = TextEncodingDescriptor(identifier: identifier)
+            let isUnicode = identifier.rawValue.hasPrefix("utf")
+            // Both halves of a UTF-16 unit can contain 0x0A without being LF.
+            let suffix = isUnicode ? "😀 ਁ䄊" : (identifier == .ascii ? "ASCII" : "é")
+            let line = "## Markdown **bold** `code` \(suffix)\r\n"
+            // CP1251 has Cyrillic rather than Latin accented letters.
+            let encodedLine = identifier == .windowsCP1251
+                ? line.replacingOccurrences(of: "é", with: "я") : line
+            let source = String(repeating: encodedLine, count: 20_000) + "tail"
+            let url = directory.appendingPathComponent("index-\(identifier.rawValue).md")
+            try XCTUnwrap(encoding.encodedData(for: source)).write(to: url)
+            let document = try FileBackedTextDocument(url: url, knownEncoding: encoding)
+            XCTAssertFalse(document.isViewportIndexReady, identifier.rawValue)
+            try document.prepareViewportIndex()
+            XCTAssertEqual(document.utf16Length, source.utf16.count, identifier.rawValue)
+            let bomBytes = try XCTUnwrap(encoding.encodedData(for: "")).count
+            let lineBytes = try XCTUnwrap(encoding.encodedData(for: encodedLine)).count - bomBytes
+            for anchor in [0, 8_000, 19_999, 20_000] {
+                let viewport = try document.viewport(aroundLine: anchor, maximumByteCount: lineBytes * 10 + (anchor == 0 ? bomBytes : 0))
+                let expectedOffset = encodedLine.utf16.count * viewport.lineRange.lowerBound
+                XCTAssertEqual(viewport.startUTF16Offset, expectedOffset, identifier.rawValue)
+                XCTAssertEqual(viewport.text, (source as NSString).substring(with: NSRange(location: expectedOffset, length: viewport.text.utf16.count)), identifier.rawValue)
+                let expectedPrefix = String(repeating: encodedLine, count: viewport.lineRange.lowerBound)
+                let expectedBytes = try XCTUnwrap(encoding.encodedData(for: expectedPrefix)).count
+                XCTAssertEqual(viewport.startByteOffset, expectedOffset == 0 ? 0 : expectedBytes, identifier.rawValue)
             }
         }
     }

--- a/Neon Vision EditorTests/FileBackedTextDocumentTests.swift
+++ b/Neon Vision EditorTests/FileBackedTextDocumentTests.swift
@@ -3,6 +3,53 @@ import XCTest
 
 @MainActor
 final class FileBackedTextDocumentTests: XCTestCase {
+    func testLogicalPositionsAreExactAcrossUnicodeStorageAndEdits() throws {
+        for identifier in [TextEncodingDescriptor.Identifier.utf8, .utf8WithBOM, .utf16LittleEndianWithBOM, .utf16BigEndian] {
+            let encoding = TextEncodingDescriptor(identifier: identifier)
+            let text = String(repeating: "é😀", count: 1_000) + "\ntarget\n"
+            let url = directory.appendingPathComponent("positions.md")
+            try XCTUnwrap(encoding.encodedData(for: text)).write(to: url)
+            let document = try FileBackedTextDocument(url: url, knownEncoding: encoding)
+            for edited in [false, true] {
+                if edited { try document.replace(utf16Range: NSRange(location: 0, length: 0), with: "x") }
+                let lineStart = 3_001 + (edited ? 1 : 0)
+                let position = try document.position(atUTF16Offset: lineStart + 2)
+                XCTAssertEqual(position.line, 1)
+                XCTAssertEqual(position.column, 2)
+                XCTAssertEqual(try document.position(atUTF16Offset: 0).line, 0)
+                let end = try document.position(atUTF16Offset: document.utf16Length)
+                XCTAssertEqual(end.line, 2)
+                XCTAssertEqual(end.column, 0)
+                XCTAssertThrowsError(try document.position(atUTF16Offset: -1))
+                XCTAssertThrowsError(try document.position(atUTF16Offset: document.utf16Length + 1))
+            }
+        }
+        let empty = FileBackedTextDocument(content: "")
+        XCTAssertEqual(try empty.position(atUTF16Offset: 0).column, 0)
+    }
+
+    func testViewportReadsDoNotInvalidateOtherEditorsButMutationsDo() throws {
+        for lazy in [false, true] {
+            let source = "first 😀\nsecond é\nthird\n"
+            let url = directory.appendingPathComponent("shared-viewport.md")
+            try source.write(to: url, atomically: true, encoding: .utf8)
+            let document = try lazy
+                ? FileBackedTextDocument(url: url, knownEncoding: .utf8)
+                : FileBackedTextDocument(content: source)
+            try document.prepareViewportIndex()
+            let first = try document.viewport(aroundLine: 0, maximumByteCount: 64)
+            let other = try document.viewport(aroundLine: 2, maximumByteCount: 32)
+            XCTAssertEqual(first.generation, other.generation)
+            try document.replace(in: first, utf16Range: NSRange(location: 0, length: 5), with: "updated")
+            XCTAssertEqual(document.string(), "updated 😀\nsecond é\nthird\n")
+            XCTAssertThrowsError(try document.replace(in: other, utf16Range: NSRange(location: 0, length: 0), with: "stale"))
+            let refreshed = try document.viewport(aroundLine: 0, maximumByteCount: 64)
+            XCTAssertNotEqual(refreshed.generation, first.generation)
+            try document.replace(in: refreshed, utf16Range: NSRange(location: 0, length: 7), with: "current")
+            XCTAssertEqual(document.string(), "current 😀\nsecond é\nthird\n")
+        }
+    }
+
     nonisolated(unsafe) private var directory: URL!
 
     override func setUpWithError() throws {
@@ -158,7 +205,8 @@ final class FileBackedTextDocumentTests: XCTestCase {
         let document = try FileBackedTextDocument(url: url)
 
         let first = try document.viewport(aroundLine: 10, maximumByteCount: 64)
-        _ = try document.viewport(aroundLine: 80, maximumByteCount: 64)
+        let second = try document.viewport(aroundLine: 80, maximumByteCount: 64)
+        try document.replace(in: second, utf16Range: NSRange(location: 0, length: 1), with: "Y")
 
         XCTAssertThrowsError(try document.replace(in: first, utf16Range: NSRange(location: 0, length: 1), with: "X"))
     }

--- a/Neon Vision EditorTests/RecentFilesStoreTests.swift
+++ b/Neon Vision EditorTests/RecentFilesStoreTests.swift
@@ -25,7 +25,7 @@ final class RecentFilesStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testRememberOrdersMostRecentFirst() throws {
+    func testRememberOrdersMostRecentFirst() async throws {
         let first = try makeFile(named: "first.txt")
         let second = try makeFile(named: "second.txt")
 
@@ -33,10 +33,11 @@ final class RecentFilesStoreTests: XCTestCase {
         RecentFilesStore.remember(second, defaults: defaults)
 
         XCTAssertEqual(RecentFilesStore.items(limit: 10, defaults: defaults).map(\.title), ["second.txt", "first.txt"])
+        await EditorPreferenceWriter.shared.flush()
     }
 
     @MainActor
-    func testPinnedItemsStayAtTop() throws {
+    func testPinnedItemsStayAtTop() async throws {
         let first = try makeFile(named: "first.txt")
         let second = try makeFile(named: "second.txt")
         let third = try makeFile(named: "third.txt")
@@ -49,10 +50,11 @@ final class RecentFilesStoreTests: XCTestCase {
         let items = RecentFilesStore.items(limit: 10, defaults: defaults)
         XCTAssertEqual(items.map(\.title), ["first.txt", "third.txt", "second.txt"])
         XCTAssertEqual(items.first?.isPinned, true)
+        await EditorPreferenceWriter.shared.flush()
     }
 
     @MainActor
-    func testClearUnpinnedRetainsPinnedItems() throws {
+    func testClearUnpinnedRetainsPinnedItems() async throws {
         let pinned = try makeFile(named: "pinned.txt")
         let unpinned = try makeFile(named: "unpinned.txt")
 
@@ -62,11 +64,91 @@ final class RecentFilesStoreTests: XCTestCase {
         RecentFilesStore.clearUnpinned(defaults: defaults)
 
         XCTAssertEqual(RecentFilesStore.items(limit: 10, defaults: defaults).map(\.title), ["pinned.txt"])
+        await EditorPreferenceWriter.shared.flush()
+    }
+
+    @MainActor
+    func testQueuedPreferencesPreserveMutationOrderAndImmediateReads() async throws {
+        let first = try makeFile(named: "first.txt")
+        let second = try makeFile(named: "second.txt")
+        RecentFilesStore.remember(first, defaults: defaults)
+        RecentFilesStore.togglePinned(first, defaults: defaults)
+        RecentFilesStore.remember(second, defaults: defaults)
+        RecentFilesStore.clearUnpinned(defaults: defaults)
+        XCTAssertEqual(RecentFilesStore.items(defaults: defaults).map(\.url), [first])
+        EditorPreferenceWriter.shared.flushBeforeTermination()
+        XCTAssertNil(defaults.object(forKey: "RecentFilesPathsV1"))
+        XCTAssertEqual(defaults.stringArray(forKey: "PinnedRecentFilesPathsV1"), [first.path])
+        let bookmarks = defaults.dictionary(forKey: "RecentFilesBookmarksV1") ?? [:]
+        XCTAssertNil(bookmarks[second.path])
+    }
+
+    @MainActor
+    func testPerformanceEventsRemainOrderedWhenClearedDuringPersistence() async {
+        let monitor = EditorPerformanceMonitor(defaults: defaults)
+        for _ in 0..<35 {
+            let id = UUID()
+            monitor.beginFileOpen(tabID: id)
+            monitor.endFileOpen(tabID: id, success: true, byteCount: 1)
+            monitor.beginTabSwitch(tabID: id)
+            monitor.markTabSwitchFirstDraw(tabID: id)
+        }
+        XCTAssertEqual(monitor.recentFileOpenEvents(limit: 100).count, 30)
+        XCTAssertEqual(monitor.recentTabSwitchEvents(limit: 100).count, 30)
+        monitor.clearRecentFileOpenEvents()
+        monitor.clearRecentTabSwitchEvents()
+        XCTAssertTrue(monitor.recentFileOpenEvents().isEmpty)
+        XCTAssertTrue(monitor.recentTabSwitchEvents().isEmpty)
+        let id = UUID()
+        monitor.beginFileOpen(tabID: id)
+        monitor.endFileOpen(tabID: id, success: false, byteCount: 42)
+        await EditorPreferenceWriter.shared.flush()
+        let persisted = EditorPerformanceMonitor(defaults: defaults)
+        XCTAssertEqual(persisted.recentFileOpenEvents().count, 1)
+        XCTAssertEqual(persisted.recentFileOpenEvents().first?.byteCount, 42)
+        XCTAssertNil(defaults.data(forKey: "PerformanceRecentTabSwitchEventsV1"))
+    }
+
+    @MainActor
+    func testRapidPreferenceUpdatesCoalesceAndPersistTheLatestValue() async {
+        let counter = PreferenceWriteCounter()
+        let releaseFirstWrite = DispatchSemaphore(value: 0)
+        let observer = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification, object: defaults, queue: nil
+        ) { _ in
+            counter.increment()
+            if counter.count == 1 { _ = releaseFirstWrite.wait(timeout: .now() + 5) }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+        for index in 0..<100 {
+            EditorPreferenceWriter.shared.set(.paths([String(index)]), forKey: "coalesced", defaults: defaults)
+        }
+        XCTAssertEqual(EditorPreferenceWriter.shared.object(forKey: "coalesced", defaults: defaults) as? [String], ["99"])
+        releaseFirstWrite.signal()
+        await EditorPreferenceWriter.shared.flush()
+        XCTAssertEqual(defaults.stringArray(forKey: "coalesced"), ["99"])
+        XCTAssertGreaterThan(counter.count, 0)
+        XCTAssertLessThanOrEqual(counter.count, 2)
     }
 
     private func makeFile(named name: String) throws -> URL {
         let url = temporaryDirectoryURL.appendingPathComponent(name)
         try "sample".write(to: url, atomically: true, encoding: .utf8)
         return url
+    }
+}
+
+private nonisolated final class PreferenceWriteCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+    }
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
     }
 }

--- a/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
+++ b/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
@@ -4,6 +4,173 @@ import XCTest
 
 @MainActor
 final class VirtualEditorLayoutTests: XCTestCase {
+    func testDenseMarkdownCanvasBoundsLayoutAcrossScrollAndEdit() throws {
+        let source = String(repeating: "# x\n", count: 220_000)
+        for wraps in [true, false] {
+            let document = FileBackedTextDocument(content: source)
+            let documentID = UUID()
+            let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+            let canvas = VirtualEditorCanvas(frame: scrollView.bounds)
+            scrollView.documentView = canvas
+            _ = canvas.setViewportSize(scrollView.contentSize)
+            let started = ProcessInfo.processInfo.systemUptime
+            canvas.configure(
+                document: document,
+                documentID: documentID,
+                resourceID: "dense-markdown-regression",
+                displayName: "Architecture.md",
+                contentRevision: 0,
+                externalContentRevision: 0,
+                caret: 0,
+                language: "markdown",
+                colorScheme: .light,
+                fontSize: 14,
+                fontName: "",
+                lineHeightMultiplier: 1,
+                isReadOnly: false,
+                translucentBackgroundEnabled: false,
+                showsLineNumbers: true,
+                highlightCurrentLine: false,
+                lineWrapEnabled: wraps,
+                showsInvisibleCharacters: false,
+                showsIndentationGuides: false,
+                showsScopeGuides: false,
+                highlightsScopeBackground: false,
+                highlightsMatchingBrackets: false,
+                autoIndentEnabled: true,
+                autoCloseBracketsEnabled: false,
+                onFontSizeChange: nil,
+                onTextMutation: { mutation in
+                    do {
+                        if let viewport = mutation.viewport {
+                            try document.replace(in: viewport, utf16Range: mutation.range, with: mutation.replacement)
+                        } else {
+                            try document.replace(utf16Range: mutation.range, with: mutation.replacement)
+                        }
+                        return true
+                    } catch { return false }
+                }
+            )
+            canvas.setFrameSize(NSSize(width: 800, height: canvas.logicalHeight))
+            let bitmap = try XCTUnwrap(NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: 800,
+                pixelsHigh: 600, bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true,
+                isPlanar: false, colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0))
+            let context = try XCTUnwrap(NSGraphicsContext(bitmapImageRep: bitmap))
+            for fraction: CGFloat in [0, 0.5, 1, 0] {
+                let y = max(0, canvas.logicalHeight - 600) * fraction
+                scrollView.contentView.scroll(to: NSPoint(x: 0, y: y))
+                canvas.reloadViewportIfNeeded(scrollY: y)
+                let visibleText = try XCTUnwrap(canvas.accessibilityValue() as? String)
+                XCTAssertLessThanOrEqual(visibleText.utf8.count, 2048)
+                NSGraphicsContext.saveGraphicsState()
+                NSGraphicsContext.current = context
+                canvas.draw(NSRect(x: 0, y: y, width: 800, height: 600))
+                NSGraphicsContext.restoreGraphicsState()
+            }
+            let elapsed = (ProcessInfo.processInfo.systemUptime - started) * 1000
+            print("DENSE_MARKDOWN_CANVAS wraps=\(wraps) configure_draw_scroll_ms=\(elapsed)")
+            canvas.insertText("Y", replacementRange: NSRange(location: 2, length: 1))
+            XCTAssertTrue(document.string().hasPrefix("# Y\n"))
+            canvas.undoManager?.undo()
+            XCTAssertTrue(document.string().hasPrefix("# x\n"))
+            // Native input can deliver several edits before SwiftUI configures again.
+            for character in "NVE_SAVE_CHECK" {
+                canvas.insertText(String(character), replacementRange: NSRange(location: NSNotFound, length: 0))
+            }
+            XCTAssertTrue(document.string().hasPrefix("# xNVE_SAVE_CHECK\n"))
+            XCTAssertEqual(canvas.selectedRange(), NSRange(location: 17, length: 0))
+            XCTAssertTrue(canvas.accessibilityHelp()?.contains("Line 1, column 18") == true)
+            canvas.insertText("😀", replacementRange: NSRange(location: NSNotFound, length: 0))
+            canvas.insertText("é", replacementRange: NSRange(location: NSNotFound, length: 0))
+            XCTAssertTrue(document.string().hasPrefix("# xNVE_SAVE_CHECK😀é\n"))
+            XCTAssertTrue(canvas.isAccessibilityElement())
+            XCTAssertEqual(canvas.accessibilityRole(), .textArea)
+            XCTAssertTrue(canvas.acceptsFirstResponder)
+        }
+    }
+
+    func testScrollContainerDoesNotRetainMeasurementsFromAnUnallocatedWidth() throws {
+        let text = String(repeating: "Markdown text ", count: 12)
+        let document = FileBackedTextDocument(content: String(repeating: text + "\n", count: 2_000))
+        let documentID = UUID()
+        let scrollView = VirtualEditorScrollView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let canvas = try XCTUnwrap(scrollView.documentView as? VirtualEditorCanvas)
+        for width: CGFloat in [800, 440, 1000] {
+            scrollView.setFrameSize(NSSize(width: width, height: 600))
+            scrollView.configure(
+                document: document,
+                documentID: documentID,
+                resourceID: "dense-markdown-regression",
+                displayName: "Architecture.md",
+                contentRevision: 0,
+                externalContentRevision: 0,
+                caret: 0,
+                language: "markdown",
+                colorScheme: .light,
+                fontSize: 14,
+                fontName: "",
+                lineHeightMultiplier: 1,
+                isReadOnly: false,
+                translucentBackgroundEnabled: false,
+                showsLineNumbers: true,
+                highlightCurrentLine: false,
+                lineWrapEnabled: true,
+                showsInvisibleCharacters: false,
+                showsIndentationGuides: false,
+                showsScopeGuides: false,
+                highlightsScopeBackground: false,
+                highlightsMatchingBrackets: false,
+                autoIndentEnabled: true,
+                autoCloseBracketsEnabled: false,
+                isSplitPaneResizeInProgress: false,
+                onFontSizeChange: nil,
+                onTextMutation: { mutation in
+                    do {
+                        if let viewport = mutation.viewport {
+                            try document.replace(in: viewport, utf16Range: mutation.range, with: mutation.replacement)
+                        } else {
+                            try document.replace(utf16Range: mutation.range, with: mutation.replacement)
+                        }
+                        return true
+                    } catch { return false }
+                }
+            )
+            let font = NSFont.monospacedSystemFont(ofSize: 14, weight: .regular)
+            let gutter = max(44, CGFloat(document.lineCount.description.count) * 14 * 0.7 + 18)
+            let fragments = VirtualEditorVisualLayout.fragments(
+                for: NSAttributedString(string: text, attributes: [.font: font]), lineStartUTF16: 0,
+                width: scrollView.contentView.bounds.width - gutter - 16, wraps: true)
+            let rowHeight = font.ascender - font.descender + font.leading + 4
+            let expectedHeight = CGFloat(document.lineCount * fragments.count) * rowHeight + 16
+            XCTAssertLessThan(canvas.logicalHeight, expectedHeight * 1.05)
+            XCTAssertGreaterThan(canvas.logicalHeight, expectedHeight * 0.95)
+            let y = max(0, canvas.logicalHeight - 600) * 0.5
+            scrollView.contentView.scroll(to: NSPoint(x: 0, y: y))
+            XCTAssertGreaterThan(canvas.viewportLineOrigin, 0)
+            let bitmap = try XCTUnwrap(NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: Int(width),
+                pixelsHigh: 600, bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true,
+                isPlanar: false, colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0))
+            let context = try XCTUnwrap(NSGraphicsContext(bitmapImageRep: bitmap))
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = context
+            let visible = scrollView.contentView.bounds
+            context.cgContext.translateBy(x: 0, y: -visible.minY)
+            canvas.draw(visible)
+            NSGraphicsContext.restoreGraphicsState()
+            var textPixels = 0
+            for pixelY in stride(from: 0, to: 600, by: 4) {
+                for pixelX in stride(from: 80, to: Int(width), by: 4) {
+                    if let color = bitmap.colorAt(x: pixelX, y: pixelY)?.usingColorSpace(.deviceRGB),
+                       color.alphaComponent > 0.5,
+                       min(color.redComponent, color.greenComponent, color.blueComponent) < 0.8 {
+                        textPixels += 1
+                    }
+                }
+            }
+            XCTAssertGreaterThan(textPixels, 100, "A scroll jump must render visible text, not a blank viewport")
+        }
+    }
+
     func testAccessibilityContextIncludesDocumentPositionEditabilityAndSelection() {
         let context = VirtualEditorAccessibilityContext(
             documentName: "Notes.md",

--- a/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
+++ b/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
@@ -86,6 +86,17 @@ final class VirtualEditorLayoutTests: XCTestCase {
             XCTAssertTrue(canvas.isAccessibilityElement())
             XCTAssertEqual(canvas.accessibilityRole(), .textArea)
             XCTAssertTrue(canvas.acceptsFirstResponder)
+            // Find/navigation offsets must not be estimated from average line lengths.
+            let uneven = String(repeating: "x", count: 300_000) + "\ntarget\n" + String(repeating: "z\n", count: 1_000)
+            try document.replaceAll(with: uneven)
+            NotificationCenter.default.post(name: .moveCursorToRange, object: nil, userInfo: [
+                EditorCommandUserInfo.documentID: documentID.uuidString,
+                EditorCommandUserInfo.rangeLocation: 300_001,
+                EditorCommandUserInfo.rangeLength: 6,
+                EditorCommandUserInfo.centerSelection: true
+            ])
+            XCTAssertEqual(canvas.selectedRange(), NSRange(location: 300_001, length: 6))
+            XCTAssertTrue(canvas.accessibilityHelp()?.contains("Line 2, column 1") == true)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -481,11 +481,11 @@ flowchart TB
   MAC --> DIST
   TOUCH --> DIST
 
-  classDef platform stroke:#2563EB,stroke-width:3px,fill:transparent,font-family:ui-monospace\, SFMono-Regular\, Menlo\, Monaco\, Consolas\, Liberation Mono\, monospace,font-size:13px;
-  classDef app stroke:#059669,stroke-width:3px,fill:transparent,font-family:ui-monospace\, SFMono-Regular\, Menlo\, Monaco\, Consolas\, Liberation Mono\, monospace,font-size:13px;
-  classDef core stroke:#EA580C,stroke-width:3px,fill:transparent,font-family:ui-monospace\, SFMono-Regular\, Menlo\, Monaco\, Consolas\, Liberation Mono\, monospace,font-size:13px;
-  classDef infra stroke:#9333EA,stroke-width:3px,fill:transparent,font-family:ui-monospace\, SFMono-Regular\, Menlo\, Monaco\, Consolas\, Liberation Mono\, monospace,font-size:13px;
-  classDef distribution stroke:#DB2777,stroke-width:3px,fill:transparent,font-family:ui-monospace\, SFMono-Regular\, Menlo\, Monaco\, Consolas\, Liberation Mono\, monospace,font-size:13px;
+  classDef platform stroke:#2563EB,stroke-width:3px,fill:transparent;
+  classDef app stroke:#059669,stroke-width:3px,fill:transparent;
+  classDef core stroke:#EA580C,stroke-width:3px,fill:transparent;
+  classDef infra stroke:#9333EA,stroke-width:3px,fill:transparent;
+  classDef distribution stroke:#DB2777,stroke-width:3px,fill:transparent;
 
   class MAC,TOUCH platform;
   class ACTIONS,VM,COMMANDS,REVISIONS app;


### PR DESCRIPTION
Large Markdown source files could block opening and scrolling, drop consecutive native edits, and fail sandboxed saves. This change prepares indexes off the main actor, bounds rendering and viewport work, coalesces preference writes, preserves Unicode coordinates, and uses the system replacement directory for atomic saves.

The release audit also fixes two independent correctness gaps: reading a second viewport no longer invalidates another editor's unchanged content, and navigation uses exact indexed positions instead of average line-length estimates. The source canvas now exposes accessibility information and publishes the selected document's caret state.

Validation: 413-test full macOS baseline passed; 38 document and 44 canvas tests passed after the audit corrections. New regressions demonstrated failures before the fixes. Prior live testing verified 220,001-line Markdown scrolling, exact rapid typing, save, Undo/Redo, and keyboard navigation. iOS Simulator build passed; release gating and remote signed/notarized packaging follow integration.

## Summary by Sourcery

Improve large-file editing reliability and responsiveness while preserving exact document coordinates, safe persistence, and accessible source editing.

New Features:
- Add native macOS HEX color previews and color editing support in the source editor.
- Expose the source canvas as an accessibility text area and publish exact caret state for the selected document.

Bug Fixes:
- Fix large-file opening, scrolling, viewport rendering, consecutive native edits, Unicode coordinate handling, navigation, independent viewport validity, and sandboxed atomic saves.
- Prevent hidden confirmation dialogs and stale visual metrics from triggering unnecessary whole-document or incorrect layout work.

Enhancements:
- Prepare large-file indexes off the main actor and bound viewport rendering by byte and line limits.
- Coalesce recent-file and performance-history preference writes while preserving immediate reads and flushing on termination.

Documentation:
- Document the v1.6.0 large-file editing, color preview, persistence, Unicode, accessibility, and save reliability improvements in the changelog.

Tests:
- Add regression coverage for large-file responsiveness, bounded dense-document rendering, Unicode positions and viewport boundaries, exact navigation, atomic save failures, preference write coalescing, and accessibility behavior.

Chores:
- Simplify Mermaid diagram styling in the README for broader rendering compatibility.