### PR TITLE
Add safe automatic local branch cleanup

### DIFF
--- a/docs/branch-cleanup.md
+++ b/docs/branch-cleanup.md
@@ -1,0 +1,21 @@
+# Automatic branch cleanup
+
+GitHub owns remote cleanup: enable **Automatically delete head branches** after PR merge. Deletion rules protect `main`, `develop`, and `archive/*`. Do not add an age-based remote branch sweeper. The recurring metrics workflow may recreate its own branch.
+
+Local cleanup uses Python 3.9+ and authenticated `git`/`gh`. Run from a clean repository root:
+
+```sh
+python3 scripts/cleanup_branches.py --repo "$PWD" --github-repo h3pdesign/Neon-Vision-Editor --dry-run
+```
+
+Use `--apply` for deletion. `--apply --not-before 2026-09-12T09:14:22+00:00` stays report-only until that instant. The scheduled task uses this one-week grace period and runs weekly through Codex; it is not a launchd service and depends on the local Codex automation environment being available.
+
+Only branches with a missing origin upstream, no open PR reference, no checked-out worktree, and a tip reachable from freshly fetched `origin/main` or `origin/develop` qualify. Local-only branches, unique commits, and squash/rebase cases without ancestry proof require manual review. Git's own `branch -d` refusal is never overridden. The script does not switch branches, stash changes, delete remote branches, or remove worktree files.
+
+Always preserved: `main`, `develop`, `archive/*`, `release/*`, `automation/*`, `codex/backup-*`, and `codex/macos-27-agentic-editor`. Update this list deliberately when long-lived development branches change.
+
+Fetch/authentication errors and a dirty current worktree abort cleanup. A shared lock prevents overlapping cleanup runs. Audit entries containing time, branch, original tip, action, and reason are appended to `branch-cleanup.jsonl` in the shared Git directory. Commits on deleted branches remain reachable from the integration branch; restore a name with `git branch <name> <logged-tip>`.
+
+The scheduled command should load the script from a pinned reviewed commit with `git show <commit>:scripts/cleanup_branches.py`, not execute an arbitrary version from the current checkout. Update that pinned commit only after tests and review. Pause/delete the automation in Codex to disable scheduling; `git config --local fetch.prune false` disables automatic remote-reference pruning.
+
+Tests: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p test_cleanup_branches.py`.

--- a/scripts/cleanup_branches.py
+++ b/scripts/cleanup_branches.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Conservative local branch cleanup. Remote deletion belongs to GitHub PR merges."""
+import argparse
+from datetime import datetime, timezone
+import fcntl
+import fnmatch
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+PRESERVE = ("main", "develop", "archive/*", "release/*", "automation/*",
+            "codex/backup-*", "codex/macos-27-agentic-editor")
+
+
+def run(*args, cwd):
+    return subprocess.run(args, cwd=cwd, text=True, capture_output=True,
+                          check=True, timeout=120).stdout.strip()
+
+
+def skip_reason(name, upstream, in_use, open_pr_refs, remote_heads, merged):
+    if any(fnmatch.fnmatchcase(name, pattern) for pattern in PRESERVE):
+        return "preserved"
+    if name in in_use:
+        return "checked out in a worktree"
+    if not upstream.startswith("refs/remotes/origin/"):
+        return "no origin upstream; manual review"
+    remote_name = upstream.removeprefix("refs/remotes/origin/")
+    if name in open_pr_refs or remote_name in open_pr_refs:
+        return "referenced by an open PR"
+    if remote_name in remote_heads:
+        return "remote branch still exists"
+    if not merged:
+        return "tip not reachable from origin/main or origin/develop; manual review"
+    return None
+
+
+def apply_enabled(apply, not_before, now):
+    if not_before is not None and not_before.tzinfo is None:
+        raise ValueError("--not-before must include a timezone")
+    return apply and (not_before is None or now >= not_before)
+
+
+def cleanup(args):
+    repo = Path(args.repo).resolve()
+    git = lambda *a: run("git", *a, cwd=repo)
+    if git("rev-parse", "--show-toplevel") != str(repo):
+        raise ValueError("--repo must be the repository root")
+    expected = args.github_repo
+    if git("remote", "get-url", "origin") not in (
+            f"https://github.com/{expected}.git", f"https://github.com/{expected}",
+            f"git@github.com:{expected}.git"):
+        raise ValueError("origin does not match --github-repo")
+    common = Path(git("rev-parse", "--git-common-dir"))
+    if not common.is_absolute():
+        common = repo / common
+    with (common / "branch-cleanup.lock").open("a") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        if git("status", "--porcelain", "--untracked-files=all"):
+            raise ValueError("current worktree is dirty; no cleanup performed")
+        # Abort on network/authentication failure. Never use stale merge/PR data.
+        git("fetch", "--prune", "origin")
+        bases = [git("rev-parse", "--verify", f"refs/remotes/origin/{b}^{{commit}}")
+                 for b in ("main", "develop")]
+        pages = json.loads(run("gh", "api", "--paginate", "--slurp",
+                               f"repos/{expected}/pulls?state=open&per_page=100", cwd=repo))
+        prs = [pr for page in pages for pr in page]
+        open_refs = {pr[side]["ref"] for pr in prs for side in ("head", "base")}
+        live_heads = {line.split("\t", 1)[1].removeprefix("refs/heads/")
+                      for line in git("ls-remote", "--heads", "origin").splitlines()}
+        in_use = {line.removeprefix("branch refs/heads/")
+                  for line in git("worktree", "list", "--porcelain").splitlines()
+                  if line.startswith("branch refs/heads/")}
+        branches = git("for-each-ref", "--format=%(refname:short)%09%(objectname)%09%(upstream)", "refs/heads")
+        apply = apply_enabled(args.apply, args.not_before, datetime.now(timezone.utc))
+        for line in branches.splitlines():
+            name, tip, upstream = (line + "\t").split("\t")[:3]
+            merged = False
+            for base in bases:
+                result = subprocess.run(["git", "merge-base", "--is-ancestor", tip, base], cwd=repo)
+                if result.returncode not in (0, 1):
+                    raise ValueError("ancestry check failed")
+                merged |= result.returncode == 0
+            reason = skip_reason(name, upstream, in_use, open_refs, live_heads, merged)
+            event = {"time": datetime.now(timezone.utc).isoformat(), "branch": name,
+                     "tip": tip, "action": "skip" if reason else "candidate", "reason": reason}
+            if reason is None and apply:
+                # Recheck local ownership and tip immediately before deletion.
+                current_worktrees = git("worktree", "list", "--porcelain").splitlines()
+                if git("rev-parse", f"refs/heads/{name}") != tip or f"branch refs/heads/{name}" in current_worktrees:
+                    event.update(action="skip", reason="branch changed during cleanup")
+                else:
+                    # Keep Git's own final merged/in-use checks. Never force-delete.
+                    try:
+                        git("branch", "-d", "--", name)
+                        event["action"] = "deleted"
+                    except subprocess.CalledProcessError:
+                        event.update(action="skip", reason="git branch -d refused; manual review")
+            record = json.dumps(event, sort_keys=True)
+            print(record)
+            with (common / "branch-cleanup.jsonl").open("a") as audit:
+                audit.write(record + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--github-repo", required=True)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Default; log candidates without deleting")
+    mode.add_argument("--apply", action="store_true")
+    parser.add_argument("--not-before", type=datetime.fromisoformat,
+                        help="With --apply, remain report-only until this timezone-aware ISO timestamp")
+    args = parser.parse_args()
+    try:
+        apply_enabled(args.apply, args.not_before, datetime.now(timezone.utc))
+        cleanup(args)
+    except (ValueError, OSError, subprocess.SubprocessError) as error:
+        print(f"Cleanup stopped safely: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_cleanup_branches.py
+++ b/scripts/test_cleanup_branches.py
@@ -1,0 +1,118 @@
+import unittest
+import argparse
+from pathlib import Path
+import subprocess
+import tempfile
+from unittest.mock import patch
+from datetime import datetime, timezone
+from cleanup_branches import apply_enabled, skip_reason, cleanup
+
+
+class CleanupPolicyTests(unittest.TestCase):
+    def reason(self, name="codex/done", upstream="refs/remotes/origin/codex/done",
+               in_use=(), prs=(), heads=(), merged=True):
+        return skip_reason(name, upstream, set(in_use), set(prs), set(heads), merged)
+
+    def test_only_merged_deleted_remote_candidate(self):
+        self.assertIsNone(self.reason())
+
+    def test_preserved_names(self):
+        for name in ("main", "develop", "archive/old/nested", "release/1.7",
+                     "automation/daily-metrics", "codex/backup-save", "codex/macos-27-agentic-editor"):
+            with self.subTest(name=name):
+                self.assertEqual(self.reason(name=name), "preserved")
+
+    def test_worktree_is_never_detached(self):
+        self.assertIsNotNone(self.reason(in_use=["codex/done"]))
+
+    def test_pr_head_or_base_protects_branch(self):
+        self.assertIsNotNone(self.reason(prs=["codex/done"]))
+
+    def test_differently_named_upstream_is_checked(self):
+        self.assertIsNotNone(self.reason(upstream="refs/remotes/origin/remote-name", prs=["remote-name"]))
+        self.assertIsNotNone(self.reason(upstream="refs/remotes/origin/remote-name", heads=["remote-name"]))
+
+    def test_unpublished_and_other_remote_branches_require_manual_review(self):
+        self.assertIsNotNone(self.reason(upstream=""))
+        self.assertIsNotNone(self.reason(upstream="refs/remotes/upstream/codex/done"))
+
+    def test_live_remote_is_not_deleted(self):
+        self.assertIsNotNone(self.reason(heads=["codex/done"]))
+
+    def test_squashed_or_unique_commits_are_preserved(self):
+        self.assertIsNotNone(self.reason(merged=False))
+
+    def test_report_only_and_grace_period(self):
+        cutoff = datetime(2026, 9, 12, tzinfo=timezone.utc)
+        before = datetime(2026, 9, 5, tzinfo=timezone.utc)
+        self.assertFalse(apply_enabled(False, None, cutoff))
+        self.assertFalse(apply_enabled(True, cutoff, before))
+        self.assertTrue(apply_enabled(True, cutoff, cutoff))
+        self.assertTrue(apply_enabled(True, None, before))
+
+    def test_naive_cutoff_rejected(self):
+        with self.assertRaises(ValueError):
+            apply_enabled(True, datetime(2026, 9, 12), datetime.now(timezone.utc))
+
+    def simulate(self, apply=False, failure=None, dirty=False, changed=False, refusal=False):
+        with tempfile.TemporaryDirectory() as directory:
+            calls = []
+            repo = Path(directory).resolve()
+            common = repo / ".git"
+            common.mkdir()
+            def command(*args, cwd):
+                calls.append(args)
+                if failure and args[:2] == failure:
+                    raise subprocess.CalledProcessError(1, args)
+                if args[0] == "gh":
+                    return "[[]]"
+                key = args[1:]
+                if key == ("rev-parse", "--show-toplevel"): return str(repo)
+                if key == ("remote", "get-url", "origin"): return "https://github.com/example/repo.git"
+                if key == ("rev-parse", "--git-common-dir"): return str(common)
+                if key[0] == "status": return " M changed" if dirty else ""
+                if key[0] == "fetch": return ""
+                if key[:2] == ("rev-parse", "--verify"): return "base"
+                if key[0] == "ls-remote": return ""
+                if key[0] == "worktree": return "branch refs/heads/develop"
+                if key[0] == "for-each-ref": return "codex/done\ttip\trefs/remotes/origin/codex/done"
+                if key[0] == "rev-parse": return "new-tip" if changed else "tip"
+                if key[:2] == ("branch", "-d"):
+                    if refusal: raise subprocess.CalledProcessError(1, args)
+                    return "Deleted"
+                raise AssertionError(args)
+            args = argparse.Namespace(repo=str(repo), github_repo="example/repo", apply=apply, not_before=None)
+            with patch("cleanup_branches.run", side_effect=command), patch("cleanup_branches.subprocess.run", return_value=subprocess.CompletedProcess([], 0)):
+                cleanup(args)
+            return calls, (common / "branch-cleanup.jsonl").read_text()
+
+    def test_dry_run_never_calls_delete(self):
+        calls, audit = self.simulate()
+        self.assertFalse(any(call[:3] == ("git", "branch", "-d") for call in calls))
+        self.assertIn('"action": "candidate"', audit)
+
+    def test_apply_uses_nonforced_delete_and_logs_tip(self):
+        calls, audit = self.simulate(apply=True)
+        self.assertIn(("git", "branch", "-d", "--", "codex/done"), calls)
+        self.assertIn('"action": "deleted"', audit)
+        self.assertIn('"tip": "tip"', audit)
+
+    def test_tip_race_prevents_deletion(self):
+        calls, audit = self.simulate(apply=True, changed=True)
+        self.assertFalse(any(call[:3] == ("git", "branch", "-d") for call in calls))
+        self.assertIn("branch changed", audit)
+
+    def test_git_refusal_is_not_force_retried(self):
+        calls, audit = self.simulate(apply=True, refusal=True)
+        self.assertIn("refused", audit)
+        self.assertFalse(any("-D" in call for call in calls))
+
+    def test_dirty_worktree_or_network_failure_aborts(self):
+        with self.assertRaises(ValueError): self.simulate(apply=True, dirty=True)
+        for failure in (("git", "fetch"), ("gh", "api")):
+            with self.subTest(failure=failure), self.assertRaises(subprocess.CalledProcessError):
+                self.simulate(apply=True, failure=failure)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add conservative report-only/apply branch cleanup with protected names, fetched ancestry, open-PR and worktree checks, non-forced deletion, locking, and audit logging.
- Add 15 policy/command-flow tests and operating documentation.
- Schedule uses a pinned committed script and one-week report-only grace period.

## Verification
15 Python tests passed. Live dry-run passed without deleting any branches. No application code changed; Xcode builds are not required.

## Repository configuration
GitHub automatic head-branch deletion enabled after checking main/develop deletion protection and adding archive deletion protection. Local fetch.prune enabled. Recurring execution is handled by the local Codex automation, not GitHub Actions or launchd.

## Summary by Sourcery

Introduce a safe, auditable workflow for automatically cleaning up eligible local branches without deleting remote branches or overriding Git safety checks.

New Features:
- Add conservative local branch cleanup with report-only and apply modes, protected branch patterns, ancestry and safety checks, non-forced deletion, locking, and audit logging.

Enhancements:
- Protect branches referenced by open pull requests, checked out in worktrees, or still present on the remote, while requiring ancestry from the integration branches before cleanup.
- Add a one-week report-only grace period and pinned-script guidance for scheduled weekly execution.

Documentation:
- Document branch cleanup operation, safety policy, scheduling, disabling controls, recovery, and verification commands.

Tests:
- Add policy and command-flow coverage for protected branches, cleanup eligibility, grace periods, failure handling, deletion races, and non-forced deletion.

Chores:
- Enable local remote-reference pruning and configure GitHub remote head-branch cleanup with protected branch patterns.