### PR TITLE
Fix visionOS support purchases and product loading

### DIFF
--- a/Neon Vision Editor/Data/SupportPurchaseManager.swift
+++ b/Neon Vision Editor/Data/SupportPurchaseManager.swift
@@ -19,11 +19,20 @@ final class SupportPurchaseManager: ObservableObject {
     @Published var statusMessage: String?
 
     private var transactionUpdatesTask: Task<Void, Never>?
-    private var lastStoreStateRefreshAt: Date?
+    private var productLoadTask: Task<Void, Never>?
+    private let loadProducts: @MainActor () async throws -> [Product]
+    private let canMakePayments: @MainActor () -> Bool
     private let storeStateFreshnessInterval: TimeInterval = 300
     private let productLookupAttempts = 3
 
-    init() {
+    init(
+        loadProducts: @escaping @MainActor () async throws -> [Product] = {
+            try await Product.products(for: [SupportPurchaseManager.supportProductID])
+        },
+        canMakePayments: @escaping @MainActor () -> Bool = { AppStore.canMakePayments }
+    ) {
+        self.loadProducts = loadProducts
+        self.canMakePayments = canMakePayments
         transactionUpdatesTask = observeTransactionUpdates()
     }
 
@@ -67,18 +76,15 @@ final class SupportPurchaseManager: ObservableObject {
 
     // Refreshes StoreKit capability and product metadata.
     func refreshStoreState() async {
-        guard !isLoadingProducts else { return }
-        lastStoreStateRefreshAt = Date()
-        isLoadingProducts = true
-        await refreshBypassEligibility()
-        await loadSupportProduct(showStatusOnFailure: false)
+        refreshPurchaseAvailability()
+        await refreshProducts(showStatusOnFailure: false)
     }
 
     // Refreshes only when the cached StoreKit state is stale or unavailable.
     func refreshStoreStateIfStale() async {
-        guard !isLoadingProducts else { return }
-        if let lastStoreStateRefreshAt,
-           Date().timeIntervalSince(lastStoreStateRefreshAt) < storeStateFreshnessInterval {
+        refreshPurchaseAvailability()
+        if supportProduct != nil, let lastSuccessfulPriceRefreshAt,
+           Date().timeIntervalSince(lastSuccessfulPriceRefreshAt) < storeStateFreshnessInterval {
             return
         }
         await refreshStoreState()
@@ -86,9 +92,19 @@ final class SupportPurchaseManager: ObservableObject {
 
     // Loads support product metadata from App Store.
     func refreshProducts(showStatusOnFailure: Bool = true) async {
-        guard !isLoadingProducts else { return }
+        if let productLoadTask {
+            await productLoadTask.value
+            return
+        }
         isLoadingProducts = true
-        await loadSupportProduct(showStatusOnFailure: showStatusOnFailure)
+        // Keep a shared lookup alive when a settings view disappears. All
+        // callers, including purchases, await the same metadata request.
+        let task = Task {
+            await loadSupportProduct(showStatusOnFailure: showStatusOnFailure)
+        }
+        productLoadTask = task
+        await task.value
+        productLoadTask = nil
     }
 
     private func loadSupportProduct(showStatusOnFailure: Bool) async {
@@ -106,13 +122,15 @@ final class SupportPurchaseManager: ObservableObject {
             }
 
             do {
-                let products = try await Product.products(for: [Self.supportProductID])
+                let products = try await loadProducts()
                 if let product = products.first(where: { $0.id == Self.supportProductID }) {
                     supportProduct = product
                     lastSuccessfulPriceRefreshAt = Date()
                     statusMessage = nil
                     return
                 }
+            } catch is CancellationError {
+                return
             } catch {
                 lastLookupError = error
                 continue
@@ -136,21 +154,17 @@ final class SupportPurchaseManager: ObservableObject {
 
     // Refreshes in-app purchase availability and product pricing for settings UI.
     func refreshPrice() async {
-        guard !isLoadingProducts else { return }
         statusMessage = nil
-        isLoadingProducts = true
-        await refreshBypassEligibility()
-        await loadSupportProduct(showStatusOnFailure: true)
+        refreshPurchaseAvailability()
+        await refreshProducts(showStatusOnFailure: true)
     }
 
     // Starts purchase flow for the optional support product.
-    func purchaseSupport() async {
-        #if os(visionOS)
-        statusMessage = NSLocalizedString("Support purchase is currently unavailable on visionOS.", comment: "")
-        return
-        #else
+    func purchaseSupport(using purchase: @MainActor (Product) async throws -> Product.PurchaseResult) async {
         // Prevent overlapping StoreKit purchase flows that can race and surface misleading cancel states.
         guard !isPurchasing else { return }
+        isPurchasing = true
+        defer { isPurchasing = false }
         if !hasCheckedStoreAvailability {
             await refreshStoreState()
         }
@@ -168,11 +182,8 @@ final class SupportPurchaseManager: ObservableObject {
 
         statusMessage = nil
         let hadSupportedBeforeAttempt = hasSupported
-        isPurchasing = true
-        defer { isPurchasing = false }
-
         do {
-            let result = try await product.purchase()
+            let result = try await purchase(product)
             switch result {
             case .success(let verificationResult):
                 let transaction = try verify(verificationResult)
@@ -205,39 +216,21 @@ final class SupportPurchaseManager: ObservableObject {
                 statusMessage = String(format: format, error.localizedDescription, details)
             }
         }
-        #endif
     }
 
     // Detects whether this device can use in-app purchases.
-    private func refreshBypassEligibility() async {
-        defer { hasCheckedStoreAvailability = true }
-        #if os(iOS) || os(macOS)
-        canUseInAppPurchases = AppStore.canMakePayments
-        #else
-        canUseInAppPurchases = false
-        #endif
-        do {
-            let appTransactionResult = try await AppTransaction.shared
-            switch appTransactionResult {
-            case .verified:
-                break
-            case .unverified:
-                canUseInAppPurchases = AppStore.canMakePayments
-            }
-        } catch {
-            #if os(iOS) || os(macOS)
-            canUseInAppPurchases = AppStore.canMakePayments
-            #else
-            canUseInAppPurchases = false
-            #endif
-        }
+    private func refreshPurchaseAvailability() {
+        // Optional consumable tips have no app-receipt entitlement prerequisite.
+        // Product lookup must not wait for AppTransaction.shared to resolve.
+        canUseInAppPurchases = canMakePayments()
+        hasCheckedStoreAvailability = true
     }
 
     // Listens for transaction updates and applies verified changes.
     private func observeTransactionUpdates() -> Task<Void, Never> {
         Task { [weak self] in
-            guard let self else { return }
             for await result in Transaction.updates {
+                guard let self else { return }
                 do {
                     let transaction = try self.verify(result)
                     await transaction.finish()

--- a/Neon Vision Editor/UI/NeonSettingsView.swift
+++ b/Neon Vision Editor/UI/NeonSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import StoreKit
 import UniformTypeIdentifiers
 #if os(macOS)
 import AppKit
@@ -42,6 +43,7 @@ struct NeonSettingsView: View {
     let supportsOpenInTabs: Bool
     let supportsTranslucency: Bool
     @Environment(EditorViewModel.self) private var editorViewModel
+    @Environment(\.purchase) private var purchase
     @EnvironmentObject private var supportPurchaseManager: SupportPurchaseManager
     @EnvironmentObject private var appUpdateManager: AppUpdateManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -1329,6 +1331,8 @@ struct NeonSettingsView: View {
             #if os(visionOS)
             if newValue == "ai" {
                 loadAPITokensIfNeeded()
+            } else if newValue == "support" {
+                refreshSupportStoreStateIfNeeded()
             }
 #elseif os(iOS)
             if newValue == "toolbar" || newValue == "templates" || newValue == "more" {
@@ -1369,7 +1373,7 @@ struct NeonSettingsView: View {
         content
         .confirmationDialog("Support Neon Vision Editor", isPresented: $showSupportPurchaseDialog, titleVisibility: .visible) {
             Button(supportPurchaseManager.supportTipDialogButtonTitle) {
-                Task { await supportPurchaseManager.purchaseSupport() }
+                Task { await supportPurchaseManager.purchaseSupport { product in try await purchase(product) } }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -5801,7 +5805,7 @@ struct NeonSettingsView: View {
         SettingsFlowLayout(spacing: UI.space10, rowSpacing: UI.space8) {
             Button(supportPurchaseManager.isPurchasing ? localized("Purchasing…") : supportPurchaseManager.supportPurchaseButtonTitle) {
                 guard supportPurchaseManager.canUseInAppPurchases else {
-                    Task { await supportPurchaseManager.purchaseSupport() }
+                    Task { await supportPurchaseManager.purchaseSupport { product in try await purchase(product) } }
                     return
                 }
                 guard supportPurchaseManager.supportProduct != nil else {

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import StoreKit
 import Foundation
 import UniformTypeIdentifiers
 #if os(macOS)
@@ -2669,6 +2670,7 @@ private final class DirectionalKeyCommandView: UIView {
 struct WelcomeTourView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openURL) private var openURL
+    @Environment(\.purchase) private var purchase
     @EnvironmentObject private var supportPurchaseManager: SupportPurchaseManager
 
     static var releaseID: String {
@@ -3647,7 +3649,7 @@ struct WelcomeTourView: View {
             HStack {
                 Spacer()
                 Button {
-                    Task { await supportPurchaseManager.purchaseSupport() }
+                    Task { await supportPurchaseManager.purchaseSupport { product in try await purchase(product) } }
                 } label: {
                     HStack(spacing: compactLayout ? 8 : 10) {
                         Image(systemName: "heart.fill")
@@ -3846,6 +3848,7 @@ struct WelcomeTourView: View {
 struct SupportPromptSheetView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openURL) private var openURL
+    @Environment(\.purchase) private var purchase
     @EnvironmentObject private var supportPurchaseManager: SupportPurchaseManager
     let onDismiss: () -> Void
 
@@ -3923,7 +3926,7 @@ struct SupportPromptSheetView: View {
 
                 VStack(spacing: compact ? 8 : 10) {
                     Button {
-                        Task { await supportPurchaseManager.purchaseSupport() }
+                        Task { await supportPurchaseManager.purchaseSupport { product in try await purchase(product) } }
                     } label: {
                         Label(supportPurchaseManager.supportPurchaseButtonTitle, systemImage: "heart.fill")
                             .frame(maxWidth: .infinity)

--- a/Neon Vision EditorTests/SupportPurchaseManagerTests.swift
+++ b/Neon Vision EditorTests/SupportPurchaseManagerTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+import StoreKit
+import StoreKitTest
+@testable import Neon_Vision_Editor
+
+@MainActor
+final class SupportPurchaseManagerTests: XCTestCase {
+    private func makeSession() throws -> SKTestSession {
+        let configuration = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("Neon Vision Editor/SupportOptional.storekit")
+        let session = try SKTestSession(contentsOf: configuration)
+        session.resetToDefaultState()
+        session.disableDialogs = true
+        session.clearTransactions()
+        return session
+    }
+
+    func testLocalStoreKitLoadsPriceAndCompletesConsumablePurchase() async throws {
+        let session = try makeSession()
+        defer { session.clearTransactions() }
+        let manager = SupportPurchaseManager(canMakePayments: { true })
+        await manager.refreshStoreState()
+        let product = try XCTUnwrap(manager.supportProduct)
+        XCTAssertEqual(product.id, SupportPurchaseManager.supportProductID)
+        XCTAssertEqual(manager.availableSupportPriceLabel, product.displayPrice)
+        XCTAssertFalse(manager.shouldShowPriceRetry)
+        await manager.purchaseSupport { try await $0.purchase() }
+        XCTAssertTrue(manager.hasSupported)
+        XCTAssertFalse(manager.isPurchasing)
+    }
+
+    func testFailedLookupDoesNotSuppressNextSupportVisit() async {
+        var attempts = 0
+        let manager = SupportPurchaseManager(loadProducts: {
+            attempts += 1
+            return []
+        }, canMakePayments: { true })
+        await manager.refreshStoreStateIfStale()
+        let initialAttempts = attempts
+        XCTAssertGreaterThan(initialAttempts, 0)
+        XCTAssertTrue(manager.shouldShowPriceRetry)
+        XCTAssertNil(manager.lastSuccessfulPriceRefreshAt)
+        await manager.refreshStoreStateIfStale()
+        XCTAssertGreaterThan(attempts, initialAttempts)
+        XCTAssertFalse(manager.isLoadingProducts)
+    }
+
+    func testRestrictedPaymentsStillLoadMetadataAndNeverPurchase() async throws {
+        let session = try makeSession()
+        defer { session.clearTransactions() }
+        let manager = SupportPurchaseManager(canMakePayments: { false })
+        await manager.refreshStoreState()
+        XCTAssertNotNil(manager.supportProduct)
+        XCTAssertTrue(manager.shouldShowStoreUnavailableMessage)
+        await manager.purchaseSupport { _ in
+            XCTFail("A restricted account must not enter the payment sheet")
+            return .pending
+        }
+        XCTAssertFalse(manager.isPurchasing)
+    }
+
+    func testPurchaseWaitsForSharedLookupAndRejectsOverlappingPurchase() async throws {
+        let session = try makeSession()
+        defer { session.clearTransactions() }
+        let products = try await Product.products(for: [SupportPurchaseManager.supportProductID])
+        XCTAssertFalse(products.isEmpty)
+        var resumeLookup: CheckedContinuation<Void, Never>?
+        var lookups = 0
+        var purchases = 0
+        let started = expectation(description: "Product request started")
+        let manager = SupportPurchaseManager(loadProducts: {
+            lookups += 1
+            await withCheckedContinuation { continuation in
+                resumeLookup = continuation
+                started.fulfill()
+            }
+            return products
+        }, canMakePayments: { true })
+        let refresh = Task { await manager.refreshStoreState() }
+        await fulfillment(of: [started], timeout: 2)
+        let purchase = Task {
+            await manager.purchaseSupport { _ in
+                purchases += 1
+                return .pending
+            }
+        }
+        // Yield until the purchase owns its guard, while lookup remains suspended.
+        for _ in 0..<100 where !manager.isPurchasing { await Task.yield() }
+        XCTAssertTrue(manager.isPurchasing)
+        XCTAssertEqual(purchases, 0)
+        await manager.purchaseSupport { _ in
+            XCTFail("Overlapping purchase must not enter StoreKit")
+            return .pending
+        }
+        resumeLookup?.resume()
+        await refresh.value
+        await purchase.value
+        XCTAssertEqual(lookups, 1)
+        XCTAssertEqual(purchases, 1)
+        XCTAssertFalse(manager.isLoadingProducts)
+        XCTAssertFalse(manager.isPurchasing)
+    }
+
+    func testSuccessfulPriceSurvivesFailedRefreshAndFreshCacheSkipsLookup() async throws {
+        let session = try makeSession()
+        defer { session.clearTransactions() }
+        let products = try await Product.products(for: [SupportPurchaseManager.supportProductID])
+        var lookups = 0
+        let manager = SupportPurchaseManager(loadProducts: {
+            lookups += 1
+            return lookups == 1 ? products : []
+        }, canMakePayments: { true })
+        await manager.refreshStoreState()
+        let price = try XCTUnwrap(manager.availableSupportPriceLabel)
+        await manager.refreshStoreStateIfStale()
+        XCTAssertEqual(lookups, 1)
+        await manager.refreshPrice()
+        XCTAssertEqual(manager.availableSupportPriceLabel, price)
+        XCTAssertNil(manager.statusMessage)
+    }
+
+    func testCancelledLookupResetsLoadingAndCanBeRetried() async {
+        var lookups = 0
+        let manager = SupportPurchaseManager(loadProducts: {
+            lookups += 1
+            throw CancellationError()
+        }, canMakePayments: { true })
+        await manager.refreshStoreState()
+        XCTAssertFalse(manager.isLoadingProducts)
+        XCTAssertNil(manager.statusMessage)
+        await manager.refreshStoreStateIfStale()
+        XCTAssertEqual(lookups, 2)
+    }
+
+    func testTransactionObserverDoesNotRetainManager() async {
+        weak var releasedManager: SupportPurchaseManager?
+        do {
+            let manager = SupportPurchaseManager(loadProducts: { [] }, canMakePayments: { true })
+            releasedManager = manager
+            await Task.yield()
+        }
+        XCTAssertNil(releasedManager)
+    }
+}

--- a/docs/AppStoreReviewNotes.md
+++ b/docs/AppStoreReviewNotes.md
@@ -35,4 +35,8 @@
 ## Test Notes
 - Local StoreKit config file included at:
   - `Neon Vision Editor/SupportOptional.storekit`
-- Use a Sandbox account or local StoreKit testing for verification.
+- Local StoreKit tests verify loading and purchase state transitions, but do not verify App Store Connect or App Review sandbox availability.
+- Before resubmitting, use a TestFlight build on iPhone and Apple Vision Pro to open Settings -> Support, confirm the localized price loads, and complete a sandbox support tip. Also check the welcome/support prompt purchase entry points.
+- For an Xcode-launched sandbox check, set the Run action's StoreKit Configuration to None; the shared schemes use the local configuration by default. TestFlight always uses Apple's sandbox.
+- A failed or interrupted lookup must recover when revisiting Support or selecting Retry App Store. Successful prices may be cached for five minutes.
+- visionOS purchases use the presenting SwiftUI view's StoreKit purchase action so the system can anchor purchase confirmation to the correct window.

--- a/scripts/ci/storekit_configuration_audit.sh
+++ b/scripts/ci/storekit_configuration_audit.sh
@@ -26,7 +26,7 @@ display_price="$(plutil -extract products.0.displayPrice raw "$STOREKIT_FILE")"
 grep -Fq "static let supportProductID = \"$EXPECTED_PRODUCT_ID\"" "$PURCHASE_MANAGER_FILE" || \
   fail "SupportPurchaseManager product ID does not match the StoreKit configuration."
 
-python3 - "$SETTINGS_FILE" <<'PY'
+python3 - "$SETTINGS_FILE" "$PURCHASE_MANAGER_FILE" <<'PY'
 import pathlib
 import sys
 
@@ -38,6 +38,12 @@ handler = source.split(anchor, 1)[1].split('.onChange(of: moreSectionTab)', 1)[0
 ios_branch = handler.split('#elseif os(iOS)', 1)[1].split('#else', 1)[0]
 if 'newValue == "support"' not in ios_branch or 'refreshSupportStoreStateIfNeeded()' not in ios_branch:
     raise SystemExit("error: Selecting Support on iOS must refresh StoreKit state.")
+vision_branch = handler.split('#if os(visionOS)', 1)[1].split('#elseif', 1)[0]
+if 'newValue == "support"' not in vision_branch or 'refreshSupportStoreStateIfNeeded()' not in vision_branch:
+    raise SystemExit("error: Selecting Support on visionOS must refresh StoreKit state.")
+manager = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+if 'Support purchase is currently unavailable on visionOS.' in manager:
+    raise SystemExit("error: Support purchases must not be disabled on visionOS.")
 PY
 
 for scheme in \


### PR DESCRIPTION
The visionOS Support tab displayed purchase controls but did not refresh products when selected, and the purchase manager unconditionally rejected visionOS purchases. Use the presenting view's StoreKit purchase action across Settings, the welcome tour, and the support prompt.

Product loading no longer waits for an unrelated app-receipt lookup. Concurrent callers await one metadata request, failed lookups do not suppress the next Support visit for five minutes, and duplicate purchase attempts are blocked before any suspension. Existing localized prices and verified transaction handling are preserved.

Validation:
- Seven focused XCTest cases passed, including a local StoreKit consumable purchase, failed-load recovery, payment restrictions, shared in-flight lookup, duplicate purchase prevention, cached-price preservation, cancellation recovery, and observer lifetime.
- StoreKit configuration audit failed on the original visionOS refresh path and passes after the fix.
- App Store scheme build matrix passed for macOS, iPhone Simulator, iPad Simulator and visionOS. GitHub is independently checking the committed branch.
- Live App Store Connect: product `002420160` is approved and available in all countries/regions; Paid Apps Agreement is active. No catalog changes were needed.

Local StoreKit tests do not establish Apple sandbox success. A replacement TestFlight build still needs an iPhone and Apple Vision Pro purchase check before resubmission.

## Summary by Sourcery

Restore reliable support product loading and purchases across visionOS and other purchase entry points.

Bug Fixes:
- Enable support purchases on visionOS through the presenting view’s StoreKit purchase action.
- Refresh support product metadata when the visionOS Support section is selected.
- Allow failed or cancelled product lookups to recover on subsequent visits without losing previously cached prices.

Enhancements:
- Coordinate concurrent product requests through a shared in-flight lookup and prevent overlapping purchase attempts.
- Decouple product metadata loading from app-receipt availability checks while preserving payment restrictions and transaction verification.

CI:
- Extend the StoreKit configuration audit to validate visionOS support refresh behavior and purchase availability.

Documentation:
- Document sandbox validation requirements and recovery behavior for support purchases across iPhone and Apple Vision Pro.

Tests:
- Add focused StoreKit tests covering product loading, purchase completion, restricted payments, concurrent lookups, duplicate purchases, price caching, cancellation recovery, and observer lifetime.