### PR TITLE
Improve external sync and welcome launch behavior

### DIFF
--- a/Neon Vision Editor/App/NeonVisionEditorApp.swift
+++ b/Neon Vision Editor/App/NeonVisionEditorApp.swift
@@ -128,7 +128,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 let target = WindowViewModelRegistry.shared.activeViewModel() ?? self.viewModel
                 if let target {
-                    if target.openFile(url: fileURL) {
+                    if target.openFileFromExternalRequest(url: fileURL) {
                         self.bringEditorWindowToFront(for: target)
                     }
                 } else {
@@ -175,7 +175,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let urls = pendingOpenURLs
         pendingOpenURLs.removeAll()
         let didOpenFile = urls.reduce(false) { didOpen, url in
-            let opened = viewModel.openFile(url: url)
+            let opened = viewModel.openFileFromExternalRequest(url: url)
             return didOpen || opened
         }
         if didOpenFile {

--- a/Neon Vision Editor/Data/EditorViewModel.swift
+++ b/Neon Vision Editor/Data/EditorViewModel.swift
@@ -735,6 +735,7 @@ class EditorViewModel {
     private static let deferredLanguageDetectionUTF16Length = 180_000
     private static let deferredLanguageDetectionDelayNanos: UInt64 = 220_000_000
     private static let deferredLanguageDetectionSampleUTF16Length = 180_000
+    private static let networkVolumePollingIntervalNanos: UInt64 = 3_000_000_000
 
     // MARK: - Observable State and Indexes
 
@@ -744,6 +745,7 @@ class EditorViewModel {
     private(set) var pendingEncodingReopen: PendingEncodingReopen?
     private(set) var externalFileRefreshStatus: ExternalFileRefreshStatus?
     private(set) var recentExternalSyncChanges: [ExternalSyncChange] = []
+    private(set) var hasReceivedExternalFileOpenRequest: Bool = false
     var pendingRemoteSaveIssue: RemoteSaveIssueState?
     var fileEncodingErrorMessage: String?
     var showSidebar: Bool = true
@@ -758,6 +760,8 @@ class EditorViewModel {
     @ObservationIgnored private var refreshedExternalTabIDs: Set<UUID> = []
     @ObservationIgnored private var reviewExternalTabIDs: Set<UUID> = []
     @ObservationIgnored private var externalRefreshStatusClearTask: Task<Void, Never>?
+    @ObservationIgnored private var networkVolumePollingTask: Task<Void, Never>?
+    @ObservationIgnored private var networkVolumePollingCandidatePaths: Set<String> = []
     @ObservationIgnored private lazy var openDocumentObservationCenter = OpenDocumentObservationCenter { [weak self] url in
         Task { @MainActor [weak self] in
             self?.handleObservedLocalFileChange(at: url)
@@ -838,14 +842,14 @@ class EditorViewModel {
     ) {
         if rebuildIndexes {
             rebuildTabIndexes()
-            openDocumentObservationCenter.updateObservedURLs(
-                tabs.compactMap { tab in
-                    guard !tab.isRemoteDocument,
-                          let fileURL = tab.fileURL,
-                          fileURL.isFileURL else { return nil }
-                    return fileURL
-                }
-            )
+            let observedURLs: [URL] = tabs.compactMap { tab -> URL? in
+                guard !tab.isRemoteDocument,
+                      let fileURL = tab.fileURL,
+                      fileURL.isFileURL else { return nil }
+                return fileURL
+            }
+            openDocumentObservationCenter.updateObservedURLs(observedURLs)
+            updateNetworkVolumePolling(for: observedURLs)
         }
         if rebuildIndexes || change == .structure {
             tabStructureVersion &+= 1
@@ -2523,6 +2527,75 @@ class EditorViewModel {
         }
     }
 
+    private func updateNetworkVolumePolling(for urls: [URL]) {
+        let uniqueURLs = Dictionary(
+            urls.compactMap { url in
+                Self.normalizedFilePathKey(for: url).map { ($0, url.standardizedFileURL) }
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let candidatePaths = Set(uniqueURLs.keys)
+        guard candidatePaths != networkVolumePollingCandidatePaths else { return }
+
+        networkVolumePollingCandidatePaths = candidatePaths
+        networkVolumePollingTask?.cancel()
+        networkVolumePollingTask = nil
+        guard !uniqueURLs.isEmpty else { return }
+
+        let candidates = Array(uniqueURLs.values)
+        networkVolumePollingTask = Task { @MainActor [weak self] in
+            let polledURLs = await Task.detached(priority: .utility) {
+                candidates.filter { Self.requiresExternalChangePolling(at: $0) }
+            }.value
+            guard !Task.isCancelled, !polledURLs.isEmpty else { return }
+
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: Self.networkVolumePollingIntervalNanos)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled else { return }
+                _ = await self?.pollOpenDocumentsForExternalChanges(at: polledURLs)
+            }
+        }
+    }
+
+    @discardableResult
+    func pollOpenDocumentsForExternalChanges(at urls: [URL]) async -> [UUID] {
+        let uniqueURLs = Dictionary(
+            urls.compactMap { url in
+                Self.normalizedFilePathKey(for: url).map { ($0, url.standardizedFileURL) }
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let metadataByPath = await Task.detached(priority: .utility) {
+            uniqueURLs.reduce(into: [String: LocalFileMetadata]()) { result, entry in
+                if let metadata = Self.readLocalFileMetadata(at: entry.value) {
+                    result[entry.key] = metadata
+                }
+            }
+        }.value
+        guard !Task.isCancelled else { return [] }
+
+        var detectedTabIDs: [UUID] = []
+        for (path, metadata) in metadataByPath {
+            guard let tabID = tabIDByStandardizedFilePath[path],
+                  let index = tabIndex(for: tabID),
+                  !tabs[index].isLoadingContent,
+                  !reviewExternalTabIDs.contains(tabID),
+                  Self.hasLocalFileMetadataChanged(
+                      knownModificationDate: tabs[index].lastKnownFileModificationDate,
+                      knownByteCount: tabs[index].fileByteCount,
+                      current: metadata
+                  ),
+                  let fileURL = tabs[index].fileURL else { continue }
+            detectedTabIDs.append(tabID)
+            handleObservedLocalFileChange(at: fileURL)
+        }
+        return detectedTabIDs
+    }
+
     private func refreshObservedLocalFile(tabID: UUID, expectedURL: URL) async {
         guard !Task.isCancelled else { return }
         guard let initialIndex = tabIndex(for: tabID),
@@ -2642,6 +2715,17 @@ class EditorViewModel {
         )
     }
 
+    private nonisolated static func requiresExternalChangePolling(at url: URL) -> Bool {
+        let didStartScopedAccess = url.startAccessingSecurityScopedResource()
+        defer {
+            if didStartScopedAccess {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+        let values = try? url.resourceValues(forKeys: [.volumeIsLocalKey])
+        return values?.volumeIsLocal != true
+    }
+
     private nonisolated static func hasLocalFileMetadataChanged(
         knownModificationDate: Date?,
         knownByteCount: Int,
@@ -2654,6 +2738,12 @@ class EditorViewModel {
     }
 
     // MARK: - File Opening
+
+    @discardableResult
+    func openFileFromExternalRequest(url: URL) -> Bool {
+        hasReceivedExternalFileOpenRequest = true
+        return openFile(url: url)
+    }
 
     // Opens file-picker UI on macOS.
     func openFile() {

--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -874,6 +874,7 @@ struct ContentView: View {
 #endif
     @AppStorage("HasSeenWelcomeTourV1") var hasSeenWelcomeTourV1: Bool = false
     @AppStorage("WelcomeTourSeenRelease") var welcomeTourSeenRelease: String = ""
+    @AppStorage(SettingsPreferenceKey.showWelcomeTourAutomatically) var showWelcomeTourAutomatically: Bool = true
     @AppStorage("AppLaunchCountV1") var appLaunchCount: Int = 0
     @AppStorage("HasShownSupportPromptV1") var hasShownSupportPromptV1: Bool = false
     @AppStorage("SharedImportAccessAllowed") var sharedImportAccessAllowed: Bool = false
@@ -2827,7 +2828,12 @@ struct ContentView: View {
                 if ShareImportHandoff.isShareImportURL(url) {
                     handleSharedImportURL(url)
                 } else {
-                    viewModel.openFile(url: url)
+                    viewModel.openFileFromExternalRequest(url: url)
+                }
+            }
+            .onChange(of: viewModel.hasReceivedExternalFileOpenRequest) { _, receivedRequest in
+                if receivedRequest {
+                    showWelcomeTour = false
                 }
             }
 #if os(iOS) || os(visionOS)
@@ -2906,9 +2912,22 @@ struct ContentView: View {
         }
 
         applyWindowTranslucency(enableTranslucentWindow)
-        if !hasSeenWelcomeTourV1 || welcomeTourSeenRelease != WelcomeTourView.releaseID {
+        if WelcomeTourPresentationPolicy.shouldPresentAutomatically(
+            isEnabled: showWelcomeTourAutomatically,
+            isNormalLaunch: startupBehavior == .standard && !viewModel.hasReceivedExternalFileOpenRequest,
+            hasSeenTour: hasSeenWelcomeTourV1,
+            seenRelease: welcomeTourSeenRelease,
+            currentRelease: WelcomeTourView.releaseID
+        ) {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                guard canPresentStartupPrompt else { return }
+                guard canPresentStartupPrompt,
+                      WelcomeTourPresentationPolicy.shouldPresentAutomatically(
+                          isEnabled: showWelcomeTourAutomatically,
+                          isNormalLaunch: startupBehavior == .standard && !viewModel.hasReceivedExternalFileOpenRequest,
+                          hasSeenTour: hasSeenWelcomeTourV1,
+                          seenRelease: welcomeTourSeenRelease,
+                          currentRelease: WelcomeTourView.releaseID
+                      ) else { return }
                 showWelcomeTour = true
             }
         }

--- a/Neon Vision Editor/UI/NeonSettingsView.swift
+++ b/Neon Vision Editor/UI/NeonSettingsView.swift
@@ -76,6 +76,7 @@ struct NeonSettingsView: View {
     @AppStorage("SettingsReopenLastSession") private var reopenLastSession: Bool = true
     @AppStorage("SettingsOpenWithBlankDocument") private var openWithBlankDocument: Bool = true
     @AppStorage("SettingsShowRecentFilesOnEmptyDocuments") private var showRecentFilesOnEmptyDocuments: Bool = true
+    @AppStorage(SettingsPreferenceKey.showWelcomeTourAutomatically) private var showWelcomeTourAutomatically: Bool = true
     @AppStorage("SettingsShareImportsAutoOpen") private var shareImportsAutoOpen: Bool = true
 #if os(macOS)
     @AppStorage("SettingsShowMenuBarIconMac") private var showMenuBarIconMac: Bool = true
@@ -1784,6 +1785,8 @@ struct NeonSettingsView: View {
                     .disabled(reopenLastSession)
                 Toggle(localized("Reopen Last Session"), isOn: $reopenLastSession)
                 Toggle(localized("Show Recent Files on Empty Documents"), isOn: $showRecentFilesOnEmptyDocuments)
+                Toggle(localized("Show Welcome Tour Automatically"), isOn: $showWelcomeTourAutomatically)
+                    .accessibilityHint(localized("When disabled, the Welcome Tour remains available from the Help menu and toolbar."))
                 Toggle(localized("Automatically Open Shared Imports"), isOn: $shareImportsAutoOpen)
                     .accessibilityHint(localized("When disabled, shared files are saved to the import history without opening editor tabs immediately."))
                 Toggle(localized("Confirm Before Closing Dirty Tab"), isOn: $confirmCloseDirtyTab)
@@ -2454,6 +2457,8 @@ struct NeonSettingsView: View {
                 .disabled(reopenLastSession)
             Toggle(localized("Reopen Last Session"), isOn: $reopenLastSession)
             Toggle(localized("Show Recent Files on Empty Documents"), isOn: $showRecentFilesOnEmptyDocuments)
+            Toggle(localized("Show Welcome Tour Automatically"), isOn: $showWelcomeTourAutomatically)
+                .accessibilityHint(localized("When disabled, the Welcome Tour remains available from the Help menu and toolbar."))
             Toggle(localized("Automatically Open Shared Imports"), isOn: $shareImportsAutoOpen)
                 .accessibilityHint(localized("When disabled, shared files are saved to the import history without opening editor tabs immediately."))
             Toggle(localized("Confirm Before Closing Dirty Tab"), isOn: $confirmCloseDirtyTab)

--- a/Neon Vision Editor/UI/SettingsInfrastructure.swift
+++ b/Neon Vision Editor/UI/SettingsInfrastructure.swift
@@ -12,6 +12,7 @@ enum SettingsPreferenceKey {
     static let editorFontSize = "SettingsEditorFontSize"
     static let lineHeight = "SettingsLineHeight"
     static let letterSpacing = "SettingsLetterSpacing"
+    static let showWelcomeTourAutomatically = "SettingsShowWelcomeTourAutomatically"
     static let lineWrapEnabled = "SettingsLineWrapEnabled"
     static let pythonInterpreterPath = "SettingsPythonInterpreterPath"
     static let showLineNumbers = "SettingsShowLineNumbers"
@@ -35,6 +36,18 @@ enum SettingsPreferenceKey {
     static let markdownProjectPreviewPlacement = "MarkdownProjectPreviewPlacementV1"
     static let markdownProjectPreviewSortOrder = "MarkdownProjectPreviewSortOrderV1"
     static let markdownPreviewSynchronousScroll = "MarkdownPreviewSynchronousScrollV1"
+}
+
+enum WelcomeTourPresentationPolicy {
+    static func shouldPresentAutomatically(
+        isEnabled: Bool,
+        isNormalLaunch: Bool,
+        hasSeenTour: Bool,
+        seenRelease: String,
+        currentRelease: String
+    ) -> Bool {
+        isEnabled && isNormalLaunch && (!hasSeenTour || seenRelease != currentRelease)
+    }
 }
 
 enum EditorWritingAssistanceMode: String, CaseIterable, Identifiable {

--- a/Neon Vision Editor/de.lproj/Localizable.strings
+++ b/Neon Vision Editor/de.lproj/Localizable.strings
@@ -66,6 +66,8 @@
 "Open with Blank Document" = "Mit leerem Dokument öffnen";
 "Reopen Last Session" = "Letzte Sitzung wiederherstellen";
 "Show Recent Files on Empty Documents" = "Zuletzt verwendete Dateien in leeren Dokumenten anzeigen";
+"Show Welcome Tour Automatically" = "Willkommens-Tour automatisch anzeigen";
+"When disabled, the Welcome Tour remains available from the Help menu and toolbar." = "Wenn deaktiviert, bleibt die Willkommens-Tour über das Hilfe-Menü und die Symbolleiste verfügbar.";
 "Automatically Open Shared Imports" = "Geteilte Importe automatisch öffnen";
 "When disabled, shared files are saved to the import history without opening editor tabs immediately." = "Wenn deaktiviert, werden geteilte Dateien im Importverlauf gespeichert, ohne sofort Editor-Tabs zu öffnen.";
 "Translucency" = "Transluzenz";

--- a/Neon Vision Editor/en.lproj/Localizable.strings
+++ b/Neon Vision Editor/en.lproj/Localizable.strings
@@ -63,6 +63,8 @@
 "Open with Blank Document" = "Open with Blank Document";
 "Reopen Last Session" = "Reopen Last Session";
 "Show Recent Files on Empty Documents" = "Show Recent Files on Empty Documents";
+"Show Welcome Tour Automatically" = "Show Welcome Tour Automatically";
+"When disabled, the Welcome Tour remains available from the Help menu and toolbar." = "When disabled, the Welcome Tour remains available from the Help menu and toolbar.";
 "Automatically Open Shared Imports" = "Automatically Open Shared Imports";
 "When disabled, shared files are saved to the import history without opening editor tabs immediately." = "When disabled, shared files are saved to the import history without opening editor tabs immediately.";
 "Translucency" = "Translucency";

--- a/Neon Vision Editor/zh-Hans.lproj/Localizable.strings
+++ b/Neon Vision Editor/zh-Hans.lproj/Localizable.strings
@@ -37,6 +37,8 @@
 "Open with Blank Document" = "以空白文档启动";
 "Reopen Last Session" = "重新打开上次会话";
 "Show Recent Files on Empty Documents" = "在空白文档中显示最近使用的文件";
+"Show Welcome Tour Automatically" = "自动显示欢迎导览";
+"When disabled, the Welcome Tour remains available from the Help menu and toolbar." = "关闭后，仍可从“帮助”菜单和工具栏打开欢迎导览。";
 "Automatically Open Shared Imports" = "自动打开共享导入";
 "When disabled, shared files are saved to the import history without opening editor tabs immediately." = "停用后，共享文件会保存到导入历史记录，而不会立即打开编辑器标签页。";
 "Default New File Language" = "新文件默认语言";

--- a/Neon Vision EditorTests/EditorSettingsDefaultsTests.swift
+++ b/Neon Vision EditorTests/EditorSettingsDefaultsTests.swift
@@ -3,6 +3,54 @@ import XCTest
 
 @MainActor
 final class EditorSettingsDefaultsTests: XCTestCase {
+    func testWelcomeTourAutomaticPresentationCanBeDisabledPermanently() {
+        XCTAssertFalse(
+            WelcomeTourPresentationPolicy.shouldPresentAutomatically(
+                isEnabled: false,
+                isNormalLaunch: true,
+                hasSeenTour: false,
+                seenRelease: "",
+                currentRelease: "1.7.0"
+            )
+        )
+        XCTAssertFalse(
+            WelcomeTourPresentationPolicy.shouldPresentAutomatically(
+                isEnabled: false,
+                isNormalLaunch: true,
+                hasSeenTour: true,
+                seenRelease: "1.6.1",
+                currentRelease: "1.7.0"
+            )
+        )
+        XCTAssertTrue(
+            WelcomeTourPresentationPolicy.shouldPresentAutomatically(
+                isEnabled: true,
+                isNormalLaunch: true,
+                hasSeenTour: true,
+                seenRelease: "1.6.1",
+                currentRelease: "1.7.0"
+            )
+        )
+        XCTAssertFalse(
+            WelcomeTourPresentationPolicy.shouldPresentAutomatically(
+                isEnabled: true,
+                isNormalLaunch: true,
+                hasSeenTour: true,
+                seenRelease: "1.7.0",
+                currentRelease: "1.7.0"
+            )
+        )
+        XCTAssertFalse(
+            WelcomeTourPresentationPolicy.shouldPresentAutomatically(
+                isEnabled: true,
+                isNormalLaunch: false,
+                hasSeenTour: false,
+                seenRelease: "",
+                currentRelease: "1.7.0"
+            )
+        )
+    }
+
     func testFocusedObservationSnapshotsOnlyCompareOwnedState() {
         XCTAssertEqual(
             ContentView.TabChromeObservationSnapshot(structureRevision: 3, metadataRevision: 7),

--- a/Neon Vision EditorTests/EditorViewModelFileOpenTests.swift
+++ b/Neon Vision EditorTests/EditorViewModelFileOpenTests.swift
@@ -147,6 +147,18 @@ final class EditorViewModelFileOpenTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedTab?.id, loadedTab.id)
     }
 
+    func testExternalFileOpenRecordsNonstandardLaunchContext() throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("finder-open.md")
+        try "# Opened from Finder\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let viewModel = EditorViewModel()
+        viewModel.resetTabsForSessionRestore()
+        XCTAssertFalse(viewModel.hasReceivedExternalFileOpenRequest)
+
+        XCTAssertTrue(viewModel.openFileFromExternalRequest(url: url))
+        XCTAssertTrue(viewModel.hasReceivedExternalFileOpenRequest)
+    }
+
     func testHiddenClearDialogDoesNotProjectDocumentContent() {
         var projectedContent = false
         let hidden = ContentView.clearEditorPreviewDescription(isPresented: false) {
@@ -606,6 +618,34 @@ final class EditorViewModelFileOpenTests: XCTestCase {
         )
         XCTAssertEqual(refreshedAgainTab.externalContentRevision, 2)
         XCTAssertFalse(refreshedAgainTab.isDirty)
+    }
+
+    func testPollingFallbackDetectsExternalChangeWithoutWaitingForPresenterDelivery() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("polled-network-file.swift")
+        try "let value = 1\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let viewModel = EditorViewModel()
+        viewModel.resetTabsForSessionRestore()
+        XCTAssertTrue(viewModel.openFile(url: url))
+        let loadedTab = try await waitForLoadedTab(in: viewModel, matching: url)
+
+        let unchangedTabIDs = await viewModel.pollOpenDocumentsForExternalChanges(at: [url])
+        XCTAssertTrue(unchangedTabIDs.isEmpty)
+        XCTAssertNil(viewModel.externalFileRefreshStatus)
+
+        let changedContent = "let value = 2\nlet detectedByPolling = true\n"
+        try changedContent.write(to: url, atomically: true, encoding: .utf8)
+
+        let detectedTabIDs = await viewModel.pollOpenDocumentsForExternalChanges(at: [url])
+        XCTAssertEqual(detectedTabIDs, [loadedTab.id])
+
+        let refreshedTab = try await waitForTab(
+            in: viewModel,
+            tabID: loadedTab.id,
+            content: changedContent
+        )
+        XCTAssertEqual(refreshedTab.externalContentRevision, 1)
+        XCTAssertFalse(refreshedTab.isDirty)
     }
 
     func testUnavailableExternalFileDoesNotLeaveRefreshStatusPending() async throws {


### PR DESCRIPTION
## Summary
- add polling fallback for external changes on network-backed files
- add a permanent Welcome Tour automatic-presentation setting
- suppress the Welcome Tour for Finder and other external document launches
- add focused regression coverage and localized settings copy

## Verification
- focused file-open and settings regression tests passed
- macOS, iOS Simulator, iPad Simulator, and visionOS build matrix passed
- localization plist validation passed

## Summary by Sourcery

Improve external document synchronization and make Welcome Tour presentation configurable and appropriate to the launch context.

New Features:
- Add automatic polling to detect external modifications for open files on network-backed volumes.
- Add a persistent setting to control automatic Welcome Tour presentation.

Bug Fixes:
- Prevent the Welcome Tour from appearing when documents are opened through Finder or other external file requests.

Enhancements:
- Centralize Welcome Tour presentation rules based on launch context, release history, and user preference.

Documentation:
- Add localized settings text and accessibility guidance for the Welcome Tour preference.

Tests:
- Add regression coverage for external file launch context, Welcome Tour presentation rules, and polling-based external change detection.