### PR TITLE
Authenticate release counter checks with scoped App Store Connect tokens

### DIFF
--- a/.github/workflows/pre-release-ci.yml
+++ b/.github/workflows/pre-release-ci.yml
@@ -80,7 +80,10 @@ jobs:
         run: python3 scripts/ci/check_performance_budget.py
 
       - name: Verify release workflow regressions offline
-        run: python3 scripts/ci/test_release_workflow.py
+        run: |
+          python3 -m venv "$RUNNER_TEMP/nve-release-tests"
+          "$RUNNER_TEMP/nve-release-tests/bin/python" -m pip install 'cryptography==50.0.1'
+          "$RUNNER_TEMP/nve-release-tests/bin/python" scripts/ci/test_release_workflow.py
 
       - name: Check project compatibility on hosted Xcode
         id: project_probe

--- a/docs/XCODE_CLOUD_RELEASE.md
+++ b/docs/XCODE_CLOUD_RELEASE.md
@@ -86,6 +86,89 @@ Use this path only on a Mac that has the latest public GM Xcode installed.
 
 If App Store Connect says the build was made with beta Xcode, discard that archive and rebuild with public GM Xcode or Xcode Cloud.
 
+## App Store Connect credentials
+
+### What you need to provide
+
+The Cloud counter check needs an App Store Connect API key (`.p8`). A signing
+certificate export (`.p12`) cannot authenticate this API; do not convert, replace,
+upload, or share your signing certificates for this setup.
+
+1. Open App Store Connect > Users and Access > Integrations > App Store Connect API.
+   If API access is unavailable, the Account Holder must request it first.
+2. Reuse a suitable existing API key if available. Otherwise an Account Holder or
+   Admin can create a Team Key named `Neon release counter`. Select the least
+   privileged role that permits the needed Cloud reads; do not grant Admin merely
+   to avoid checking permissions. Team keys apply across the team's apps.
+3. Download the `.p8` once and keep it in your existing secure credential storage,
+   outside this repository and its worktrees. Record its Key ID and Issuer ID.
+   Individual keys do not use an Issuer ID; the built-in signer supports team
+   keys only. Individual keys need an externally generated JWT instead.
+4. Provide only the local key-file path, Key ID, key type, and (for a team key)
+   Issuer ID to the person configuring the tooling. Do not paste the private key,
+   JWT, password, or `.p12` contents into chat, Git, or logs.
+
+See Apple's [API access and key setup](https://developer.apple.com/help/app-store-connect/get-started/app-store-connect-api/)
+and [private-key storage guidance](https://developer.apple.com/documentation/appstoreconnectapi/creating-api-keys-for-app-store-connect-api).
+
+### Configuration handoff and read-only test
+
+`scripts/cloud_build_number.py` can generate a fresh two-minute JWT in memory for
+each counter request, using a team `.p8` key. Each token is scoped to that exact
+GET request. No JWT or private-key contents are saved in Git or printed. The
+signer requires Python's `cryptography` library (tested with 50.0.1); external-JWT
+and offline dry-run paths do not require it. To use an isolated Python environment:
+
+```bash
+nve_auth_env="$(mktemp -d "${TMPDIR:-/tmp}/nve-cloud-auth.XXXXXX")"
+python3 -m venv "$nve_auth_env"
+"$nve_auth_env/bin/python" -m pip install 'cryptography==50.0.1'
+export PATH="$nve_auth_env/bin:$PATH"
+```
+
+Use that Python environment for the preflight and release scripts. The API key
+must remain in secure storage outside any Git checkout, with owner-only access
+(`chmod 600` on the specific key file). A downloaded iCloud file still follows
+your iCloud synchronization policy; file permissions do not remove cloud copies.
+The script rejects keys stored inside Git and does not import or relocate keys.
+See Apple's [JWT requirements](https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests).
+
+With authentication configured, resolve Neon's Cloud product using Apple's
+[`GET /v1/ciProducts`](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-ciproducts)
+and confirm its associated app. This product ID is distinct from the App Store
+app ID and the Cloud workflow ID.
+
+Configure these non-secret references once from the repository root. Do not
+commit a shell script containing your machine's settings:
+
+```bash
+git config --local nve.asc.productId "REPLACE_WITH_CONFIRMED_CLOUD_PRODUCT_ID"
+git config --local nve.asc.keyId "REPLACE_WITH_KEY_ID"
+git config --local nve.asc.issuerId "REPLACE_WITH_ISSUER_ID"
+git config --local nve.asc.privateKeyPath "/absolute/secure/path/AuthKey_KEY_ID.p8"
+python3 scripts/cloud_build_number.py
+```
+
+These references are local to the Git repository (normally shared by linked
+worktrees); other clones need their own setup. Environment variables
+`ASC_CLOUD_PRODUCT_ID`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, and `ASC_PRIVATE_KEY_PATH`
+override the respective local settings.
+
+An existing `ASC_API_TOKEN` takes precedence over a token from the Keychain
+generic-password service named by `ASC_TOKEN_KEYCHAIN_SERVICE`; either token
+source takes precedence over `.p8` signing. Externally supplied tokens are not
+refreshed by this script, so remove stale token overrides when using `.p8` signing.
+Most Apple API requests reject token lifetimes above 20 minutes.
+The successful output
+contains only `product_id` and `max_number`. Missing credentials, denied/expired
+authentication, or active/queued builds must be resolved before release prep.
+This check starts no builds, allocates no number, and publishes nothing.
+
+Finally, verify the configured next Cloud build number in App Store Connect and
+coordinate automatic triggers before release prep. A history read cannot reserve
+a number or detect a manually configured next counter. Do not assume 1029 remains
+available if Cloud has since allocated another build.
+
 ## Xcode Cloud Archive
 
 For shared local/GitHub/Cloud build numbering, use the authenticated counter

--- a/release/RELEASE-WORKFLOW.md
+++ b/release/RELEASE-WORKFLOW.md
@@ -55,14 +55,22 @@ Retries preserve the allocated number and reject a changed Cloud counter.
 
 Configure these outside the repository:
 
+For first-time setup, see [App Store Connect credentials](../docs/XCODE_CLOUD_RELEASE.md#app-store-connect-credentials).
+
 - `ASC_CLOUD_PRODUCT_ID`: the Cloud **product** ID, not the App Store app ID or workflow ID.
+- For automatic two-minute, read-scoped JWTs, supply `ASC_KEY_ID`, `ASC_ISSUER_ID`,
+  and `ASC_PRIVATE_KEY_PATH` for a team key in secure storage outside Git with
+  owner-only file permissions. This mode requires Python `cryptography` (tested
+  with 50.0.1). The setup guide also supports local Git configuration of these
+  non-secret references; no key contents are stored in Git.
 - `ASC_TOKEN_KEYCHAIN_SERVICE`: a macOS Keychain generic-password service containing
   a valid App Store Connect JWT with read access to that Cloud product. Provision
   it using Keychain Access or your existing secure credential tooling; do not paste
   a token into chat or commit it.
 - Alternatively, inject `ASC_API_TOKEN` through your existing secure CI secret
-  provider. It takes precedence over Keychain. Refresh expired tokens through
-  that provider; this script does not generate JWTs or store private keys.
+  provider. It takes precedence over Keychain; both external-token sources take
+  precedence over `.p8` signing. Refresh external tokens through that provider;
+  only `.p8` signing automatically generates fresh JWTs before each request.
 
 Check the connection without editing files or starting builds:
 

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Offline regression suite for release preparation; never builds or publishes."""
+import base64
 import copy
 import hashlib
 import importlib.util
@@ -247,6 +248,9 @@ class ReleaseWorkflowTests(unittest.TestCase):
 
 class CloudCounterTests(unittest.TestCase):
     def setUp(self):
+        config = mock.patch.object(cloud_module, "local_setting", return_value="")
+        config.start()
+        self.addCleanup(config.stop)
         self.client = cloud_module.CloudBuildCounter("product-id", "fixture-token")
 
     @staticmethod
@@ -344,6 +348,117 @@ class CloudCounterTests(unittest.TestCase):
             with mock.patch.object(self.client._opener, "open", return_value=response):
                 with self.assertRaises(ValueError):
                     self.client._get(url, 1)
+
+
+class TeamKeyAuthenticationTests(unittest.TestCase):
+    def setUp(self):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+        self.temp = tempfile.TemporaryDirectory(prefix="nve-auth-test-")
+        self.addCleanup(self.temp.cleanup)
+        self.key = ec.generate_private_key(ec.SECP256R1())
+        self.path = Path(self.temp.name) / "AuthKey_TESTKEY123.p8"
+        self.path.write_bytes(self.key.private_bytes(serialization.Encoding.PEM,
+                             serialization.PrivateFormat.PKCS8, serialization.NoEncryption()))
+        self.path.chmod(0o600)
+        self.key_id = "TESTKEY123"
+        self.issuer = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        self.url = cloud_module.ORIGIN + "/v1/ciProducts/product-id/buildRuns?limit=200&fields%5BciBuildRuns%5D=number,executionProgress"
+
+    def signer(self):
+        return cloud_module.TeamKeyToken(self.key_id, self.issuer, str(self.path))
+
+    @staticmethod
+    def decode(value):
+        return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+    def test_signature_scope_and_renewal(self):
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec, utils
+        signer = self.signer()
+        for now in (1000, 2000):
+            with mock.patch.object(cloud_module.time, "time", return_value=now):
+                token = signer(self.url)
+            header, payload, signature = token.split(".")
+            self.assertEqual(json.loads(self.decode(header)), {"alg": "ES256", "kid": self.key_id, "typ": "JWT"})
+            claims = json.loads(self.decode(payload))
+            self.assertEqual(claims, {"iss": self.issuer, "iat": now, "exp": now + 120,
+                             "aud": "appstoreconnect-v1", "scope": ["GET " + self.url.removeprefix(cloud_module.ORIGIN)]})
+            raw = self.decode(signature)
+            self.assertEqual(len(raw), 64)
+            der = utils.encode_dss_signature(int.from_bytes(raw[:32], "big"), int.from_bytes(raw[32:], "big"))
+            self.key.public_key().verify(der, (header + "." + payload).encode(), ec.ECDSA(hashes.SHA256()))
+
+    def test_private_key_location_permissions_and_content(self):
+        self.path.chmod(0o644)
+        with self.assertRaisesRegex(ValueError, "permissions"):
+            self.signer()
+        self.path.chmod(0o600)
+        (self.path.parent / ".git").mkdir()
+        with self.assertRaisesRegex(ValueError, "outside Git"):
+            self.signer()
+        (self.path.parent / ".git").rmdir()
+        self.path.write_text("private fixture contents must not appear in errors")
+        with self.assertRaisesRegex(ValueError, "P-256") as error:
+            self.signer()
+        self.assertNotIn("private fixture", str(error.exception))
+        self.path.unlink()
+        with self.assertRaisesRegex(ValueError, "Could not read"):
+            self.signer()
+
+    def test_wrong_curve_and_identifiers_are_rejected(self):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+        self.path.write_bytes(ec.generate_private_key(ec.SECP384R1()).private_bytes(
+            serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()))
+        with self.assertRaisesRegex(ValueError, "P-256"):
+            self.signer()
+        for key_id, issuer in (("", self.issuer), (self.key_id, "not-an-issuer")):
+            with self.assertRaises(ValueError):
+                cloud_module.TeamKeyToken(key_id, issuer, str(self.path))
+        with self.assertRaisesRegex(ValueError, "absolute"):
+            cloud_module.TeamKeyToken(self.key_id, self.issuer, "relative.p8")
+
+    def test_authentication_precedence_and_local_configuration(self):
+        settings = {"productId": "product-id", "keyId": self.key_id,
+                    "issuerId": self.issuer, "privateKeyPath": str(self.path)}
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(cloud_module, "local_setting", side_effect=settings.get):
+            client = cloud_module.CloudBuildCounter.from_environment()
+            self.assertIsInstance(client._token, cloud_module.TeamKeyToken)
+        with mock.patch.dict(os.environ, {"ASC_CLOUD_PRODUCT_ID": "override", "ASC_API_TOKEN": "external-token"}, clear=True), mock.patch.object(cloud_module, "local_setting") as config:
+            client = cloud_module.CloudBuildCounter.from_environment()
+            self.assertEqual(client.product_id, "override")
+            self.assertEqual(client._token, "external-token")
+            config.assert_not_called()
+        env = {"ASC_CLOUD_PRODUCT_ID": "product-id", "ASC_KEY_ID": self.key_id,
+               "ASC_ISSUER_ID": self.issuer, "ASC_PRIVATE_KEY_PATH": str(self.path)}
+        with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(cloud_module, "local_setting") as config:
+            self.assertIsInstance(cloud_module.CloudBuildCounter.from_environment()._token, cloud_module.TeamKeyToken)
+            config.assert_not_called()
+
+    def test_generated_tokens_are_refreshed_only_for_valid_requests(self):
+        signer = mock.Mock(return_value="generated-token")
+        client = cloud_module.CloudBuildCounter("product-id", signer)
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = b'{}'
+        with mock.patch.object(client._opener, "open", return_value=response):
+            client._get(self.url, 1)
+            client._get(self.url, 1)
+            self.assertEqual(signer.call_count, 2)
+            with self.assertRaises(ValueError):
+                client._get("https://evil.invalid/", 1)
+            self.assertEqual(signer.call_count, 2)
+        for url in ("https://evil.invalid/", self.url + "#fragment", self.url.replace("https:", "http:")):
+            with self.assertRaises(ValueError):
+                self.signer()(url)
+
+    def test_local_config_is_never_read_from_global_settings(self):
+        with mock.patch.object(cloud_module.subprocess, "run", return_value=mock.Mock(returncode=0, stdout="fixture\n")) as run:
+            self.assertEqual(cloud_module.local_setting("keyId"), "fixture")
+            self.assertIn("--local", run.call_args.args[0])
+            self.assertIn("nve.asc.keyId", run.call_args.args[0])
+        with mock.patch.object(cloud_module.subprocess, "run", return_value=mock.Mock(returncode=1)):
+            self.assertEqual(cloud_module.local_setting("keyId"), "")
 
 
 if __name__ == "__main__":

--- a/scripts/cloud_build_number.py
+++ b/scripts/cloud_build_number.py
@@ -2,9 +2,12 @@
 """Read-only App Store Connect counter preflight. Never reserves or starts builds."""
 from __future__ import annotations
 
+import base64
 import json
 import os
+from pathlib import Path
 import re
+import stat
 import subprocess
 import time
 import urllib.error
@@ -14,6 +17,75 @@ import urllib.request
 ORIGIN = "https://api.appstoreconnect.apple.com"
 
 
+def local_setting(name: str) -> str:
+    """Read non-secret setup from this checkout's local Git config only."""
+    try:
+        result = subprocess.run(["git", "-C", str(Path(__file__).resolve().parents[1]),
+                                 "config", "--local", "--get", "nve.asc." + name],
+                                capture_output=True, text=True, timeout=10)
+        if result.returncode not in (0, 1):
+            raise ValueError("Could not read local App Store Connect configuration.")
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except (OSError, subprocess.SubprocessError):
+        raise ValueError("Could not read local App Store Connect configuration.") from None
+
+
+class TeamKeyToken:
+    """Generate a two-minute, GET-scoped JWT in memory for each request."""
+    def __init__(self, key_id: str, issuer_id: str, key_path: str):
+        if not re.fullmatch(r"[A-Z0-9]{10}", key_id or "") or not re.fullmatch(
+                r"[a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}", issuer_id or ""):
+            raise ValueError("Set ASC_KEY_ID and ASC_ISSUER_ID for a team API key.")
+        path = Path(key_path).expanduser()
+        if not key_path or not path.is_absolute():
+            raise ValueError("ASC_PRIVATE_KEY_PATH must be an absolute path outside Git.")
+        try:
+            path = path.resolve(strict=True)
+            if any((parent / ".git").exists() for parent in path.parents):
+                raise ValueError("Keep the API private key outside Git repositories and worktrees.")
+            info = path.stat()
+            if not stat.S_ISREG(info.st_mode) or info.st_size > 16384:
+                raise ValueError("Expected a small private-key file.")
+            if info.st_mode & 0o077:
+                raise ValueError("Restrict the API private-key file permissions to 600 before use.")
+            with path.open("rb") as source:
+                pem = source.read(16385)
+            if len(pem) > 16384:
+                raise ValueError("Expected a small private-key file.")
+        except OSError:
+            raise ValueError("Could not read the configured API private-key file.") from None
+        try:
+            from cryptography.hazmat.primitives import serialization
+            from cryptography.hazmat.primitives.asymmetric import ec
+        except ImportError:
+            raise ValueError("API-key signing requires cryptography; see docs/XCODE_CLOUD_RELEASE.md.") from None
+        try:
+            key = serialization.load_pem_private_key(pem, password=None)
+        except (ValueError, TypeError):
+            raise ValueError("Expected an unencrypted App Store Connect P-256 .p8 key.") from None
+        if not isinstance(key, ec.EllipticCurvePrivateKey) or not isinstance(key.curve, ec.SECP256R1):
+            raise ValueError("Expected an App Store Connect P-256 .p8 key.")
+        self._key, self._key_id, self._issuer_id = key, key_id, issuer_id
+
+    def __call__(self, url: str) -> str:
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec, utils
+        parsed = urllib.parse.urlsplit(url)
+        if (parsed.scheme != "https" or parsed.netloc != "api.appstoreconnect.apple.com"
+                or parsed.fragment or not re.fullmatch(r"/v1/ciProducts/[A-Za-z0-9-]+/buildRuns", parsed.path)):
+            raise ValueError("Refusing to sign an unexpected Cloud request.")
+        now = int(time.time())
+        header = {"alg": "ES256", "kid": self._key_id, "typ": "JWT"}
+        scope = parsed.path + ("?" + parsed.query if parsed.query else "")
+        claims = {"iss": self._issuer_id, "iat": now, "exp": now + 120,
+                  "aud": "appstoreconnect-v1", "scope": ["GET " + scope]}
+        def encode(value):
+            return base64.urlsafe_b64encode(value).rstrip(b"=")
+        message = b".".join(encode(json.dumps(value, separators=(",", ":")).encode()) for value in (header, claims))
+        r, s = utils.decode_dss_signature(self._key.sign(message, ec.ECDSA(hashes.SHA256())))
+        return (message + b"." + encode(r.to_bytes(32, "big") + s.to_bytes(32, "big"))).decode()
+
+
 class NoRedirect(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         # Never forward the bearer token to a redirect target.
@@ -21,10 +93,10 @@ class NoRedirect(urllib.request.HTTPRedirectHandler):
 
 
 class CloudBuildCounter:
-    def __init__(self, product_id: str, token: str):
+    def __init__(self, product_id: str, token):
         if not re.fullmatch(r"[A-Za-z0-9-]+", product_id or ""):
             raise ValueError("Set ASC_CLOUD_PRODUCT_ID to the app's Xcode Cloud product ID.")
-        if not token or any(c.isspace() for c in token):
+        if not callable(token) and (not isinstance(token, str) or not token or any(c.isspace() for c in token)):
             raise ValueError("A valid App Store Connect bearer token is required.")
         self.product_id = product_id
         self._token = token
@@ -32,7 +104,11 @@ class CloudBuildCounter:
 
     @classmethod
     def from_environment(cls):
-        product = os.environ.get("ASC_CLOUD_PRODUCT_ID", "")
+        product = os.environ.get("ASC_CLOUD_PRODUCT_ID")
+        if product is None:
+            product = local_setting("productId")
+        if not product:
+            raise ValueError("Set ASC_CLOUD_PRODUCT_ID or local nve.asc.productId.")
         token = os.environ.get("ASC_API_TOKEN", "")
         service = os.environ.get("ASC_TOKEN_KEYCHAIN_SERVICE", "")
         if not token and service:
@@ -42,8 +118,11 @@ class CloudBuildCounter:
                 token = result.stdout.strip()
             except (OSError, subprocess.SubprocessError):
                 raise ValueError("Could not read the configured App Store Connect token from Keychain.") from None
-        if not product or not token:
-            raise ValueError("Cloud preflight requires ASC_CLOUD_PRODUCT_ID and an App Store Connect JWT via ASC_API_TOKEN or ASC_TOKEN_KEYCHAIN_SERVICE. Do not put credentials in Git.")
+        if not token:
+            def setting(env_name, config_name):
+                return os.environ[env_name] if env_name in os.environ else local_setting(config_name)
+            token = TeamKeyToken(setting("ASC_KEY_ID", "keyId"), setting("ASC_ISSUER_ID", "issuerId"),
+                                 setting("ASC_PRIVATE_KEY_PATH", "privateKeyPath"))
         return cls(product, token)
 
     def _get(self, url: str, timeout: float) -> dict:
@@ -51,7 +130,8 @@ class CloudBuildCounter:
         expected_path = f"/v1/ciProducts/{self.product_id}/buildRuns"
         if parsed.scheme != "https" or parsed.netloc != "api.appstoreconnect.apple.com" or parsed.path != expected_path or parsed.fragment:
             raise ValueError("Refusing an unexpected App Store Connect pagination URL.")
-        request = urllib.request.Request(url, headers={"Authorization": "Bearer " + self._token,
+        token = self._token(url) if callable(self._token) else self._token
+        request = urllib.request.Request(url, headers={"Authorization": "Bearer " + token,
                                                       "Accept": "application/json"})
         try:
             with self._opener.open(request, timeout=timeout) as response:


### PR DESCRIPTION
Adds in-memory two-minute ES256 tokens for read-only Cloud counter requests, local non-secret configuration, private-key safeguards, and setup documentation. Preserves external-token support. Adds six authentication regression tests and installs the pinned cryptography dependency in an isolated CI environment. All 29 local tests passed. No private keys, tokens, or machine-specific IDs are committed. Live Apple authentication passed; Cloud build 968 cancellation is being handled separately. Merge only after hosted checks pass.

## Summary by Sourcery

Authenticate read-only Xcode Cloud counter checks with securely scoped, short-lived App Store Connect team-key tokens while retaining external-token support.

New Features:
- Add automatic two-minute ES256 JWT generation for read-only App Store Connect Cloud counter requests using scoped team API keys.
- Support local Git configuration for non-secret App Store Connect references while preserving environment and external-token authentication.

Bug Fixes:
- Reject unsafe, malformed, incorrectly permissioned, or repository-contained private keys and refuse to sign unexpected request URLs.

Enhancements:
- Preserve external API-token precedence and refresh generated tokens for each valid request.
- Document App Store Connect credential setup, secure key handling, local configuration, and read-only counter verification.

Build:
- Run release workflow regression tests in an isolated virtual environment with pinned cryptography 50.0.1.

Documentation:
- Document team API key requirements, private-key safeguards, local configuration, token precedence, and Cloud counter preflight usage.

Tests:
- Add authentication regression coverage for JWT claims and signatures, token renewal, key validation, configuration precedence, request scoping, and local Git settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for App Store Connect team API key authentication when retrieving cloud build numbers.
  - Added automatic JWT generation using configured `.p8` keys, with support for local Git configuration and environment variables.
  - Added authentication-source precedence and token refresh handling.

- **Documentation**
  - Expanded release and Xcode Cloud setup guides with API key creation, configuration, permissions, handoff, and read-only verification instructions.

- **Tests**
  - Added comprehensive coverage for team-key authentication and credential validation.
  - Improved offline release workflow verification with an isolated Python environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->