### PR TITLE
Fix support alert lifecycle and sync published documentation

### DIFF
--- a/Neon Vision Editor/Data/SupportPurchaseManager.swift
+++ b/Neon Vision Editor/Data/SupportPurchaseManager.swift
@@ -126,7 +126,9 @@ final class SupportPurchaseManager: ObservableObject {
                 if let product = products.first(where: { $0.id == Self.supportProductID }) {
                     supportProduct = product
                     lastSuccessfulPriceRefreshAt = Date()
-                    statusMessage = nil
+                    // Metadata refresh does not acknowledge purchase feedback.
+                    // A purchase may have completed while this lookup awaited
+                    // StoreKit. Explicit retry/dismissal owns status clearing.
                     return
                 }
             } catch is CancellationError {

--- a/Neon Vision Editor/UI/NeonSettingsView.swift
+++ b/Neon Vision Editor/UI/NeonSettingsView.swift
@@ -210,6 +210,7 @@ struct NeonSettingsView: View {
     @State private var commandLineHelperCopyStatus: String = ""
 #endif
     @State private var supportRefreshTask: Task<Void, Never>?
+    @State private var supportStatusAlert = SupportStatusAlertPresentation()
     @State private var isDiscoveringFonts: Bool = false
     private let privacyPolicyURL = URL(string: "https://github.com/h3pdesign/Neon-Vision-Editor/blob/main/PRIVACY.md")
     private let termsOfUseURL = URL(string: "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/")
@@ -1390,10 +1391,22 @@ struct NeonSettingsView: View {
             Text("Neon Vision Editor will ask macOS to open its supported text and source-code file types. macOS may request your confirmation.")
         }
 #endif
-        .alert("App Store", isPresented: supportStatusAlertBinding) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(supportPurchaseManager.statusMessage ?? "")
+        .onChange(of: supportPurchaseManager.statusMessage, initial: true) { _, message in
+            supportStatusAlert.receive(message)
+        }
+        .onChange(of: supportStatusAlert.isPresented) { _, isPresented in
+            if !isPresented { supportStatusAlert.didDismiss() }
+        }
+        .alert("App Store", isPresented: $supportStatusAlert.isPresented, presenting: supportStatusAlert.message) { message in
+            Button("OK", role: .cancel) {
+                // A user action acknowledges feedback. SwiftUI's presentation
+                // binding only changes local state, never the observed manager.
+                if supportPurchaseManager.statusMessage == message {
+                    supportPurchaseManager.statusMessage = nil
+                }
+            }
+        } message: { message in
+            Text(message)
         }
         .sheet(isPresented: $showDataDisclosureDialog) {
             dataDisclosureDialog
@@ -1408,17 +1421,6 @@ struct NeonSettingsView: View {
     }
 
     // MARK: - Lifecycle Helpers
-
-    private var supportStatusAlertBinding: Binding<Bool> {
-        Binding(
-            get: { supportPurchaseManager.statusMessage != nil },
-            set: { isPresented in
-                if !isPresented {
-                    supportPurchaseManager.statusMessage = nil
-                }
-            }
-        )
-    }
 
     private func cancelSupportRefreshTask() {
         supportRefreshTask?.cancel()

--- a/Neon Vision Editor/UI/SettingsInfrastructure.swift
+++ b/Neon Vision Editor/UI/SettingsInfrastructure.swift
@@ -2,6 +2,38 @@ import SwiftUI
 import Foundation
 import UniformTypeIdentifiers
 
+/// Presentation is view-local: framework dismissal must never publish through
+/// the purchase manager. A replacement waits until the visible alert closes.
+struct SupportStatusAlertPresentation {
+    var isPresented = false
+    private(set) var message: String?
+    private var pendingMessage: String?
+
+    mutating func receive(_ value: String?) {
+        guard let value else {
+            message = nil
+            pendingMessage = nil
+            isPresented = false
+            return
+        }
+        if isPresented {
+            pendingMessage = value == message ? nil : value
+        } else {
+            message = value
+            pendingMessage = nil
+            isPresented = true
+        }
+    }
+
+    mutating func didDismiss() {
+        guard !isPresented else { return }
+        message = nil
+        if let pendingMessage {
+            receive(pendingMessage)
+        }
+    }
+}
+
 // MARK: - Settings Preference Schema
 
 /// Preference keys shared by Settings, the editor shell, and native editor bridges.

--- a/Neon Vision EditorTests/EditorSettingsDefaultsTests.swift
+++ b/Neon Vision EditorTests/EditorSettingsDefaultsTests.swift
@@ -3,6 +3,52 @@ import XCTest
 
 @MainActor
 final class EditorSettingsDefaultsTests: XCTestCase {
+    func testSupportAlertQueuesReplacementUntilFrameworkDismissal() {
+        var state = SupportStatusAlertPresentation()
+        state.receive("First")
+        XCTAssertTrue(state.isPresented)
+        state.receive("Second")
+        XCTAssertEqual(state.message, "First")
+        state.isPresented = false
+        state.didDismiss()
+        XCTAssertTrue(state.isPresented)
+        XCTAssertEqual(state.message, "Second")
+        state.receive(nil)
+        state.didDismiss()
+        XCTAssertFalse(state.isPresented)
+        XCTAssertNil(state.message)
+    }
+
+    func testSupportAlertCoalescesLatestStatusAndDoesNotReopenAcknowledgedMessage() {
+        var state = SupportStatusAlertPresentation()
+        state.receive("First")
+        state.receive("Second")
+        state.receive("Latest")
+        state.isPresented = false
+        state.didDismiss()
+        XCTAssertEqual(state.message, "Latest")
+        state.receive("Latest")
+        state.isPresented = false
+        state.didDismiss()
+        XCTAssertFalse(state.isPresented)
+        XCTAssertNil(state.message)
+        state.didDismiss()
+        XCTAssertFalse(state.isPresented)
+    }
+
+    func testSupportAlertClearDiscardsPendingStatus() {
+        var state = SupportStatusAlertPresentation()
+        state.receive("First")
+        state.receive("Pending")
+        state.receive(nil)
+        state.didDismiss()
+        XCTAssertFalse(state.isPresented)
+        XCTAssertNil(state.message)
+        state.receive("Fresh")
+        XCTAssertTrue(state.isPresented)
+        XCTAssertEqual(state.message, "Fresh")
+    }
+
     func testWelcomeTourAutomaticPresentationCanBeDisabledPermanently() {
         XCTAssertFalse(
             WelcomeTourPresentationPolicy.shouldPresentAutomatically(

--- a/Neon Vision EditorTests/SupportPurchaseManagerTests.swift
+++ b/Neon Vision EditorTests/SupportPurchaseManagerTests.swift
@@ -1,10 +1,96 @@
 import XCTest
 import StoreKit
 import StoreKitTest
+#if os(macOS)
+import AppKit
+import SwiftUI
+#endif
 @testable import Neon_Vision_Editor
 
 @MainActor
 final class SupportPurchaseManagerTests: XCTestCase {
+#if os(macOS)
+    func testNativeSettingsAlertPresentsReplacementAfterDismissal() async throws {
+        let manager = SupportPurchaseManager(loadProducts: { [] }, canMakePayments: { false })
+        let root = NeonSettingsView()
+            .environment(EditorViewModel())
+            .environmentObject(manager)
+            .environmentObject(AppUpdateManager())
+        let hosting = NSHostingView(rootView: root)
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 900, height: 700), styleMask: [.titled, .closable], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentView = hosting
+        window.makeKeyAndOrderFront(nil)
+        defer { window.orderOut(nil); window.close() }
+        func descendants(_ view: NSView) -> [NSView] {
+            [view] + view.subviews.flatMap(descendants)
+        }
+        func alertButton() -> NSButton? {
+            guard let content = window.attachedSheet?.contentView else { return nil }
+            return descendants(content).compactMap { $0 as? NSButton }.first { $0.title == "OK" }
+        }
+        manager.statusMessage = "First test status"
+        for _ in 0..<200 where alertButton() == nil { try await Task.sleep(for: .milliseconds(10)) }
+        let firstButton = try XCTUnwrap(alertButton(), "Native settings alert must appear")
+        manager.statusMessage = "Replacement test status"
+        try await Task.sleep(for: .milliseconds(50))
+        firstButton.performClick(nil)
+        for _ in 0..<200 where alertButton() == nil || alertButton() === firstButton {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let replacementButton = try XCTUnwrap(alertButton(), "Queued replacement must appear")
+        XCTAssertFalse(replacementButton === firstButton)
+        XCTAssertEqual(manager.statusMessage, "Replacement test status")
+        replacementButton.performClick(nil)
+        for _ in 0..<200 where window.attachedSheet != nil { try await Task.sleep(for: .milliseconds(10)) }
+        XCTAssertNil(manager.statusMessage)
+        XCTAssertNil(window.attachedSheet)
+    }
+#endif
+
+    func testSettingsAlertUsesLocalPresentationState() throws {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("Neon Vision Editor/UI/NeonSettingsView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        // Structural guard for the framework-owned presentation setter: it must
+        // not synchronously publish through SupportPurchaseManager.
+        XCTAssertTrue(source.contains("isPresented: $supportStatusAlert.isPresented"))
+        XCTAssertFalse(source.contains("private var supportStatusAlertBinding"))
+    }
+
+    func testBackgroundMetadataRefreshPreservesNewerPurchaseStatus() async throws {
+        let session = try makeSession()
+        defer { session.clearTransactions() }
+        let products = try await Product.products(for: [SupportPurchaseManager.supportProductID])
+        XCTAssertFalse(products.isEmpty)
+        var lookups = 0
+        var resume: CheckedContinuation<Void, Never>?
+        let started = expectation(description: "Background refresh suspended")
+        let manager = SupportPurchaseManager(loadProducts: {
+            lookups += 1
+            if lookups == 2 {
+                await withCheckedContinuation { continuation in
+                    resume = continuation
+                    started.fulfill()
+                }
+            }
+            return products
+        }, canMakePayments: { true })
+        await manager.refreshStoreState()
+        let refresh = Task { await manager.refreshStoreState() }
+        defer { resume?.resume() }
+        await fulfillment(of: [started], timeout: 3)
+        await manager.purchaseSupport { _ in .pending }
+        let purchaseStatus = try XCTUnwrap(manager.statusMessage)
+        resume?.resume()
+        resume = nil
+        await refresh.value
+        XCTAssertEqual(manager.statusMessage, purchaseStatus)
+        XCTAssertNotNil(manager.availableSupportPriceLabel)
+        XCTAssertFalse(manager.isLoadingProducts)
+    }
+
     private func makeSession() throws -> SKTestSession {
         let configuration = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent()

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9839&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9894&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>

--- a/README.md
+++ b/README.md
@@ -881,7 +881,19 @@ open "Neon Vision Editor.xcodeproj"
 
 Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
-1. Fork the repo and create a focused branch.
+### Branches and PR targets
+
+| Branch | Purpose | Use for contributions |
+| --- | --- | --- |
+| `main` | Production-ready code and published release state | Do not develop directly on this branch. Target it only for a maintainer-requested production fix or standalone documentation/maintenance change. |
+| `develop` | Integration branch for the next release | Start normal feature, bug-fix, and code-related documentation work here, then open the PR back into `develop`. |
+| `release/<version>` | Short-lived release stabilization branch created from `develop` | Maintainer-managed; do not use it for regular contributions or new features. Its release PR targets `main`. |
+| `archive/legacy-branches` | Preserved historical branch tips | Read-only history; do not branch from it or target it with a PR. |
+| `automation/*` | Generated metadata, metrics, appcast, or Store synchronization | Bot-managed; do not use these branches for manual contributions. |
+
+Both `main` and `develop` are protected, so contribute from a branch in your fork. Unless a maintainer asks for another target, branch from the latest `develop` and open your PR into `develop`. Focused names such as `fix/...`, `feature/...`, or `docs/...` make the change easy to identify.
+
+1. Fork the repo and create a focused branch from `develop`.
 2. Implement the smallest safe diff for your change.
 3. Build on macOS first.
 4. Run cross-platform verification script.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9894&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9961&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>

--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ Contributor guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 | Branch | Purpose | Use for contributions |
 | --- | --- | --- |
-| `main` | Production-ready code and published release state | Do not develop directly on this branch. Target it only for a maintainer-requested production fix or standalone documentation/maintenance change. |
+| `main` | Production-ready code and published release state | Do not target this branch for contributions. All contributions, including standalone documentation and maintenance changes, must target `develop` unless a maintainer explicitly requests `main`. |
 | `develop` | Integration branch for the next release | Start normal feature, bug-fix, and code-related documentation work here, then open the PR back into `develop`. |
 | `release/<version>` | Short-lived release stabilization branch created from `develop` | Maintainer-managed; do not use it for regular contributions or new features. Its release PR targets `main`. |
 | `archive/legacy-branches` | Preserved historical branch tips | Read-only history; do not branch from it or target it with a PR. |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 > Platform target: **macOS 26 (Tahoe)** compatible with **macOS Sequoia**
 > Apple Silicon: tested / Intel: not tested
 > Direct GitHub release: **v1.6.1** / App Store and TestFlight availability varies by platform and review status
-> Last updated (README): **2026-09-04** for latest release **v1.6.1**
+> Last updated (README): **2026-09-05** for latest release **v1.6.1**
 
 ## What's New in v1.6.0 and v1.6.1
 
@@ -163,7 +163,7 @@
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9961&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=9982&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>
@@ -178,12 +178,12 @@
 
 <p align="center"><em>Styled line chart shows per-release totals with 14-day traffic counters for clones and views.</em></p>
 <p align="center">
-  <img alt="Unique cloners (14d)" src="https://img.shields.io/static/v1?label=Unique+cloners+%2814d%29&message=229&color=7C3AED&style=for-the-badge">
-  <img alt="Unique visitors (14d)" src="https://img.shields.io/static/v1?label=Unique+visitors+%2814d%29&message=157&color=0EA5E9&style=for-the-badge">
+  <img alt="Unique cloners (14d)" src="https://img.shields.io/static/v1?label=Unique+cloners+%2814d%29&message=236&color=7C3AED&style=for-the-badge">
+  <img alt="Unique visitors (14d)" src="https://img.shields.io/static/v1?label=Unique+visitors+%2814d%29&message=163&color=0EA5E9&style=for-the-badge">
 </p>
 <p align="center">
-  <img alt="Clone snapshot (UTC)" src="https://img.shields.io/static/v1?label=Clone+snapshot+%28UTC%29&message=2026-09-04&color=334155&style=flat-square">
-  <img alt="View snapshot (UTC)" src="https://img.shields.io/static/v1?label=View+snapshot+%28UTC%29&message=2026-09-04&color=334155&style=flat-square">
+  <img alt="Clone snapshot (UTC)" src="https://img.shields.io/static/v1?label=Clone+snapshot+%28UTC%29&message=2026-09-05&color=334155&style=flat-square">
+  <img alt="View snapshot (UTC)" src="https://img.shields.io/static/v1?label=View+snapshot+%28UTC%29&message=2026-09-05&color=334155&style=flat-square">
 </p>
 
 ## Project Documentation

--- a/docs/images/release-download-trend-dark.svg
+++ b/docs/images/release-download-trend-dark.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-04</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.0 · 156 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 46 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -47,15 +47,15 @@
   <line x1="130" y1="170.0" x2="1070" y2="170.0" stroke="#2B4255" stroke-width="1"/>
   <line x1="130" y1="120.0" x2="1070" y2="120.0" stroke="#37566F" stroke-width="1"/>
   <text x="68" y="326.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">0</text>
-  <text x="58" y="276.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">100</text>
-  <text x="58" y="226.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">200</text>
-  <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">300</text>
-  <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">400</text>
+  <text x="58" y="276.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">80</text>
+  <text x="58" y="226.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">160</text>
+  <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
+  <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 139.0 L 264.3 230.0 L 398.6 254.0 L 532.9 162.0 L 667.1 234.0 L 801.4 277.5 L 935.7 170.5 L 1070.0 242.0 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 291.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,139.0 264.3,230.0 398.6,254.0 532.9,162.0 667.1,234.0 801.4,277.5 935.7,170.5 1070.0,242.0"
+    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,291.2"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -64,22 +64,22 @@
     filter="url(#glow)"
   />
 
-  <circle cx="130.0" cy="139.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="264.3" cy="230.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="398.6" cy="254.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="532.9" cy="162.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="667.1" cy="234.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="801.4" cy="277.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="170.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="242.0" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
-  <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.6</text>
-  <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
-  <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
-  <text x="532.9" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
-  <text x="667.1" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
-  <text x="801.4" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
-  <text x="935.7" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
-  <text x="1070.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
+  <circle cx="130.0" cy="207.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="264.3" cy="237.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="398.6" cy="122.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="532.9" cy="212.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="667.1" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="801.4" cy="133.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="291.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
+  <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
+  <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
+  <text x="532.9" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
+  <text x="667.1" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
+  <text x="801.4" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
+  <text x="935.7" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
+  <text x="1070.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.1</text>
   <text x="70" y="414" fill="#E6F3FF" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="94" y="462" fill="#C4B5FD" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>

--- a/docs/images/release-download-trend-dark.svg
+++ b/docs/images/release-download-trend-dark.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-04</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 46 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 113 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 291.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 249.4 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,291.2"
+    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,249.4"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -71,7 +71,7 @@
   <circle cx="667.1" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="133.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="935.7" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="291.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="249.4" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>

--- a/docs/images/release-download-trend-dark.svg
+++ b/docs/images/release-download-trend-dark.svg
@@ -36,10 +36,10 @@
   <rect x="24" y="24" width="1152" height="572" rx="14" stroke="#2A4762" stroke-width="1.5"/>
 
   <text x="70" y="68" fill="#E6F3FF" font-size="30" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Release downloads</text>
-  <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-04</text>
+  <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-05</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 113 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 134 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 249.4 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 236.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,249.4"
+    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,236.2"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -71,7 +71,7 @@
   <circle cx="667.1" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="133.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="935.7" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="249.4" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="236.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
@@ -83,15 +83,15 @@
   <text x="70" y="414" fill="#E6F3FF" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="94" y="462" fill="#C4B5FD" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>
-  <text x="94" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">229</text>
+  <text x="94" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">236</text>
   <text x="190" y="508" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="94" y="526" width="425" height="10" rx="5" fill="#15263A"/>
-  <rect x="94" y="526" width="405.5" height="10" rx="5" fill="url(#cloneFill)"/>
+  <rect x="94" y="526" width="417.9" height="10" rx="5" fill="url(#cloneFill)"/>
   <rect x="595" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="619" y="462" fill="#7DD3FC" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE VISITORS</text>
-  <text x="619" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">157</text>
+  <text x="619" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">163</text>
   <text x="715" y="508" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="619" y="526" width="425" height="10" rx="5" fill="#15263A"/>
-  <rect x="619" y="526" width="278.0" height="10" rx="5" fill="url(#viewFill)"/>
+  <rect x="619" y="526" width="288.6" height="10" rx="5" fill="url(#viewFill)"/>
   <text x="70" y="582" fill="#9CC3E6" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Shared scale: 0–240 events</text>
 </svg>

--- a/docs/images/release-download-trend-light.svg
+++ b/docs/images/release-download-trend-light.svg
@@ -36,10 +36,10 @@
   <rect x="24" y="24" width="1152" height="572" rx="14" stroke="#CBD5E1" stroke-width="1.5"/>
 
   <text x="70" y="68" fill="#0F172A" font-size="30" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Release downloads</text>
-  <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-04</text>
+  <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-05</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="884" y="70" fill="#475569" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 113 downloads</text>
+  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 134 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#94A3B8" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#CBD5E1" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 249.4 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 236.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,249.4"
+    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,236.2"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -71,7 +71,7 @@
   <circle cx="667.1" cy="266.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="801.4" cy="133.1" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="935.7" cy="216.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="1070.0" cy="249.4" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="1070.0" cy="236.2" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
@@ -83,15 +83,15 @@
   <text x="70" y="414" fill="#0F172A" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="94" y="462" fill="#6D28D9" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>
-  <text x="94" y="508" fill="#0F172A" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">229</text>
+  <text x="94" y="508" fill="#0F172A" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">236</text>
   <text x="190" y="508" fill="#64748B" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="94" y="526" width="425" height="10" rx="5" fill="#E2E8F0"/>
-  <rect x="94" y="526" width="405.5" height="10" rx="5" fill="url(#cloneFill)"/>
+  <rect x="94" y="526" width="417.9" height="10" rx="5" fill="url(#cloneFill)"/>
   <rect x="595" y="432" width="505" height="124" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="619" y="462" fill="#0369A1" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE VISITORS</text>
-  <text x="619" y="508" fill="#0F172A" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">157</text>
+  <text x="619" y="508" fill="#0F172A" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">163</text>
   <text x="715" y="508" fill="#64748B" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="619" y="526" width="425" height="10" rx="5" fill="#E2E8F0"/>
-  <rect x="619" y="526" width="278.0" height="10" rx="5" fill="url(#viewFill)"/>
+  <rect x="619" y="526" width="288.6" height="10" rx="5" fill="url(#viewFill)"/>
   <text x="70" y="582" fill="#64748B" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Shared scale: 0–240 events</text>
 </svg>

--- a/docs/images/release-download-trend-light.svg
+++ b/docs/images/release-download-trend-light.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-04</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="884" y="70" fill="#475569" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.0 · 156 downloads</text>
+  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 46 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#94A3B8" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#CBD5E1" stroke-width="1"/>
@@ -47,15 +47,15 @@
   <line x1="130" y1="170.0" x2="1070" y2="170.0" stroke="#CBD5E1" stroke-width="1"/>
   <line x1="130" y1="120.0" x2="1070" y2="120.0" stroke="#94A3B8" stroke-width="1"/>
   <text x="68" y="326.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">0</text>
-  <text x="58" y="276.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">100</text>
-  <text x="58" y="226.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">200</text>
-  <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">300</text>
-  <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">400</text>
+  <text x="58" y="276.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">80</text>
+  <text x="58" y="226.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">160</text>
+  <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
+  <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 139.0 L 264.3 230.0 L 398.6 254.0 L 532.9 162.0 L 667.1 234.0 L 801.4 277.5 L 935.7 170.5 L 1070.0 242.0 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 291.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,139.0 264.3,230.0 398.6,254.0 532.9,162.0 667.1,234.0 801.4,277.5 935.7,170.5 1070.0,242.0"
+    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,291.2"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -64,22 +64,22 @@
     filter="url(#glow)"
   />
 
-  <circle cx="130.0" cy="139.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="264.3" cy="230.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="398.6" cy="254.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="532.9" cy="162.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="667.1" cy="234.0" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="801.4" cy="277.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="935.7" cy="170.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="1070.0" cy="242.0" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
-  <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.6</text>
-  <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
-  <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
-  <text x="532.9" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
-  <text x="667.1" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
-  <text x="801.4" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
-  <text x="935.7" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
-  <text x="1070.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
+  <circle cx="130.0" cy="207.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="264.3" cy="237.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="398.6" cy="122.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="532.9" cy="212.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="667.1" cy="266.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="801.4" cy="133.1" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="935.7" cy="216.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="1070.0" cy="291.2" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
+  <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
+  <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
+  <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
+  <text x="532.9" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
+  <text x="667.1" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
+  <text x="801.4" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
+  <text x="935.7" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
+  <text x="1070.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.1</text>
   <text x="70" y="414" fill="#0F172A" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="94" y="462" fill="#6D28D9" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>

--- a/docs/images/release-download-trend-light.svg
+++ b/docs/images/release-download-trend-light.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-04</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="884" y="70" fill="#475569" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 46 downloads</text>
+  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 113 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#94A3B8" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#CBD5E1" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 291.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 249.4 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,291.2"
+    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,249.4"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -71,7 +71,7 @@
   <circle cx="667.1" cy="266.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="801.4" cy="133.1" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="935.7" cy="216.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="1070.0" cy="291.2" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="1070.0" cy="249.4" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>

--- a/docs/images/release-download-trend.svg
+++ b/docs/images/release-download-trend.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-04</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.0 · 156 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 46 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -47,15 +47,15 @@
   <line x1="130" y1="170.0" x2="1070" y2="170.0" stroke="#2B4255" stroke-width="1"/>
   <line x1="130" y1="120.0" x2="1070" y2="120.0" stroke="#37566F" stroke-width="1"/>
   <text x="68" y="326.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">0</text>
-  <text x="58" y="276.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">100</text>
-  <text x="58" y="226.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">200</text>
-  <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">300</text>
-  <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">400</text>
+  <text x="58" y="276.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">80</text>
+  <text x="58" y="226.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">160</text>
+  <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
+  <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 139.0 L 264.3 230.0 L 398.6 254.0 L 532.9 162.0 L 667.1 234.0 L 801.4 277.5 L 935.7 170.5 L 1070.0 242.0 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 291.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,139.0 264.3,230.0 398.6,254.0 532.9,162.0 667.1,234.0 801.4,277.5 935.7,170.5 1070.0,242.0"
+    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,291.2"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -64,22 +64,22 @@
     filter="url(#glow)"
   />
 
-  <circle cx="130.0" cy="139.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="264.3" cy="230.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="398.6" cy="254.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="532.9" cy="162.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="667.1" cy="234.0" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="801.4" cy="277.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="170.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="242.0" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
-  <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.4.6</text>
-  <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
-  <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
-  <text x="532.9" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
-  <text x="667.1" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
-  <text x="801.4" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
-  <text x="935.7" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
-  <text x="1070.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
+  <circle cx="130.0" cy="207.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="264.3" cy="237.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="398.6" cy="122.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="532.9" cy="212.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="667.1" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="801.4" cy="133.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="291.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
+  <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
+  <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
+  <text x="532.9" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
+  <text x="667.1" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
+  <text x="801.4" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
+  <text x="935.7" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
+  <text x="1070.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.1</text>
   <text x="70" y="414" fill="#E6F3FF" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="94" y="462" fill="#C4B5FD" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>

--- a/docs/images/release-download-trend.svg
+++ b/docs/images/release-download-trend.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-04</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 46 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 113 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 291.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 249.4 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,291.2"
+    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,249.4"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -71,7 +71,7 @@
   <circle cx="667.1" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="133.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="935.7" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="291.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="249.4" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>

--- a/docs/images/release-download-trend.svg
+++ b/docs/images/release-download-trend.svg
@@ -36,10 +36,10 @@
   <rect x="24" y="24" width="1152" height="572" rx="14" stroke="#2A4762" stroke-width="1.5"/>
 
   <text x="70" y="68" fill="#E6F3FF" font-size="30" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Release downloads</text>
-  <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-04</text>
+  <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-05</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 113 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 134 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 249.4 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 133.1 L 935.7 216.9 L 1070.0 236.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,249.4"
+    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,133.1 935.7,216.9 1070.0,236.2"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -71,7 +71,7 @@
   <circle cx="667.1" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="133.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="935.7" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="249.4" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="236.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
@@ -83,15 +83,15 @@
   <text x="70" y="414" fill="#E6F3FF" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="94" y="462" fill="#C4B5FD" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>
-  <text x="94" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">229</text>
+  <text x="94" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">236</text>
   <text x="190" y="508" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="94" y="526" width="425" height="10" rx="5" fill="#15263A"/>
-  <rect x="94" y="526" width="405.5" height="10" rx="5" fill="url(#cloneFill)"/>
+  <rect x="94" y="526" width="417.9" height="10" rx="5" fill="url(#cloneFill)"/>
   <rect x="595" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="619" y="462" fill="#7DD3FC" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE VISITORS</text>
-  <text x="619" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">157</text>
+  <text x="619" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">163</text>
   <text x="715" y="508" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="619" y="526" width="425" height="10" rx="5" fill="#15263A"/>
-  <rect x="619" y="526" width="278.0" height="10" rx="5" fill="url(#viewFill)"/>
+  <rect x="619" y="526" width="288.6" height="10" rx="5" fill="url(#viewFill)"/>
   <text x="70" y="582" fill="#9CC3E6" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Shared scale: 0–240 events</text>
 </svg>


### PR DESCRIPTION
## Summary
- Fix SwiftUI publication during Settings alert reconciliation using local presentation state.
- Preserve newer purchase feedback across background metadata refreshes and queue replacement alerts.
- Add six regression tests, including native macOS alert replacement and dismissal.
- Bring already-published main-branch contribution guidance and download charts into develop.

## Scope
No macOS 27 agent implementation, agent tests, or agent specification is included. The recovery snapshot remains local.

## Verification
The alert patch was verified before extraction: 22 related tests passed, the native alert test recorded no runtime warnings, all four platform builds passed, and the StoreKit audit passed. Two independent source reviews cleared the patch. Extraction and documentation merge passed git diff --check. An existing unmounted-view warning in the font-settings test remains outside this fix; mobile alert runtime and VoiceOver were not exercised.

This PR is for review and integration into develop, not a production release.

## Summary by Sourcery

Stabilize support purchase alert lifecycle and synchronize published documentation and download metrics.

Bug Fixes:
- Fix Settings support alerts so dismissal is handled locally without clearing purchase feedback unintentionally.
- Preserve newer purchase feedback during background StoreKit metadata refreshes and queue replacement alerts until the current alert is dismissed.

Documentation:
- Sync published contribution guidance and update README download metrics and release trend charts.

Tests:
- Add regression coverage for alert replacement, dismissal, local presentation state, and purchase feedback surviving metadata refreshes.