### PR TITLE
Fix visionOS archive compilation

### DIFF
--- a/Neon Vision Editor/UI/CodeSnapshotComposerView.swift
+++ b/Neon Vision Editor/UI/CodeSnapshotComposerView.swift
@@ -532,8 +532,10 @@ struct CodeSnapshotComposerView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+#endif
+#if os(iOS)
     @AppStorage("EnableTranslucentWindow") private var translucentWindow = true
 #else
     @AppStorage("EnableTranslucentWindow") private var translucentWindow = false

--- a/Neon Vision Editor/UI/EditorTextView+iOS.swift
+++ b/Neon Vision Editor/UI/EditorTextView+iOS.swift
@@ -1967,7 +1967,9 @@ struct CustomTextEditor: UIViewRepresentable {
         )
         textView.setBracketAccessoryVisible(showKeyboardAccessoryBar)
         configurePointerSelectionBehavior(textView)
+#if os(iOS)
         textView.installPencilInputIfNeeded()
+#endif
         context.coordinator.installFontSizePinchRecognizer(on: textView)
         let shouldWrapText = isLineWrapEnabled && !isLargeFileMode
         applyWrapMode(shouldWrapText, textView: textView, preserveOffset: false)

--- a/scripts/ci/build_platform_matrix.sh
+++ b/scripts/ci/build_platform_matrix.sh
@@ -22,6 +22,7 @@ Runs build verification sequentially for:
   1) macOS
   2) iOS Simulator
   3) iPad Simulator target family
+  4) visionOS
 
 Environment overrides:
   PROJECT, SCHEME, CONFIGURATION, CODE_SIGNING_ALLOWED
@@ -151,6 +152,11 @@ run_build "iPad Simulator" \
   -sdk iphonesimulator \
   -destination "generic/platform=iOS Simulator" \
   TARGETED_DEVICE_FAMILY=2 \
+  build
+
+run_build "visionOS" \
+  -sdk xros \
+  -destination "generic/platform=visionOS" \
   build
 
 echo "Build matrix completed successfully."


### PR DESCRIPTION
The visionOS archive failed because the shared snapshot composer referenced an environment property declared only on iOS, and the shared UIKit editor called an iOS-only Pencil installer.

Declare the size-class property on visionOS and restrict Pencil installation to iOS. Add visionOS to the normal platform matrix so these compiler errors cannot escape the gate again. Existing iOS/macOS behavior and translucency defaults are preserved.

Validation: reproduced both exact errors before the fix (archive exit 65); the corrected unsigned visionOS Release archive passed. The expanded macOS, iPhone Simulator, iPad Simulator, and visionOS build matrix passed. Shell syntax and diff checks passed. Local validation used Xcode 27 beta; Xcode Cloud signing and distribution require a new run from the fixed commit.

## Summary by Sourcery

Restore visionOS archive builds and extend platform validation to cover visionOS.

Bug Fixes:
- Fix visionOS archive compilation by making shared UI code compatible with visionOS and limiting Pencil input setup to iOS.

CI:
- Add visionOS to the standard platform build matrix to prevent platform-specific compiler regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visionOS support for the code snapshot composer and text editor.
  * Added visionOS to the platform verification build matrix.

* **Bug Fixes**
  * Prevented iOS-only Apple Pencil input setup from running on visionOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->