### PR TITLE
docs: explain contribution branch workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,19 @@ open "Neon Vision Editor.xcodeproj"
 
 Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
-1. Fork the repo and create a focused branch.
+### Branches and PR targets
+
+| Branch | Purpose | Use for contributions |
+| --- | --- | --- |
+| `main` | Production-ready code and published release state | Do not develop directly on this branch. Target it only for a maintainer-requested production fix or standalone documentation/maintenance change. |
+| `develop` | Integration branch for the next release | Start normal feature, bug-fix, and code-related documentation work here, then open the PR back into `develop`. |
+| `release/<version>` | Short-lived release stabilization branch created from `develop` | Maintainer-managed; do not use it for regular contributions or new features. Its release PR targets `main`. |
+| `archive/legacy-branches` | Preserved historical branch tips | Read-only history; do not branch from it or target it with a PR. |
+| `automation/*` | Generated metadata, metrics, appcast, or Store synchronization | Bot-managed; do not use these branches for manual contributions. |
+
+Both `main` and `develop` are protected, so contribute from a branch in your fork. Unless a maintainer asks for another target, branch from the latest `develop` and open your PR into `develop`. Focused names such as `fix/...`, `feature/...`, or `docs/...` make the change easy to identify.
+
+1. Fork the repo and create a focused branch from `develop`.
 2. Implement the smallest safe diff for your change.
 3. Build on macOS first.
 4. Run cross-platform verification script.

--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 | Branch | Purpose | Use for contributions |
 | --- | --- | --- |
-| `main` | Production-ready code and published release state | Do not develop directly on this branch. Target it only for a maintainer-requested production fix or standalone documentation/maintenance change. |
+| `main` | Production-ready code and published release state | Do not target this branch for contributions. All contributions, including standalone documentation and maintenance changes, must target `develop` unless a maintainer explicitly requests `main`. |
 | `develop` | Integration branch for the next release | Start normal feature, bug-fix, and code-related documentation work here, then open the PR back into `develop`. |
 | `release/<version>` | Short-lived release stabilization branch created from `develop` | Maintainer-managed; do not use it for regular contributions or new features. Its release PR targets `main`. |
 | `archive/legacy-branches` | Preserved historical branch tips | Read-only history; do not branch from it or target it with a PR. |


### PR DESCRIPTION
## Summary

- What changed: Documented the roles of `main`, `develop`, `release/<version>`, historical archive, and automation branches, with consistent PR-target guidance.
- Why: Contributors need a clear default branch and an unambiguous exception for maintainer-directed changes.
- Scope: Docs
- Linked issue/milestone: None

## Validation

- [ ] Built on macOS — not applicable; documentation-only change
- [ ] Built on iOS simulator — not applicable; documentation-only change
- [ ] Built on iPad simulator — not applicable; documentation-only change
- [x] Reviewed the rendered Markdown structure and branch guidance
- [ ] Reproduction steps included — not applicable; not a bug fix
- [ ] Expected versus actual behavior documented — not applicable; not a bug fix
- [x] `git diff --check`
- [x] Referenced repository paths verified

## Checklist

- [x] Accessibility impact evaluated — no UI change
- [x] Keyboard navigation impact evaluated — no UI change
- [x] VoiceOver impact evaluated — no UI change
- [x] Changelog not required — contribution documentation only
- [x] Documentation updated
- [x] No unrelated refactors

## Risk

- Risk level: Low
- User-facing risk: Contributors could select the wrong PR base if the wording remains ambiguous; the updated guidance consistently defaults to `develop` unless a maintainer explicitly requests `main`.
- Rollback plan: Revert this documentation PR.

## Summary by Sourcery

Documentation:
- Document branch purposes and consistent pull-request targeting guidance, with `develop` as the default contribution target unless a maintainer requests otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to require all changes, including documentation and maintenance work, to target the `develop` branch unless a maintainer explicitly requests `main`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->