### PR TITLE
Fix cropped AI Assistant screenshots on GitHub Pages

### DIFF
--- a/site/da/index.html
+++ b/site/da/index.html
@@ -557,6 +557,7 @@
 
     .ai-shot .screenshot-link {
       display: grid;
+      grid-template-rows: minmax(0, 1fr);
       min-height: 0;
       place-items: center;
       overflow: hidden;
@@ -565,8 +566,10 @@
 
     .ai-shot .screenshot-link img {
       display: block;
-      width: auto;
-      height: auto;
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
       max-width: 100%;
       max-height: 100%;
       object-fit: contain;

--- a/site/de/index.html
+++ b/site/de/index.html
@@ -558,6 +558,7 @@
 
     .ai-shot .screenshot-link {
       display: grid;
+      grid-template-rows: minmax(0, 1fr);
       min-height: 0;
       place-items: center;
       overflow: hidden;
@@ -566,8 +567,10 @@
 
     .ai-shot .screenshot-link img {
       display: block;
-      width: auto;
-      height: auto;
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
       max-width: 100%;
       max-height: 100%;
       object-fit: contain;

--- a/site/es/index.html
+++ b/site/es/index.html
@@ -557,6 +557,7 @@
 
     .ai-shot .screenshot-link {
       display: grid;
+      grid-template-rows: minmax(0, 1fr);
       min-height: 0;
       place-items: center;
       overflow: hidden;
@@ -565,8 +566,10 @@
 
     .ai-shot .screenshot-link img {
       display: block;
-      width: auto;
-      height: auto;
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
       max-width: 100%;
       max-height: 100%;
       object-fit: contain;

--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -557,6 +557,7 @@
 
     .ai-shot .screenshot-link {
       display: grid;
+      grid-template-rows: minmax(0, 1fr);
       min-height: 0;
       place-items: center;
       overflow: hidden;
@@ -565,8 +566,10 @@
 
     .ai-shot .screenshot-link img {
       display: block;
-      width: auto;
-      height: auto;
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
       max-width: 100%;
       max-height: 100%;
       object-fit: contain;

--- a/site/index.html
+++ b/site/index.html
@@ -558,6 +558,7 @@
 
     .ai-shot .screenshot-link {
       display: grid;
+      grid-template-rows: minmax(0, 1fr);
       min-height: 0;
       place-items: center;
       overflow: hidden;
@@ -566,8 +567,10 @@
 
     .ai-shot .screenshot-link img {
       display: block;
-      width: auto;
-      height: auto;
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
       max-width: 100%;
       max-height: 100%;
       object-fit: contain;

--- a/site/ja/index.html
+++ b/site/ja/index.html
@@ -557,6 +557,7 @@
 
     .ai-shot .screenshot-link {
       display: grid;
+      grid-template-rows: minmax(0, 1fr);
       min-height: 0;
       place-items: center;
       overflow: hidden;
@@ -565,8 +566,10 @@
 
     .ai-shot .screenshot-link img {
       display: block;
-      width: auto;
-      height: auto;
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
       max-width: 100%;
       max-height: 100%;
       object-fit: contain;

--- a/site/zh-Hans/index.html
+++ b/site/zh-Hans/index.html
@@ -557,6 +557,7 @@
 
     .ai-shot .screenshot-link {
       display: grid;
+      grid-template-rows: minmax(0, 1fr);
       min-height: 0;
       place-items: center;
       overflow: hidden;
@@ -565,8 +566,10 @@
 
     .ai-shot .screenshot-link img {
       display: block;
-      width: auto;
-      height: auto;
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+      min-height: 0;
       max-width: 100%;
       max-height: 100%;
       object-fit: contain;


### PR DESCRIPTION
The AI Assistant gallery clips its screenshots, including the German “Fragen, prüfen, weitermachen” card. The portrait image renders about 1,181 px tall inside a 420 px frame; the landscape screenshot overflows too.

Constrain the nested grid track and size the image box to its frame, retaining object-fit: contain so the full screenshot keeps its proportions. Apply the same scoped CSS correction to all seven language pages.

Validation: reproduced on live Pages; browser geometry checks passed for both images in all seven locales at 390 px and 1280 px viewport widths (14 cases). Visually checked German desktop and mobile layouts, verified screenshot link labels and keyboard focus order/outline, and passed git diff --check. No Apple app code changed; Level 0, no Xcode build. Native VoiceOver speech was not exercised. Live deployment remains pending merge.

## Summary by Sourcery

Fix AI Assistant gallery layout so screenshots fit completely within their frames on every language page.

Bug Fixes:
- Prevent AI Assistant screenshots from being cropped in their gallery frames across all seven localized GitHub Pages sites.

Enhancements:
- Preserve full portrait and landscape screenshots within their containers while maintaining their proportions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved AI Assistant screenshot layouts across the main, Danish, German, Spanish, French, Japanese, and Simplified Chinese landing pages.
  * Screenshots now fill the available display area while preserving their aspect ratio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->