### PR TITLE
Fix document save safety and prepare the 1.6.2 release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,23 +11,31 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 - Detects external edits on network volumes even when filesystem change notifications are missed.
 - Lets you disable the automatic Welcome Tour and opens Finder documents without interrupting them with a tour.
 - Keeps purchase feedback stable while Settings updates and product information refreshes.
+- Improves external-document save safety and opens text files with unknown extensions or no extension.
 
 ### Highlights
 
 - Adds a background metadata polling fallback for open network-volume files, reusing the existing external-change conflict handling.
 - Adds an automatic Welcome Tour preference; Finder file launches suppress the tour, including after app updates.
 - Presents purchase alerts using local SwiftUI presentation state and preserves the latest queued purchase message.
+- Retains a complete local recovery copy of external-document save payloads on iOS/iPadOS and visionOS.
 
 ### Fixes
 
 - Avoids duplicate network-file checks and skips tabs that are still loading or already reviewing an external change.
 - Rechecks launch intent before presenting a delayed Welcome Tour.
 - Prevents purchase-alert state publication during SwiftUI view updates and stops successful product metadata refreshes from clearing purchase feedback.
+- Coordinates external file access and saves large-file snapshots in the background without discarding newer edits.
+- Preserves queued encoding changes and refreshes cached metadata after atomic replacement to avoid false save conflicts.
+- Preserves ANSI escape sequences, tabs, and Unicode formatting when loading text instead of treating them as pasted display markers.
+- Keeps failed-open placeholders read-only and retains unsaved buffers when files become unavailable or conflict.
+- Waits for saves before closing tabs or projects; failed or conflicted documents remain open.
 
 ### Maintenance
 
 - Isolates release preparation from develop, reuses allocated build numbers, and verifies generated documentation in a disposable dry run.
 - Keeps public download references on the published version until release verification succeeds.
+- Distinguishes proven historical TestFlight distribution-only actions from active Xcode Cloud builds during release-number preflight.
 
 ### Breaking changes
 

--- a/Neon Vision Editor/Core/RemoteSessionStore.swift
+++ b/Neon Vision Editor/Core/RemoteSessionStore.swift
@@ -1721,7 +1721,11 @@ final class RemoteSessionStore {
                     return
                 }
 
-                let content = String(decoding: payloadData, as: UTF8.self)
+                guard let content = String(data: payloadData, encoding: .utf8),
+                      CoordinatedDocumentAccess.isText(Data(payloadData), encoding: .utf8) else {
+                    continuation.resume(returning: .failure("Remote file is not valid UTF-8 text; it was not opened for editing."))
+                    return
+                }
                 let name = URL(fileURLWithPath: remotePath).lastPathComponent
                 continuation.resume(
                     returning: .success(

--- a/Neon Vision Editor/Data/CoordinatedDocumentAccess.swift
+++ b/Neon Vision Editor/Data/CoordinatedDocumentAccess.swift
@@ -1,0 +1,109 @@
+import Foundation
+import CryptoKit
+
+/// External document access must cooperate with File Provider, not just write
+/// atomically to its local cache. Keep coordination off the UI thread at callers.
+nonisolated enum CoordinatedDocumentAccess {
+    static func read<T>(at url: URL, _ body: (URL) throws -> T) throws -> T {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+        var coordinationError: NSError?
+        var result: Result<T, Swift.Error>?
+        NSFileCoordinator().coordinate(readingItemAt: url, options: [], error: &coordinationError) { coordinatedURL in
+            var freshURL = coordinatedURL
+            freshURL.removeAllCachedResourceValues()
+            result = Result { try body(freshURL) }
+        }
+        if let coordinationError { throw coordinationError }
+        guard let result else { throw CocoaError(.fileReadUnknown) }
+        return try result.get()
+    }
+
+    static func write<T>(at url: URL, _ body: (URL) throws -> T) throws -> T {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer { if accessed { url.stopAccessingSecurityScopedResource() } }
+        var coordinationError: NSError?
+        var result: Result<T, Swift.Error>?
+        NSFileCoordinator().coordinate(writingItemAt: url, options: .forReplacing, error: &coordinationError) { coordinatedURL in
+            var freshURL = coordinatedURL
+            freshURL.removeAllCachedResourceValues()
+            result = Result { try body(freshURL) }
+        }
+        if let coordinationError { throw coordinationError }
+        guard let result else { throw CocoaError(.fileWriteUnknown) }
+        return try result.get()
+    }
+
+    /// Retain a full local copy even after a provider accepts a write: that is
+    /// not proof of server upload. One latest copy per source path, visible in
+    /// the app's Documents/Neon Recovery folder, never silently truncated.
+    static func recoveryURL(for source: URL, in recoveryDirectory: URL? = nil) throws -> URL? {
+        let directory: URL
+        if let recoveryDirectory {
+            directory = recoveryDirectory
+        } else {
+#if os(iOS) || os(visionOS)
+        guard !source.standardizedFileURL.path.hasPrefix(NSHomeDirectory() + "/") else { return nil }
+        directory = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask,
+                                                    appropriateFor: nil, create: true)
+            .appendingPathComponent("Neon Recovery", isDirectory: true)
+#else
+            return nil
+#endif
+        }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let key = SHA256.hash(data: Data(source.standardizedFileURL.path.utf8))
+            .prefix(12).map { String(format: "%02x", $0) }.joined()
+        let displayName = String(decoding: source.lastPathComponent.utf8.prefix(180), as: UTF8.self)
+        return directory.appendingPathComponent(key + "-" + displayName)
+    }
+
+    static func preserveRecovery(_ data: Data, for source: URL, in directory: URL? = nil) throws {
+        if let destination = try recoveryURL(for: source, in: directory) {
+            try data.write(to: destination, options: .atomic)
+        }
+    }
+
+    static func preserveRecovery(from temporary: URL, for source: URL, in directory: URL? = nil) throws {
+        guard let destination = try recoveryURL(for: source, in: directory) else { return }
+        let staging = destination.deletingLastPathComponent().appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: staging) }
+        try FileManager.default.copyItem(at: temporary, to: staging)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            _ = try FileManager.default.replaceItemAt(destination, withItemAt: staging)
+        } else {
+            try FileManager.default.moveItem(at: staging, to: destination)
+        }
+    }
+
+    /// Content validation, independent of filename. Recognize UTF-16 before
+    /// checking control characters so its zero bytes are not mistaken for binary.
+    static func isText(_ data: Data, encoding: TextEncodingDescriptor? = nil) -> Bool {
+        if data.isEmpty { return true }
+        guard let descriptor = encoding ?? FileBackedTextDocument.boundedEncoding(from: data, allowsIncompleteUTF8Sequence: true) else { return false }
+        var text: String?
+        if descriptor.identifier == .utf8 || descriptor.identifier == .utf8WithBOM {
+            text = String(decoding: data, as: UTF8.self)
+        } else {
+            text = descriptor.decode(data)
+            // A bounded probe may end between a UTF-16 surrogate pair.
+            // Omit only the incomplete suffix, never an interior invalid unit.
+            if text == nil, data.count >= 2,
+               descriptor.encoding == .utf16LittleEndian || descriptor.encoding == .utf16BigEndian {
+                let bytes = Array(data.suffix(2))
+                let lastUnit = descriptor.encoding == .utf16LittleEndian
+                    ? UInt16(bytes[0]) | UInt16(bytes[1]) << 8
+                    : UInt16(bytes[0]) << 8 | UInt16(bytes[1])
+                if (0xD800...0xDBFF).contains(lastUnit) {
+                    text = descriptor.decode(Data(data.dropLast(2)))
+                }
+            }
+        }
+        guard let text else { return false }
+        return !text.unicodeScalars.contains { scalar in
+            // ANSI escapes, backspace and vertical tabs occur in valid logs
+            // and source fixtures. A NUL is the binary signal, not all C0 text.
+            scalar.value == 0
+        }
+    }
+}

--- a/Neon Vision Editor/Data/EditorViewModel.swift
+++ b/Neon Vision Editor/Data/EditorViewModel.swift
@@ -130,19 +130,12 @@ private enum EditorLoadHelper {
     nonisolated static let skipFingerprintByteThreshold = 1_000_000
     nonisolated static let streamChunkBytes = 262_144
 
-    nonisolated static func sanitizeTextForFileLoad(_ input: String, useFastPath: Bool) -> String {
-        if useFastPath {
-            // Fast path for large files: preserve visible content, normalize line endings,
-            // and only strip NUL which frequently breaks text system behavior.
-            if !input.contains("\0") && !input.contains("\r") {
-                return input
-            }
-            return input
-                .replacingOccurrences(of: "\0", with: "")
-                .replacingOccurrences(of: "\r\n", with: "\n")
-                .replacingOccurrences(of: "\r", with: "\n")
-        }
-        return EditorTextSanitizer.sanitize(input)
+    nonisolated static func sanitizeTextForFileLoad(_ input: String, useFastPath _: Bool) -> String {
+        // File contents are not pasted display markers: preserve tabs, ANSI
+        // escapes and Unicode formatting. Only normalize the editor's newlines.
+        guard input.contains("\r") else { return input }
+        return input.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
     }
 
     nonisolated static func decodeFileText(
@@ -753,6 +746,7 @@ class EditorViewModel {
     var isLineWrapEnabled: Bool = true
     @ObservationIgnored private let tabCommandQueue = TabCommandQueue()
     @ObservationIgnored private var pendingLanguageDetectionTasks: [UUID: Task<Void, Never>] = [:]
+    @ObservationIgnored private var localSaveTasks: [UUID: (id: UUID, task: Task<Void, Never>)] = [:]
     @ObservationIgnored private var pendingExternalFileRefreshTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored private var pendingExternalRefreshTabIDs: Set<UUID> = []
     @ObservationIgnored private var refreshedExternalTabIDs: Set<UUID> = []
@@ -1670,6 +1664,28 @@ class EditorViewModel {
         closeTab(tabID: tab.id)
     }
 
+    /// Closing must wait for local writes, including writes queued while an
+    /// earlier snapshot was saving. Failed saves and newer edits stay open.
+    @discardableResult
+    func saveAndCloseTabs(tabIDs: [UUID]) async -> Bool {
+        for tabID in tabIDs {
+            if let tab = tabs.first(where: { $0.id == tabID }), tab.isDirty {
+                saveFile(tabID: tabID)
+            }
+        }
+        for tabID in tabIDs {
+            while let pending = localSaveTasks[tabID]?.task { await pending.value }
+            guard let tab = tabs.first(where: { $0.id == tabID }),
+                  !tab.isDirty, !tab.isLoadingContent else { continue }
+            closeTab(tabID: tabID)
+        }
+        let closed = !tabs.contains(where: { tabIDs.contains($0.id) })
+        if !closed, fileEncodingErrorMessage == nil, pendingExternalFileConflict == nil {
+            fileEncodingErrorMessage = "Unsaved tabs were left open. Finish saving or resolve any conflicts before closing them."
+        }
+        return closed
+    }
+
     // MARK: - Saving and Conflict Resolution
 
     // Saves tab content to the existing file URL or falls back to Save As.
@@ -1680,37 +1696,19 @@ class EditorViewModel {
             enqueueRemoteSave(tabID: tabID, remotePath: remotePath, signpostName: "save_remote_file")
             return
         }
-        if !allowExternalOverwrite,
+        if !tabs[index].usesFileBackedStorage, !allowExternalOverwrite, localSaveTasks[tabID] == nil,
            let conflict = detectExternalConflict(for: tabs[index]) {
             pendingExternalFileConflict = conflict
             return
         }
         if let fileBackedDocument = tabs[index].fileBackedDocument,
            let url = tabs[index].fileURL {
-            do {
-                try fileBackedDocument.saveAtomically(allowExternalOverwrite: allowExternalOverwrite)
-                let metadata = try url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
-                _ = applyTabCommand(
-                    .markSaved(
-                        tabID: tabID,
-                        fileURL: nil,
-                        fingerprint: nil,
-                        fileModificationDate: metadata.contentModificationDate,
-                        fileEncodingRawValue: fileBackedDocument.encodingDescriptor.encodingRawValue,
-                        fileByteCount: metadata.fileSize
-                    )
-                )
-            } catch FileBackedTextDocument.Error.externalConflict {
-                if let conflict = detectExternalConflict(for: tabs[index]) {
-                    pendingExternalFileConflict = conflict
-                }
-            } catch {
-                fileEncodingErrorMessage = "Couldn’t save \(tabs[index].name). \(error.localizedDescription)"
-            }
+            enqueueFileBackedSave(tabID: tabID, document: fileBackedDocument, to: url,
+                                  saveAs: false, allowExternalOverwrite: allowExternalOverwrite)
             return
         }
         if let url = tabs[index].fileURL {
-            enqueueSave(tabID: tabID, to: url, updateFileURLOnSuccess: nil, signpostName: "save_file")
+            enqueueSave(tabID: tabID, to: url, updateFileURLOnSuccess: nil, signpostName: "save_file", allowExternalOverwrite: allowExternalOverwrite)
         } else {
             saveFileAs(tabID: tabID)
         }
@@ -2053,30 +2051,50 @@ class EditorViewModel {
     }
 
     private func saveFileBackedAs(tabID: UUID, document: FileBackedTextDocument, to destinationURL: URL) {
+        enqueueFileBackedSave(tabID: tabID, document: document, to: destinationURL, saveAs: true)
+    }
+
+    private func enqueueFileBackedSave(tabID: UUID, document: FileBackedTextDocument, to destinationURL: URL,
+                                      saveAs: Bool, allowExternalOverwrite: Bool = false) {
         guard let index = tabIndex(for: tabID), tabs[index].fileBackedDocument === document else { return }
-        do {
-            try document.saveAtomically(to: destinationURL)
-            let replacement = try FileBackedTextDocument(
-                url: destinationURL,
-                knownUTF8Encoding: document.encodingDescriptor
-            )
-            try replacement.prepareViewportIndex()
-            let metadata = try destinationURL.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
-            _ = tabs[index].installLoadedFileBackedDocument(replacement)
-            _ = applyTabCommand(
-                .markSaved(
-                    tabID: tabID,
-                    fileURL: destinationURL,
-                    fingerprint: nil,
-                    fileModificationDate: metadata.contentModificationDate,
-                    fileEncodingRawValue: replacement.encodingDescriptor.encodingRawValue,
-                    fileByteCount: metadata.fileSize
-                )
-            )
-            pendingExternalFileConflict = nil
-        } catch {
-            fileEncodingErrorMessage = "Couldn’t save \(destinationURL.lastPathComponent). The document was left unchanged. \(error.localizedDescription)"
+        let predecessor = localSaveTasks[tabID]?.task
+        let saveID = UUID()
+        let task = Task { [weak self] in
+            await predecessor?.value
+            guard let self else { return }
+            defer { if self.localSaveTasks[tabID]?.id == saveID { self.localSaveTasks[tabID] = nil } }
+            guard let index = self.tabIndex(for: tabID), let document = self.tabs[index].fileBackedDocument else { return }
+            let revision = self.tabs[index].contentRevision
+            let snapshot = document.makeSaveSnapshot()
+            do {
+                let receipt = try await Task.detached(priority: .utility) {
+                    try snapshot.write(to: saveAs ? destinationURL : nil, allowExternalOverwrite: allowExternalOverwrite)
+                }.value
+                guard let finalIndex = self.tabIndex(for: tabID), self.tabs[finalIndex].fileBackedDocument === document else { return }
+                if !saveAs {
+                    document.acceptSave(receipt)
+                    self.tabs[finalIndex].lastKnownFileModificationDate = receipt.modificationDate
+                    self.tabs[finalIndex].updateFileByteCount(receipt.byteCount)
+                }
+                guard self.tabs[finalIndex].contentRevision == revision else {
+                    if saveAs { self.fileEncodingErrorMessage = "A copy was saved, but newer edits remain in the original tab. Save again to include them." }
+                    return
+                }
+                if let replacement = receipt.replacement {
+                    _ = self.tabs[finalIndex].installLoadedFileBackedDocument(replacement)
+                }
+                _ = self.applyTabCommand(.markSaved(tabID: tabID, fileURL: saveAs ? destinationURL : nil,
+                                                   fingerprint: nil, fileModificationDate: receipt.modificationDate,
+                                                   fileEncodingRawValue: document.encodingDescriptor.encodingRawValue,
+                                                   fileByteCount: receipt.byteCount))
+                self.pendingExternalFileConflict = nil
+            } catch FileBackedTextDocument.Error.externalConflict {
+                self.pendingExternalFileConflict = ExternalFileConflictState(tabID: tabID, fileURL: destinationURL, diskModifiedAt: nil)
+            } catch {
+                self.fileEncodingErrorMessage = "Couldn’t save \(destinationURL.lastPathComponent). \(error.localizedDescription)"
+            }
         }
+        localSaveTasks[tabID] = (saveID, task)
     }
 
     func saveFileAs(tab: TabData) {
@@ -2140,22 +2158,23 @@ class EditorViewModel {
         to destinationURL: URL,
         updateFileURLOnSuccess: URL?,
         signpostName: StaticString,
-        encodingOverride: TextEncodingDescriptor? = nil
+        encodingOverride: TextEncodingDescriptor? = nil,
+        allowExternalOverwrite: Bool = false
     ) {
         guard let index = tabIndex(for: tabID) else { return }
         let snapshotContent = tabs[index].document.string()
         let snapshotRevision = tabs[index].contentRevision
-        let snapshotLastSavedFingerprint = tabs[index].lastSavedFingerprint
-        let previousEncoding = tabs[index].fileEncoding
-        let previousEncodingWasAutomatic = tabs[index].usesAutomaticFileEncoding
-        let snapshotEncoding = encodingOverride ?? previousEncoding
         let snapshotLineEnding = tabs[index].lineEnding
         let trimTrailingWhitespace = UserDefaults.standard.bool(forKey: "SettingsTrimTrailingWhitespace")
-        let requiresTranscoding = encodingOverride != nil
-            && (snapshotEncoding != previousEncoding || previousEncodingWasAutomatic)
 
-        Task { [weak self] in
+        let predecessor = localSaveTasks[tabID]?.task
+        let saveID = UUID()
+        let task = Task { [weak self] in
+            await predecessor?.value
             guard let self else { return }
+            defer {
+                if self.localSaveTasks[tabID]?.id == saveID { self.localSaveTasks[tabID] = nil }
+            }
             let saveInterval = Self.saveSignposter.beginInterval(signpostName)
             defer { Self.saveSignposter.endInterval(signpostName, saveInterval) }
 
@@ -2165,9 +2184,14 @@ class EditorViewModel {
             )
 
             guard let preflightIndex = self.tabIndex(for: tabID),
-                  self.tabs[preflightIndex].contentRevision == snapshotRevision else {
+                  self.tabs[preflightIndex].contentRevision == snapshotRevision
+                    || self.tabs[preflightIndex].document.string() == payload.content else {
                 return
             }
+            let expectedMetadata = updateFileURLOnSuccess == nil && !allowExternalOverwrite
+                ? LocalFileMetadata(modificationDate: self.tabs[preflightIndex].lastKnownFileModificationDate,
+                                    byteCount: self.tabs[preflightIndex].fileByteCount) : nil
+            let snapshotEncoding = encodingOverride ?? self.tabs[preflightIndex].fileEncoding
 
             let normalizationOutcome = self.applyTabCommand(
                 .updateContent(
@@ -2175,66 +2199,40 @@ class EditorViewModel {
                     mutation: .replaceAll(
                         text: payload.content,
                         markDirty: false,
-                        compareIfLengthAtMost: Self.deferredLanguageDetectionUTF16Length
+                        compareIfLengthAtMost: Int.max
                     )
                 )
             )
-            let expectedRevision = normalizationOutcome.contentRevision ?? snapshotRevision
-
-            if !requiresTranscoding,
-               snapshotLastSavedFingerprint == payload.fingerprint,
-               FileManager.default.fileExists(atPath: destinationURL.path) {
-                if let finalIndex = self.tabIndex(for: tabID),
-                   self.tabs[finalIndex].contentRevision == expectedRevision {
-                    let fileMetadata = try? destinationURL.resourceValues(
-                        forKeys: [.contentModificationDateKey, .fileSizeKey]
-                    )
-                    _ = self.applyTabCommand(
-                        .markSaved(
-                            tabID: tabID,
-                            fileURL: updateFileURLOnSuccess,
-                            fingerprint: payload.fingerprint,
-                            fileModificationDate: fileMetadata?.contentModificationDate,
-                            fileEncodingRawValue: snapshotEncoding.encodingRawValue,
-                            fileByteCount: fileMetadata?.fileSize
-                        )
-                    )
-                    if encodingOverride != nil {
-                        self.setFileEncoding(
-                            tabID: tabID,
-                            encoding: snapshotEncoding,
-                            usesAutomatic: false
-                        )
-                    }
-                    self.pendingExternalFileConflict = nil
-                    self.completePendingEncodingReopenAfterSave(tabID: tabID)
-                }
-                return
-            }
+            let expectedRevision = normalizationOutcome.contentRevision ?? self.tabs[preflightIndex].contentRevision
 
             do {
-                let actualEncoding = try await Self.writeFileContent(
+                let (actualEncoding, fileMetadata) = try await Self.writeFileContent(
                     payload.content,
                     to: destinationURL,
                     encoding: snapshotEncoding,
-                    lineEnding: snapshotLineEnding
+                    lineEnding: snapshotLineEnding,
+                    expectedMetadata: expectedMetadata
                 )
+                if let writtenIndex = self.tabIndex(for: tabID),
+                   self.tabs[writtenIndex].fileURL?.standardizedFileURL == destinationURL.standardizedFileURL {
+                    // A later edit remains dirty, but the next queued save must
+                    // compare against our just-completed write, not the old file.
+                    self.tabs[writtenIndex].lastKnownFileModificationDate = fileMetadata.modificationDate
+                    self.tabs[writtenIndex].updateFileByteCount(fileMetadata.byteCount)
+                }
                 guard let finalIndex = self.tabIndex(for: tabID),
                       self.tabs[finalIndex].contentRevision == expectedRevision else {
                     return
                 }
 
-                let fileMetadata = try? destinationURL.resourceValues(
-                    forKeys: [.contentModificationDateKey, .fileSizeKey]
-                )
                 _ = self.applyTabCommand(
                     .markSaved(
                         tabID: tabID,
                         fileURL: updateFileURLOnSuccess,
                         fingerprint: payload.fingerprint,
-                        fileModificationDate: fileMetadata?.contentModificationDate,
+                        fileModificationDate: fileMetadata.modificationDate,
                         fileEncodingRawValue: actualEncoding.encodingRawValue,
-                        fileByteCount: fileMetadata?.fileSize
+                        fileByteCount: fileMetadata.byteCount
                     )
                 )
                 if encodingOverride != nil {
@@ -2257,11 +2255,16 @@ class EditorViewModel {
                 } else {
                     message = "Couldn’t save \(destinationURL.lastPathComponent). The document was left unchanged. \(error.localizedDescription)"
                 }
+                if (error as? CocoaError)?.code == .fileWriteFileExists {
+                    self.pendingExternalFileConflict = ExternalFileConflictState(
+                        tabID: tabID, fileURL: destinationURL, diskModifiedAt: nil)
+                }
                 self.fileEncodingErrorMessage = message
                 self.debugLog(message)
                 return
             }
         }
+        localSaveTasks[tabID] = (saveID, task)
     }
 
     private func completePendingEncodingReopenAfterSave(tabID: UUID) {
@@ -2366,9 +2369,10 @@ class EditorViewModel {
     }
 
     private func detectExternalConflict(for tab: TabData) -> ExternalFileConflictState? {
-        guard tab.isDirty, let fileURL = tab.fileURL else { return nil }
+        guard tab.isDirty, var fileURL = tab.fileURL else { return nil }
+        fileURL.removeAllCachedResourceValues()
         guard let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]) else {
-            return nil
+            return ExternalFileConflictState(tabID: tab.id, fileURL: fileURL, diskModifiedAt: nil)
         }
         let metadata = LocalFileMetadata(
             modificationDate: values.contentModificationDate,
@@ -2862,7 +2866,7 @@ class EditorViewModel {
             let fileHandle = try? FileHandle(forReadingFrom: url)
             defer { try? fileHandle?.close() }
             if let prefix = try? fileHandle?.read(upToCount: 4_096),
-               prefix.contains(0) {
+               !CoordinatedDocumentAccess.isText(prefix) {
                 return false
             }
         }
@@ -2873,12 +2877,7 @@ class EditorViewModel {
         }
 
         if ext.isEmpty {
-            let supportedDotfiles: Set<String> = [
-                ".zshrc", ".zprofile", ".zlogin", ".zlogout",
-                ".bashrc", ".bash_profile", ".bash_login", ".bash_logout",
-                ".profile", ".vimrc", ".env", ".envrc", ".gitconfig"
-            ]
-            return supportedDotfiles.contains(fileName) || fileName.hasPrefix(".env")
+            return true // Unknown dotfiles and extensionless text are valid documents.
         }
 
         let knownSupportedExtensions: Set<String> = [
@@ -2895,11 +2894,11 @@ class EditorViewModel {
             return true
         }
 
-        guard let type = UTType(filenameExtension: ext) else { return false }
+        guard let type = UTType(filenameExtension: ext) else { return true }
         if type.conforms(to: .text) || type.conforms(to: .plainText) || type.conforms(to: .sourceCode) {
             return true
         }
-        return false
+        return true // Type hints choose syntax; content validation happens during load.
     }
 
     /// Preview-only assets must be non-editable from the moment their placeholder
@@ -2991,6 +2990,7 @@ class EditorViewModel {
         priority: TaskPriority = .userInitiated
     ) async throws -> EditorFileLoadResult {
         try await Task.detached(priority: priority) {
+            try CoordinatedDocumentAccess.read(at: url) { url in
             let didStartScopedAccess = url.startAccessingSecurityScopedResource()
             defer {
                 if didStartScopedAccess {
@@ -3017,6 +3017,10 @@ class EditorViewModel {
                     fileBackedDocument: nil
                 )
             }
+            let textProbe = try EditorLoadHelper.partialFileData(from: url, maximumByteCount: 64_000)
+            guard CoordinatedDocumentAccess.isText(textProbe, encoding: preferredEncoding) else {
+                throw CocoaError(.fileReadInapplicableStringEncoding)
+            }
             let boundedPreviewLimit = EditorLoadHelper.boundedPreviewLimit(
                 forExtension: previewOnlyExtension,
                 byteCount: totalByteCount
@@ -3024,7 +3028,7 @@ class EditorViewModel {
             let isPartialPreview = totalByteCount >= EditorLoadHelper.partialOpenByteThreshold || boundedPreviewLimit != nil
 
             if isLargeCandidate, !isPartialPreview {
-                let prefix = try EditorLoadHelper.partialFileData(from: url, maximumByteCount: 64_000)
+                let prefix = textProbe
                 let encoding = preferredEncoding ?? FileBackedTextDocument.boundedEncoding(from: prefix, allowsIncompleteUTF8Sequence: totalByteCount > prefix.count)
                 if let encoding,
                    Self.isFileBackedEligible(
@@ -3134,6 +3138,7 @@ class EditorViewModel {
                 fileBackedEncoding: nil,
                 fileBackedDocument: fileBackedDocument
             )
+            }
         }.value
     }
 
@@ -3184,14 +3189,43 @@ class EditorViewModel {
         _ content: String,
         to url: URL,
         encoding: TextEncodingDescriptor,
-        lineEnding: TextLineEnding
-    ) async throws -> TextEncodingDescriptor {
+        lineEnding: TextLineEnding,
+        expectedMetadata: LocalFileMetadata? = nil
+    ) async throws -> (TextEncodingDescriptor, LocalFileMetadata) {
         try await Task.detached(priority: .utility) {
             guard let data = encoding.encodedData(for: lineEnding.applying(to: content)) else {
                 throw CocoaError(.fileWriteInapplicableStringEncoding)
             }
-            try data.write(to: url, options: .atomic)
-            return encoding
+            try CoordinatedDocumentAccess.preserveRecovery(data, for: url)
+            return try CoordinatedDocumentAccess.write(at: url) { coordinatedURL in
+                var coordinatedURL = coordinatedURL
+                coordinatedURL.removeAllCachedResourceValues()
+                if let expectedMetadata {
+                    let metadata = try coordinatedURL.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+                    guard let expectedDate = expectedMetadata.modificationDate,
+                          let actualDate = metadata.contentModificationDate,
+                          let actualSize = metadata.fileSize,
+                          actualSize == expectedMetadata.byteCount,
+                          abs(actualDate.timeIntervalSince(expectedDate)) <= 0.001 else {
+                        throw CocoaError(.fileWriteFileExists)
+                    }
+                }
+                let existingData: Data?
+                if expectedMetadata != nil {
+                    existingData = try Data(contentsOf: coordinatedURL, options: .mappedIfSafe)
+                } else {
+                    existingData = try? Data(contentsOf: coordinatedURL, options: .mappedIfSafe)
+                }
+                if existingData != data {
+                    try data.write(to: coordinatedURL, options: .atomic)
+                }
+                // URL caches metadata read before the atomic replacement.
+                // The next queued save needs the new inode's revision.
+                coordinatedURL.removeAllCachedResourceValues()
+                let metadata = try coordinatedURL.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+                return (encoding, LocalFileMetadata(modificationDate: metadata.contentModificationDate,
+                                                     byteCount: metadata.fileSize ?? data.count))
+            }
         }.value
     }
 
@@ -3236,7 +3270,13 @@ class EditorViewModel {
     }
 
     private func markTabLoadFailed(tabID: UUID) async {
+        if let index = tabIndex(for: tabID), tabs[index].lastKnownFileModificationDate == nil,
+           !tabs[index].isDirty {
+            tabs[index].isReadOnlyPreview = true
+            recordTabStateMutation()
+        }
         _ = await dispatchTabCommandSerialized(.setLoading(tabID: tabID, isLoading: false))
+        fileEncodingErrorMessage = "Couldn’t read the document safely. No changes were saved. Try opening it again or download a local copy first."
         EditorPerformanceMonitor.shared.endFileOpen(tabID: tabID, success: false, byteCount: nil)
         debugLog("Failed to open file.")
     }

--- a/Neon Vision Editor/Data/FileBackedTextDocument.swift
+++ b/Neon Vision Editor/Data/FileBackedTextDocument.swift
@@ -118,6 +118,77 @@ nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Senda
     private var cachedViewport: (key: ViewportCacheKey, value: EditorDocumentViewport)?
     private(set) var viewportIndexPreparedOnMainThread: Bool?
 
+    /// The worker owns this copy exclusively. Arrays/Data use value semantics;
+    /// the live document and its seekable file handle never cross actors.
+    struct SaveSnapshot: Sendable {
+        fileprivate let copy: FileBackedTextDocument
+        fileprivate let needsSourceRead: Bool
+        fileprivate let generation: UInt64
+        fileprivate let editCount: Int
+
+        func write(to destination: URL? = nil, allowExternalOverwrite: Bool = false) throws -> SaveReceipt {
+            if needsSourceRead, let source = copy.url {
+                try CoordinatedDocumentAccess.read(at: source) { coordinatedURL in
+                    let current = try coordinatedURL.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
+                    guard let expected = copy.savedFileMetadata,
+                          current.fileSize == expected.byteCount,
+                          current.contentModificationDate == expected.modificationDate else { throw Error.externalConflict }
+                    copy.lazyFileHandle = try FileHandle(forReadingFrom: coordinatedURL)
+                    try copy.materializeLazyStorageIfNeeded()
+                }
+            }
+            if let destination {
+                try copy.saveAtomically(to: destination)
+                let replacement = try CoordinatedDocumentAccess.read(at: destination) { url in
+                    let document = try FileBackedTextDocument(url: url, knownUTF8Encoding: copy.encodingDescriptor)
+                    try document.prepareViewportIndex()
+                    return document
+                }
+                guard let metadata = replacement.savedFileMetadata else { throw Error.externalConflict }
+                return SaveReceipt(metadata: metadata, generation: generation,
+                                   editCount: editCount, replacement: replacement)
+            }
+            try copy.saveAtomically(allowExternalOverwrite: allowExternalOverwrite)
+            guard let metadata = copy.savedFileMetadata else { throw Error.externalConflict }
+            return SaveReceipt(metadata: metadata, generation: generation, editCount: editCount, replacement: nil)
+        }
+
+    }
+
+    struct SaveReceipt: Sendable {
+        fileprivate let metadata: FileMetadata
+        fileprivate let generation: UInt64
+        fileprivate let editCount: Int
+        let replacement: FileBackedTextDocument?
+        var modificationDate: Date? { metadata.modificationDate }
+        var byteCount: Int { metadata.byteCount }
+    }
+
+    private init(saveCopy source: FileBackedTextDocument) {
+        url = source.url
+        originalData = source.originalData
+        pieces = source.pieces
+        lineStarts = source.lineStarts
+        cachedUTF16Length = source.cachedUTF16Length
+        encodingDescriptor = source.encodingDescriptor
+        savedFileMetadata = source.savedFileMetadata
+        dirty = source.dirty
+        lazyFileByteCount = source.lazyFileByteCount
+    }
+
+    func makeSaveSnapshot() -> SaveSnapshot {
+        SaveSnapshot(copy: FileBackedTextDocument(saveCopy: self), needsSourceRead: lazyFileHandle != nil,
+                     generation: viewportGeneration, editCount: edits.count)
+    }
+
+    /// Called on the live document's owner after the worker completes. Newer
+    /// edits remain dirty and their recovery log is relative to the saved copy.
+    func acceptSave(_ receipt: SaveReceipt) {
+        savedFileMetadata = receipt.metadata
+        edits.removeFirst(min(receipt.editCount, edits.count))
+        dirty = viewportGeneration != receipt.generation
+    }
+
     convenience init(url: URL) throws {
         let prefix = try Self.readPrefix(from: url, maximumByteCount: 64 * 1024)
         let byteCount = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? prefix.count
@@ -678,10 +749,16 @@ nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Senda
     func saveAtomically(allowExternalOverwrite: Bool = false) throws {
         guard dirty else { return }
         guard let url, savedFileMetadata != nil else { throw Error.externalConflict }
+        try CoordinatedDocumentAccess.write(at: url) { coordinatedURL in
+            try saveCoordinated(at: coordinatedURL, allowExternalOverwrite: allowExternalOverwrite)
+        }
+    }
+
+    private func saveCoordinated(at url: URL, allowExternalOverwrite: Bool) throws {
         let didAccess = url.startAccessingSecurityScopedResource()
         defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
         try materializeLazyStorageIfNeeded()
-        guard allowExternalOverwrite || !hasExternalConflict() else { throw Error.externalConflict }
+        guard allowExternalOverwrite || !hasExternalConflict(at: url) else { throw Error.externalConflict }
         let replacementDirectory = try FileManager.default.url(
             for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: url, create: true)
         defer { try? FileManager.default.removeItem(at: replacementDirectory) }
@@ -694,11 +771,12 @@ nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Senda
             }
             try output.synchronize()
             try output.close()
+            try CoordinatedDocumentAccess.preserveRecovery(from: temporaryURL, for: url)
             _ = try FileManager.default.replaceItemAt(url, withItemAt: temporaryURL)
-            dirty = false
             lineStarts = lineStartsFromPieceMetadata()
             let savedData = try Data(contentsOf: url, options: [.alwaysMapped])
             self.savedFileMetadata = try Self.fileMetadata(at: url, fingerprint: Self.fingerprint(of: savedData))
+            dirty = false
             edits.removeAll(keepingCapacity: true)
         } catch {
             try? output.close()
@@ -711,6 +789,12 @@ nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Senda
     /// a whole-document string. Transcoding and normalization are intentionally
     /// unavailable on this virtual-document path.
     func saveAtomically(to destinationURL: URL) throws {
+        try CoordinatedDocumentAccess.write(at: destinationURL) { coordinatedURL in
+            try saveCoordinated(to: coordinatedURL)
+        }
+    }
+
+    private func saveCoordinated(to destinationURL: URL) throws {
         let didAccess = destinationURL.startAccessingSecurityScopedResource()
         defer { if didAccess { destinationURL.stopAccessingSecurityScopedResource() } }
         try materializeLazyStorageIfNeeded()
@@ -726,6 +810,7 @@ nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Senda
             }
             try output.synchronize()
             try output.close()
+            try CoordinatedDocumentAccess.preserveRecovery(from: temporaryURL, for: destinationURL)
             if FileManager.default.fileExists(atPath: destinationURL.path) {
                 _ = try FileManager.default.replaceItemAt(destinationURL, withItemAt: temporaryURL)
             } else {
@@ -1083,11 +1168,11 @@ nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Senda
                 .map { $0 - range.lowerBound })
     }
 
-    func hasExternalConflict() -> Bool {
+    func hasExternalConflict(at coordinatedURL: URL? = nil) -> Bool {
         try? materializeLazyStorageIfNeeded()
-        guard let url,
+        guard let url = coordinatedURL ?? url,
               let currentValues = try? url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey]),
-              let savedFileMetadata else { return false }
+              let savedFileMetadata else { return true }
         guard (currentValues.fileSize ?? 0) == savedFileMetadata.byteCount,
               currentValues.contentModificationDate == savedFileMetadata.modificationDate else {
             return true
@@ -1397,13 +1482,15 @@ nonisolated final class FileBackedTextDocument: EditorDocument, @unchecked Senda
         }
     }
 
-    private struct FileMetadata: Equatable {
+    fileprivate struct FileMetadata: Equatable, Sendable {
         let byteCount: Int
         let modificationDate: Date?
         let fingerprint: UInt64
     }
 
     private static func fileMetadata(at url: URL, fingerprint: UInt64) throws -> FileMetadata {
+        var url = url
+        url.removeAllCachedResourceValues()
         let values = try url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
         return FileMetadata(
             byteCount: values.fileSize ?? 0,

--- a/Neon Vision Editor/UI/ContentView+Actions.swift
+++ b/Neon Vision Editor/UI/ContentView+Actions.swift
@@ -765,17 +765,8 @@ extension ContentView {
     }
 
     func closeAllTabsFromToolbar() {
-        let dirtyTabIDs = viewModel.tabs.filter(\.isDirty).map(\.id)
-        for tabID in dirtyTabIDs {
-            guard viewModel.tabs.contains(where: { $0.id == tabID }) else { continue }
-            viewModel.saveFile(tabID: tabID)
-        }
-
         let tabIDsToClose = viewModel.tabs.map(\.id)
-        for tabID in tabIDsToClose {
-            guard viewModel.tabs.contains(where: { $0.id == tabID }) else { continue }
-            viewModel.closeTab(tabID: tabID)
-        }
+        Task { await viewModel.saveAndCloseTabs(tabIDs: tabIDsToClose) }
     }
 
     func requestCloseAllTabsFromToolbar() {
@@ -811,14 +802,9 @@ extension ContentView {
             return
         }
 
-        viewModel.saveFile(tabID: pendingCloseTabID)
-
-        if let updated = viewModel.tabs.first(where: { $0.id == pendingCloseTabID }),
-           !updated.isDirty {
-            viewModel.closeTab(tabID: pendingCloseTabID)
-            self.pendingCloseTabID = nil
-        } else {
-            self.pendingCloseTabID = nil
+        Task {
+            await viewModel.saveAndCloseTabs(tabIDs: [pendingCloseTabID])
+            if self.pendingCloseTabID == pendingCloseTabID { self.pendingCloseTabID = nil }
         }
     }
 
@@ -1311,25 +1297,12 @@ extension ContentView {
             return path == rootPath || path.hasPrefix(rootPath + "/")
         }
 
-        for tab in projectTabs where tab.isDirty {
-            viewModel.saveFile(tabID: tab.id)
-        }
-
-        let nonProjectTabs = viewModel.tabs.filter { tab in
-            !projectTabs.contains(where: { $0.id == tab.id })
-        }
-        if nonProjectTabs.isEmpty {
-            viewModel.resetTabsForSessionRestore()
-            viewModel.addNewTab()
-        } else {
-            for tab in projectTabs {
-                guard viewModel.tabs.contains(where: { $0.id == tab.id }) else { continue }
-                viewModel.closeTab(tabID: tab.id)
-            }
-        }
-
         showCloseProjectFolderAndTabsDialog = false
-        closeProjectFolder()
+        Task {
+            guard await viewModel.saveAndCloseTabs(tabIDs: projectTabs.map(\.id)),
+                  projectRootFolderURL?.standardizedFileURL == rootURL else { return }
+            closeProjectFolder()
+        }
     }
 
     func refreshProjectTree() {

--- a/Neon Vision EditorTests/EditorViewModelFileOpenTests.swift
+++ b/Neon Vision EditorTests/EditorViewModelFileOpenTests.swift
@@ -40,7 +40,8 @@ final class EditorViewModelFileOpenTests: XCTestCase {
             "sample.xml",
             "sample.plist",
             "sample.sh",
-            "Package.resolved"
+            "Package.resolved",
+            "sample.nve-unknown-text", "NOTES", ".custom-settings"
         ]
 
         for name in supportedNames {
@@ -62,6 +63,227 @@ final class EditorViewModelFileOpenTests: XCTestCase {
         try Data([0xCF, 0xFA, 0xED, 0xFE, 0x00, 0x01]).write(to: binaryURL)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
         XCTAssertFalse(EditorViewModel.isSupportedEditorFileURL(binaryURL))
+    }
+
+    func testUnknownExtensionAndExtensionlessTextOpenWithoutConversion() async throws {
+        for name in ["sample.nve-unknown-text", "NOTES", ".custom-settings"] {
+            let url = temporaryDirectoryURL.appendingPathComponent(name)
+            let original = "Hello 👋\nunknown-extension text\n"
+            try Data(original.utf8).write(to: url)
+            let model = EditorViewModel()
+            XCTAssertTrue(model.openFile(url: url))
+            let tab = try await waitForLoadedTab(in: model, matching: url)
+            XCTAssertEqual(tab.document.string(), original)
+            XCTAssertFalse(tab.isReadOnlyPreview)
+            XCTAssertEqual(try Data(contentsOf: url), Data(original.utf8))
+        }
+    }
+
+    func testUnknownExtensionUTF16AndBinaryClassification() throws {
+        for identifier: TextEncodingDescriptor.Identifier in [.utf16LittleEndianWithBOM, .utf16BigEndianWithBOM] {
+            let encoding = TextEncodingDescriptor(identifier: identifier)
+            let bytes = try XCTUnwrap(encoding.encodedData(for: "Hello world\n"))
+            XCTAssertTrue(CoordinatedDocumentAccess.isText(bytes))
+            let splitSurrogate = try XCTUnwrap(encoding.encodedData(for: "Hello 😀"))
+            XCTAssertTrue(CoordinatedDocumentAccess.isText(Data(splitSurrogate.dropLast(2))))
+        }
+        XCTAssertTrue(CoordinatedDocumentAccess.isText(Data()))
+        XCTAssertFalse(CoordinatedDocumentAccess.isText(Data([0xCF, 0xFA, 0xED, 0xFE, 0, 1])))
+        XCTAssertFalse(CoordinatedDocumentAccess.isText(Data([0x50, 0x4b, 3, 4, 0, 0])))
+    }
+
+    func testQueuedSavesPreserveNewestContent() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("queued.txt")
+        try Data("original".utf8).write(to: url)
+        let model = EditorViewModel()
+        XCTAssertTrue(model.openFile(url: url))
+        let tab = try await waitForLoadedTab(in: model, matching: url)
+        for revision in 1...20 {
+            model.updateTabContent(tabID: tab.id, content: "revision \(revision)\n")
+            model.saveFile(tabID: tab.id)
+            await Task.yield()
+        }
+        let saved = try await waitForLoadedTab(in: model, matching: url, requireDirty: false)
+        XCTAssertEqual(saved.document.string(), "revision 20\n")
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "revision 20\n")
+        XCTAssertNil(model.pendingExternalFileConflict)
+    }
+
+    func testQueuedEncodingSaveSurvivesNormalization() async throws {
+        let settingsKey = "SettingsTrimTrailingWhitespace"
+        let previous = UserDefaults.standard.object(forKey: settingsKey)
+        defer { UserDefaults.standard.set(previous, forKey: settingsKey) }
+        UserDefaults.standard.set(true, forKey: settingsKey)
+        for count in [10, 180_001] {
+            let url = temporaryDirectoryURL.appendingPathComponent("queued-encoding-\(count).txt")
+            let original = String(repeating: "x", count: count) + "  \n"
+            try Data(original.utf8).write(to: url)
+            let model = EditorViewModel()
+            XCTAssertTrue(model.openFile(url: url))
+            let tab = try await waitForLoadedTab(in: model, matching: url)
+            model.saveFile(tabID: tab.id, using: .init(identifier: .utf16LittleEndianWithBOM))
+            let lastEncoding = TextEncodingDescriptor(identifier: .utf16BigEndianWithBOM)
+            model.saveFile(tabID: tab.id, using: lastEncoding)
+            let deadline = Date().addingTimeInterval(10)
+            while tab.fileEncoding != lastEncoding, Date() < deadline {
+                try await Task.sleep(nanoseconds: 10_000_000)
+            }
+            XCTAssertNil(model.fileEncodingErrorMessage)
+            XCTAssertNil(model.pendingExternalFileConflict)
+            XCTAssertEqual(tab.fileEncoding, lastEncoding)
+            XCTAssertEqual(try Data(contentsOf: url), lastEncoding.encodedData(for: String(repeating: "x", count: count) + "\n"))
+            XCTAssertFalse(tab.isDirty)
+        }
+    }
+
+    func testANSILogWithUnknownExtensionOpensUnchanged() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("terminal.capture")
+        let content = "\u{1B}[31merror\u{1B}[0m\nprogress\u{8}\u{0B}done\n"
+        try Data(content.utf8).write(to: url)
+        let model = EditorViewModel()
+        XCTAssertTrue(model.openFile(url: url))
+        let tab = try await waitForLoadedTab(in: model, matching: url)
+        XCTAssertFalse(tab.isReadOnlyPreview)
+        XCTAssertEqual(tab.document.string(), content)
+    }
+
+    func testFileBackedSaveDoesNotBlockMainActorOnProviderLock() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("locked-large.txt")
+        try Data(String(repeating: "line\n", count: 420_000).utf8).write(to: url)
+        let model = EditorViewModel()
+        XCTAssertTrue(model.openFile(url: url))
+        let tab = try await waitForLoadedTab(in: model, matching: url)
+        XCTAssertTrue(tab.usesFileBackedStorage)
+        XCTAssertTrue(model.applyTabContentEdit(tabID: tab.id, range: NSRange(location: 0, length: 4), replacement: "first"))
+        let locked = expectation(description: "Other writer holds coordination")
+        let release = DispatchSemaphore(value: 0)
+        let blocker = Task.detached {
+            try CoordinatedDocumentAccess.write(at: url) { _ in
+                locked.fulfill()
+                _ = release.wait(timeout: .now() + 3)
+            }
+        }
+        defer { release.signal() }
+        await fulfillment(of: [locked], timeout: 5)
+        let started = ProcessInfo.processInfo.systemUptime
+        model.saveFile(tabID: tab.id)
+        XCTAssertLessThan(ProcessInfo.processInfo.systemUptime - started, 0.25)
+        // Give the first worker time to reach the held coordination request.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertTrue(model.applyTabContentEdit(tabID: tab.id, range: NSRange(location: 0, length: 5), replacement: "newest"))
+        model.saveFile(tabID: tab.id)
+        release.signal()
+        try await blocker.value
+        _ = try await waitForLoadedTab(in: model, matching: url, requireDirty: false, timeout: 15)
+        XCTAssertTrue(try String(contentsOf: url, encoding: .utf8).hasPrefix("newest\n"))
+        XCTAssertNil(model.pendingExternalFileConflict)
+    }
+
+    func testRecoveryRetainsCompleteLatestPayloadAndSeparatesSources() throws {
+        let recovery = temporaryDirectoryURL.appendingPathComponent("recovery", isDirectory: true)
+        let first = URL(fileURLWithPath: "/provider/first/notes.txt")
+        let second = URL(fileURLWithPath: "/provider/second/notes.txt")
+        let firstBackup = try XCTUnwrap(CoordinatedDocumentAccess.recoveryURL(for: first, in: recovery))
+        let secondBackup = try XCTUnwrap(CoordinatedDocumentAccess.recoveryURL(for: second, in: recovery))
+        XCTAssertNotEqual(firstBackup, secondBackup)
+        let completePayload = Data(String(repeating: "recovery 😀\n", count: 150_000).utf8)
+        try CoordinatedDocumentAccess.preserveRecovery(completePayload, for: first, in: recovery)
+        XCTAssertEqual(try Data(contentsOf: firstBackup), completePayload)
+        try CoordinatedDocumentAccess.preserveRecovery(Data("other source".utf8), for: second, in: recovery)
+        let staged = temporaryDirectoryURL.appendingPathComponent("staged.txt")
+        try Data("newest payload".utf8).write(to: staged)
+        try CoordinatedDocumentAccess.preserveRecovery(from: staged, for: first, in: recovery)
+        XCTAssertEqual(try String(contentsOf: firstBackup, encoding: .utf8), "newest payload")
+        XCTAssertEqual(try String(contentsOf: secondBackup, encoding: .utf8), "other source")
+        XCTAssertThrowsError(try CoordinatedDocumentAccess.preserveRecovery(from: staged.appendingPathExtension("missing"), for: first, in: recovery))
+        XCTAssertEqual(try String(contentsOf: firstBackup, encoding: .utf8), "newest payload")
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: recovery.path).count, 2)
+    }
+
+    func testSaveAndCloseWaitsForWriteBeforeRemovingTab() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("save-and-close.txt")
+        try Data("original\n".utf8).write(to: url)
+        let model = EditorViewModel()
+        XCTAssertTrue(model.openFile(url: url))
+        let tab = try await waitForLoadedTab(in: model, matching: url)
+        model.updateTabContent(tabID: tab.id, content: "preserve before close\n")
+        let closed = await model.saveAndCloseTabs(tabIDs: [tab.id])
+        XCTAssertTrue(closed)
+        XCTAssertFalse(model.tabs.contains(where: { $0.id == tab.id }))
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "preserve before close\n")
+    }
+
+    func testSaveAndCloseKeepsConflictedBufferOpen() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("conflicted-close.txt")
+        try Data("original\n".utf8).write(to: url)
+        let model = EditorViewModel()
+        XCTAssertTrue(model.openFile(url: url))
+        let tab = try await waitForLoadedTab(in: model, matching: url)
+        model.updateTabContent(tabID: tab.id, content: "local edits\n")
+        try Data("external revision\n".utf8).write(to: url, options: .atomic)
+        let closed = await model.saveAndCloseTabs(tabIDs: [tab.id])
+        XCTAssertFalse(closed)
+        XCTAssertTrue(model.tabs.contains(where: { $0.id == tab.id }))
+        XCTAssertTrue(tab.isDirty)
+        XCTAssertEqual(tab.document.string(), "local edits\n")
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "external revision\n")
+    }
+
+    func testCoordinatedAccessPropagatesFailureWithoutWriting() throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("protected.txt")
+        let original = Data("original".utf8)
+        try original.write(to: url)
+        XCTAssertThrowsError(try CoordinatedDocumentAccess.write(at: url) { _ in
+            throw CocoaError(.fileWriteNoPermission)
+        })
+        XCTAssertEqual(try CoordinatedDocumentAccess.read(at: url) { try Data(contentsOf: $0) }, original)
+    }
+
+    func testConsecutiveSizeChangingSavesUseFreshMetadata() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("resized.txt")
+        try Data("original\n".utf8).write(to: url)
+        let model = EditorViewModel()
+        XCTAssertTrue(model.openFile(url: url))
+        let tab = try await waitForLoadedTab(in: model, matching: url)
+        for count in [100, 2_000, 10] {
+            let content = String(repeating: "x", count: count) + "\n"
+            model.updateTabContent(tabID: tab.id, content: content)
+            model.saveFile(tabID: tab.id)
+            _ = try await waitForLoadedTab(in: model, matching: url, requireDirty: false)
+            XCTAssertEqual(try Data(contentsOf: url), Data(content.utf8))
+            XCTAssertEqual(tab.fileByteCount, content.utf8.count)
+            XCTAssertNil(model.pendingExternalFileConflict)
+        }
+    }
+
+    func testFailedBinaryOpenCannotOverwriteOriginal() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("binary.unknown")
+        let original = Data([0x50, 0x4b, 3, 4, 0, 0])
+        try original.write(to: url)
+        let model = EditorViewModel()
+        XCTAssertTrue(model.openFile(url: url))
+        let tab = try await waitForLoadedTab(in: model, matching: url)
+        XCTAssertTrue(tab.isReadOnlyPreview)
+        model.updateTabContent(tabID: tab.id, content: "must not overwrite")
+        model.saveFile(tabID: tab.id)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(try Data(contentsOf: url), original)
+    }
+
+    func testMissingDocumentAtSaveKeepsDirtyBufferAndDoesNotRecreateFile() async throws {
+        let url = temporaryDirectoryURL.appendingPathComponent("gone.txt")
+        try Data("original".utf8).write(to: url)
+        let model = EditorViewModel()
+        XCTAssertTrue(model.openFile(url: url))
+        let tab = try await waitForLoadedTab(in: model, matching: url)
+        model.updateTabContent(tabID: tab.id, content: "keep these edits")
+        try FileManager.default.removeItem(at: url)
+        model.saveFile(tabID: tab.id)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(model.tabs.first(where: { $0.id == tab.id })?.document.string(), "keep these edits")
+        XCTAssertEqual(model.tabs.first(where: { $0.id == tab.id })?.isDirty, true)
+        XCTAssertNotNil(model.pendingExternalFileConflict)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
     }
 
     func testPreviewOnlyTabIsReadOnlyBeforeAsynchronousLoadFinishes() throws {
@@ -237,7 +459,9 @@ final class EditorViewModelFileOpenTests: XCTestCase {
             "graphql", "gql", "rst", "conf", "nginx", "cob", "cbl", "cobol", "sh", "bash", "zsh", "fish", "pl", "pm", "lua", "r",
             "tf", "tfvars", "hcl", "xcconfig", "strings", "stringsdict", "jsx", "tex", "latex", "bib", "sty", "cls", "vasp", "isoviz", "upf", "xyz", "xsf"
         ]
-        let line = Data((String(repeating: "bounded-open-line ", count: 8) + "\n").utf8)
+        // Supply text throughout the content-sniffing window; sparse zero bytes
+        // are binary data, not a representative text-file prefix.
+        let line = Data(String(repeating: String(repeating: "bounded-open-line ", count: 8) + "\n", count: 512).utf8)
 
         for byteCount in [10 * 1_000_000, 50 * 1_000_000] {
             let started = ContinuousClock.now

--- a/Neon Vision EditorTests/FileBackedTextDocumentTests.swift
+++ b/Neon Vision EditorTests/FileBackedTextDocumentTests.swift
@@ -585,6 +585,65 @@ final class FileBackedTextDocumentTests: XCTestCase {
         }
     }
 
+    func testMissingSourceIsAnExternalConflict() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".txt")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("original\n".utf8).write(to: url)
+        let document = try FileBackedTextDocument(url: url)
+        try FileManager.default.removeItem(at: url)
+        XCTAssertTrue(document.hasExternalConflict())
+    }
+
+    func testBackgroundSaveSnapshotPreservesLaterEditsAndRecoveryLog() async throws {
+        let url = directory.appendingPathComponent("snapshot.txt")
+        try Data("original\n".utf8).write(to: url)
+        let document = try FileBackedTextDocument(url: url)
+        try document.replace(utf16Range: NSRange(location: 0, length: 8), with: "first")
+        let snapshot = document.makeSaveSnapshot()
+        try document.replace(utf16Range: NSRange(location: 0, length: 5), with: "newest")
+        let receipt = try await Task.detached { try snapshot.write() }.value
+        document.acceptSave(receipt)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "first\n")
+        XCTAssertTrue(document.isDirty)
+        let restored = try FileBackedTextDocument(restoring: document.sessionState)
+        XCTAssertEqual(try restored.text(inByteRange: NSRange(location: 0, length: restored.byteCount)), "newest\n")
+        let newest = document.makeSaveSnapshot()
+        let finalReceipt = try await Task.detached { try newest.write() }.value
+        document.acceptSave(finalReceipt)
+        XCTAssertFalse(document.isDirty)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "newest\n")
+    }
+
+    func testLazySaveAsSnapshotLeavesOriginalAndLiveEditsUntouched() async throws {
+        let url = directory.appendingPathComponent("source.txt")
+        let destination = directory.appendingPathComponent("copy.txt")
+        try Data("original\n".utf8).write(to: url)
+        let document = try FileBackedTextDocument(url: url, knownUTF8Encoding: .utf8)
+        let snapshot = document.makeSaveSnapshot()
+        try document.replace(utf16Range: NSRange(location: 0, length: 8), with: "newest")
+        let receipt = try await Task.detached { try snapshot.write(to: destination) }.value
+        XCTAssertNotNil(receipt.replacement)
+        XCTAssertTrue(document.isDirty)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "original\n")
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), "original\n")
+    }
+
+    func testLazySaveAsSnapshotRefusesChangedSource() async throws {
+        let url = directory.appendingPathComponent("changed-source.txt")
+        let destination = directory.appendingPathComponent("not-created.txt")
+        try Data("original\n".utf8).write(to: url)
+        let document = try FileBackedTextDocument(url: url, knownUTF8Encoding: .utf8)
+        let snapshot = document.makeSaveSnapshot()
+        try Data("different source\n".utf8).write(to: url, options: .atomic)
+        do {
+            _ = try await Task.detached { try snapshot.write(to: destination) }.value
+            XCTFail("Must not copy a different source revision")
+        } catch {
+            XCTAssertEqual(error as? FileBackedTextDocument.Error, .externalConflict)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+    }
+
     func testAtomicSaveRefusesAnExternalChangeAfterOpening() throws {
         let url = directory.appendingPathComponent("save-conflict.txt")
         try "local\n".write(to: url, atomically: true, encoding: .utf8)

--- a/docs/FILE_PROVIDER_VERIFICATION.md
+++ b/docs/FILE_PROVIDER_VERIFICATION.md
@@ -1,0 +1,78 @@
+# File Provider safety verification
+
+Automated tests cover local file admission, failed reads, coordinated access,
+missing-file conflicts, queued saves, encoding preservation, and file-backed
+documents. They do not establish that Nextcloud uploaded a saved file.
+
+## Required device acceptance test
+
+Use disposable files only. Record the exact iPhone/iPad model, iOS/iPadOS version,
+Nextcloud app and server versions, and Neon build. “Current version” is not a
+reproducible version identifier.
+Use a development/TestFlight build containing this patch; the existing App Store
+build cannot validate changes that have not been published.
+
+1. Create text files named `notes.txt`, `notes.custom-extension`, `NOTES`, and
+   `.custom-settings`; include Unicode, empty text, and a larger text file.
+2. In Files, select Nextcloud and open each in Neon. Edit, save, close, reopen,
+   and compare the complete contents both in Files and on the server.
+3. Repeat with an initially undownloaded file, offline, after backgrounding,
+   and after terminating/relaunching Neon. Check that errors never replace the
+   document with an empty buffer or silently discard dirty edits.
+4. While Neon has unsaved edits, modify or delete the disposable source from
+   another client. Saving must preserve the local edits and present a conflict
+   or error instead of silently recreating or overwriting the source.
+5. Make rapid edits and repeated saves, including immediately before
+   backgrounding. The final saved contents must be the newest requested revision.
+6. For an external document saved on iOS/visionOS, check Files → On My
+   iPhone/iPad → Neon Vision Editor → Neon Recovery. The latest full save payload
+   is retained there, with a path-derived prefix, even after a provider accepts
+   the save. Compare it with the intended edits when testing upload failures.
+7. Try binary data with an unknown suffix. A rejected read must leave the source
+   unchanged and the failed placeholder non-editable.
+8. Use Save and Close, Close All, and Close Project during a slow/offline save.
+   Tabs must remain available until saving succeeds; failed/conflicted documents
+   must remain open. Include an ANSI-colored terminal log and consecutive saves
+   that change the file size or encoding.
+
+Recovery copies are local, contain document text, and are not server-sync
+receipts. They retain the latest attempted save per source path, not version
+history or edits never submitted for saving. Delete disposable recovery copies
+after testing; do not uninstall the app before retrieving a needed copy.
+
+## Acceptance boundary
+
+Device/provider verification remains pending until the above cases pass on the
+affected Nextcloud setup. Local builds and synthetic tests cannot attribute the
+original loss to Nextcloud or prove that a remote upload completed.
+
+## Local verification — 2026-09-05
+
+- Verification Level 2: macOS, iOS Simulator, iPad Simulator, and visionOS builds passed with Xcode 27 beta.
+- Final serial macOS regression run: 89 tests passed across
+  file opening and file-backed documents, including UTF-16 split surrogates, queued
+  encoding changes, stale metadata, ANSI preservation, recovery contents, snapshot
+  isolation, a deliberately blocked coordinated writer, and save-before-close/conflict retention.
+- Final large-Markdown activation: 662 ms total, 213 ms longest main-thread gap
+  (below the 250 ms test limit). The preceding 87-test run measured 524 ms / 11 ms.
+  The preceding parallel run exceeded the 250 ms responsiveness limit at 389 ms;
+  concurrent test-host load remains a timing sensitivity, not proof of a provider defect.
+- Existing unrelated test-concurrency and App Intents metadata-extraction warnings remain.
+- Temporary matrix build products were removed by the matrix script.
+- Actual Nextcloud upload/recovery, physical-device UI/accessibility behavior, and
+  provider-dependent total save latency have not been verified. File-backed saves now
+  use an exclusively owned snapshot on a background worker; the held-lock test verifies
+  that initiating Save does not wait on the main actor and later edits survive.
+
+## Reviewed changes
+
+- `EditorViewModel.enqueueSave`: queue-aware normalization and fresh post-replacement
+  metadata, so a previous save cannot invalidate an equivalent queued encoding request.
+- `FileBackedTextDocument.SaveSnapshot`: background Save/Save As without sharing the
+  live mutable document or seekable handle; subsequent edits retain their recovery log.
+- `CoordinatedDocumentAccess.isText` and file-load normalization: permit ANSI/control
+  text without stripping it, while keeping NUL-based binary rejection.
+- `EditorViewModel.saveAndCloseTabs` and close actions: await writes before discarding
+  buffers, and retain failed/conflicted tabs and their project access.
+- Recovery storage tests use an injected temporary directory, exercising full-copy,
+  replacement, source separation, and error preservation without accessing real files.

--- a/docs/XCODE_CLOUD_RELEASE.md
+++ b/docs/XCODE_CLOUD_RELEASE.md
@@ -163,6 +163,10 @@ The successful output
 contains only `product_id` and `max_number`. Missing credentials, denied/expired
 authentication, or active/queued builds must be resolved before release prep.
 This check starts no builds, allocates no number, and publishes nothing.
+Older runs held open solely by recognized TestFlight distribution actions can
+be nonblocking after successful archives and a newer completed run; see the
+[exact preflight rules](../release/RELEASE-WORKFLOW.md#cloud-build-number-preflight).
+Do not cancel TestFlight distribution just to satisfy the counter check.
 
 Finally, verify the configured next Cloud build number in App Store Connect and
 coordinate automatic triggers before release prep. A history read cannot reserve

--- a/release/RELEASE-WORKFLOW.md
+++ b/release/RELEASE-WORKFLOW.md
@@ -48,8 +48,14 @@ It reads every page of the selected product's Cloud build runs and chooses
 `max(project build, published GitHub build, highest Cloud run number) + 1`.
 With project build 1028 and Cloud's last allocated run 1028, the candidate is 1029.
 It records the product ID and observed counter in the release manifest, never the
-credential. Active/queued runs, unknown states, missing history, malformed
+credential. Active/queued builds, unknown states, missing history, malformed
 responses, authentication errors and incomplete pagination stop preparation.
+An older RUNNING run is nonblocking only when a newer run is COMPLETE and its
+action history proves successful completed archives, successful other completed
+actions, and only standard-named TestFlight distribution actions still RUNNING
+after archiving. Renamed/ambiguous actions and the latest unfinished run still
+block. Every run number is counted, including distribution-only runs. This does
+not cancel actions or change Apple's recorded status.
 The counter is checked again before committing and immediately before pushing.
 Retries preserve the allocated number and reject a changed Cloud counter.
 

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -270,6 +270,70 @@ class CloudCounterTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "active, queued or unknown"):
                     self.client.snapshot()
 
+    def test_old_testflight_distribution_does_not_block_counter(self):
+        history = self.page(1028)
+        history['data'] += self.page(968, 'RUNNING')['data']
+        actions = {'data': [
+            {'id': 'archive', 'type': 'ciBuildActions', 'attributes': {
+                'actionType': 'ARCHIVE', 'name': 'Archive - macOS',
+                'executionProgress': 'COMPLETE', 'completionStatus': 'SUCCEEDED',
+                'finishedDate': '2026-08-05T23:44:16Z'}},
+            {'id': 'distribution', 'type': 'ciBuildActions', 'attributes': {
+                'actionType': 'TEST', 'name': 'TestFlight External Testing - macOS',
+                'executionProgress': 'RUNNING', 'completionStatus': None,
+                'startedDate': '2026-08-05T23:48:01Z', 'finishedDate': None}}
+        ], 'links': {}}
+        actions['data'].append({'id': 'notarize', 'type': 'ciBuildActions', 'attributes': {
+            'actionType': 'ARCHIVE', 'name': 'Notarize - macOS',
+            'executionProgress': 'COMPLETE', 'completionStatus': 'SUCCEEDED',
+            'finishedDate': '2026-08-05T23:49:04Z'}})
+        with mock.patch.object(self.client, '_get', side_effect=[history, actions]):
+            self.assertEqual(self.client.snapshot()['max_number'], 1028)
+
+        next_url = cloud_module.ORIGIN + '/v1/ciBuildRuns/968/actions?cursor=next'
+        first = {'data': actions['data'][:1], 'links': {'next': next_url}}
+        second = {'data': actions['data'][1:], 'links': {}}
+        with mock.patch.object(self.client, '_get', side_effect=[history, first, second]) as get:
+            self.assertEqual(self.client.snapshot()['max_number'], 1028)
+            self.assertEqual(get.call_args.kwargs, {'action_run_id': '968'})
+        for bad in ({'data': actions['data'], 'links': {'next': next_url}},
+                    {'data': None, 'links': {}}, {'data': actions['data'], 'links': {'next': 42}},
+                    {'data': actions['data'], 'links': {'next': ''}}):
+            with mock.patch.object(self.client, '_get', side_effect=[history, first, bad]):
+                with self.assertRaises(ValueError):
+                    self.client.snapshot()
+
+        failed_archive = copy.deepcopy(actions)
+        failed_archive['data'][0]['attributes']['completionStatus'] = 'FAILED'
+        with mock.patch.object(self.client, '_get', side_effect=[history, failed_archive]):
+            with self.assertRaises(ValueError):
+                self.client.snapshot()
+
+        with mock.patch.object(self.client, '_get') as get:
+            self.assertFalse(self.client._only_lingering_distribution('968', 0))
+            get.assert_not_called()
+
+        for field, value in [('name', 'Unit tests'), ('actionType', 'BUILD'),
+                             ('executionProgress', 'PENDING'), ('startedDate', None),
+                             ('startedDate', '2026-08-05T23:40:00Z')]:
+            bad = copy.deepcopy(actions)
+            bad['data'][1]['attributes'][field] = value
+            with self.subTest(field=field, value=value), mock.patch.object(self.client, '_get', side_effect=[history, bad]):
+                with self.assertRaises(ValueError):
+                    self.client.snapshot()
+
+        for records in ([], actions['data'][1:], [dict(actions['data'][0], attributes={})]):
+            with mock.patch.object(self.client, '_get', side_effect=[history, {'data': records, 'links': {}}]):
+                with self.assertRaises(ValueError):
+                    self.client.snapshot()
+
+        latest_running = self.page(1029, 'RUNNING')
+        latest_running['data'] += self.page(1028)['data']
+        with mock.patch.object(self.client, '_get', return_value=latest_running) as get:
+            with self.assertRaises(ValueError):
+                self.client.snapshot()
+            self.assertEqual(get.call_count, 1)
+
     def test_empty_malformed_and_duplicate_history_block(self):
         bad_pages = [{"data": [], "links": {}}, {"data": None, "links": {}},
                      self.page(number=True), self.page(number="1028"), self.page(number=-1)]
@@ -313,6 +377,22 @@ class CloudCounterTests(unittest.TestCase):
                     self.client._get(url, 1)
                 opened.assert_not_called()
         self.assertIsNone(cloud_module.NoRedirect().redirect_request(None, None, 302, "", {}, "https://evil.invalid"))
+
+    def test_action_requests_are_scoped_to_the_resolved_run(self):
+        correct = cloud_module.ORIGIN + '/v1/ciBuildRuns/968/actions'
+        for url in (correct.replace('/968/', '/969/'), correct.replace('https:', 'http:'),
+                    'https://evil.invalid/v1/ciBuildRuns/968/actions', correct + '#fragment'):
+            with mock.patch.object(self.client._opener, 'open') as opened:
+                with self.assertRaises(ValueError):
+                    self.client._get(url, 1, action_run_id='968')
+                opened.assert_not_called()
+        with self.assertRaises(ValueError):
+            self.client._get(correct, 1, action_run_id='../968')
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = b'{}'
+        with mock.patch.object(self.client._opener, 'open', return_value=response) as opened:
+            self.client._get(correct, 1, action_run_id='968')
+            self.assertEqual(opened.call_args.args[0].get_method(), 'GET')
 
     def test_auth_rate_limit_and_network_errors_are_sanitized(self):
         url = cloud_module.ORIGIN + "/v1/ciProducts/product-id/buildRuns"
@@ -388,6 +468,10 @@ class TeamKeyAuthenticationTests(unittest.TestCase):
             self.assertEqual(len(raw), 64)
             der = utils.encode_dss_signature(int.from_bytes(raw[:32], "big"), int.from_bytes(raw[32:], "big"))
             self.key.public_key().verify(der, (header + "." + payload).encode(), ec.ECDSA(hashes.SHA256()))
+
+        actions_url = cloud_module.ORIGIN + '/v1/ciBuildRuns/968/actions?limit=200'
+        claims = json.loads(self.decode(signer(actions_url).split('.')[1]))
+        self.assertEqual(claims['scope'], ['GET /v1/ciBuildRuns/968/actions?limit=200'])
 
     def test_private_key_location_permissions_and_content(self):
         self.path.chmod(0o644)

--- a/scripts/cloud_build_number.py
+++ b/scripts/cloud_build_number.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import datetime as dt
 import json
 import os
 from pathlib import Path
@@ -72,7 +73,8 @@ class TeamKeyToken:
         from cryptography.hazmat.primitives.asymmetric import ec, utils
         parsed = urllib.parse.urlsplit(url)
         if (parsed.scheme != "https" or parsed.netloc != "api.appstoreconnect.apple.com"
-                or parsed.fragment or not re.fullmatch(r"/v1/ciProducts/[A-Za-z0-9-]+/buildRuns", parsed.path)):
+                or parsed.fragment or not re.fullmatch(
+                    r"/v1/(?:ciProducts/[A-Za-z0-9-]+/buildRuns|ciBuildRuns/[A-Za-z0-9-]+/actions)", parsed.path)):
             raise ValueError("Refusing to sign an unexpected Cloud request.")
         now = int(time.time())
         header = {"alg": "ES256", "kid": self._key_id, "typ": "JWT"}
@@ -125,9 +127,13 @@ class CloudBuildCounter:
                                  setting("ASC_PRIVATE_KEY_PATH", "privateKeyPath"))
         return cls(product, token)
 
-    def _get(self, url: str, timeout: float) -> dict:
+    def _get(self, url: str, timeout: float, *, action_run_id: str | None = None) -> dict:
         parsed = urllib.parse.urlsplit(url)
         expected_path = f"/v1/ciProducts/{self.product_id}/buildRuns"
+        if action_run_id is not None:
+            if not re.fullmatch(r"[A-Za-z0-9-]+", action_run_id):
+                raise ValueError("Invalid Cloud run ID.")
+            expected_path = f"/v1/ciBuildRuns/{action_run_id}/actions"
         if parsed.scheme != "https" or parsed.netloc != "api.appstoreconnect.apple.com" or parsed.path != expected_path or parsed.fragment:
             raise ValueError("Refusing an unexpected App Store Connect pagination URL.")
         token = self._token(url) if callable(self._token) else self._token
@@ -148,11 +154,79 @@ class CloudBuildCounter:
         except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, UnicodeDecodeError):
             raise ValueError("App Store Connect could not be read safely; no build number was allocated.") from None
 
+    def _only_lingering_distribution(self, run_id: str, deadline: float) -> bool:
+        """Do not mistake a historical TestFlight post-action for active compilation.
+
+        Names alone are not enough: require successful completed archives, all
+        other actions successful, and distribution starting after all archives.
+        Unknown/renamed actions fail closed. The caller also requires a newer
+        completed run; never exempt the latest allocated run.
+        """
+        if not re.fullmatch(r"[A-Za-z0-9-]+", run_id):
+            return False
+        url = ORIGIN + f"/v1/ciBuildRuns/{run_id}/actions?limit=200"
+        seen_urls, seen_ids, archives, distribution = set(), set(), [], []
+
+        def timestamp(value):
+            if not isinstance(value, str):
+                raise ValueError("Missing action timestamp")
+            result = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if result.tzinfo is None:
+                raise ValueError("Missing action timezone")
+            return result
+
+        while url:
+            remaining = deadline - time.monotonic()
+            if url in seen_urls or len(seen_urls) >= 100 or remaining <= 0:
+                return False
+            seen_urls.add(url)
+            data = self._get(url, min(20, remaining), action_run_id=run_id)
+            if not isinstance(data.get("data"), list) or not isinstance(data.get("links"), dict):
+                return False
+            for item in data["data"]:
+                if (not isinstance(item, dict) or item.get("type") != "ciBuildActions"
+                        or not isinstance(item.get("id"), str) or not item["id"] or item["id"] in seen_ids):
+                    return False
+                seen_ids.add(item["id"])
+                attrs = item.get("attributes")
+                if not isinstance(attrs, dict):
+                    return False
+                try:
+                    if attrs.get("executionProgress") == "COMPLETE":
+                        if attrs.get("completionStatus") != "SUCCEEDED":
+                            return False
+                        finished = timestamp(attrs.get("finishedDate"))
+                        if attrs.get("actionType") == "ARCHIVE":
+                            # Apple also reports notarization as ARCHIVE. It may
+                            # run alongside TestFlight distribution, after the
+                            # actual archives; require success but not ordering.
+                            if attrs.get("name") == "Notarize - macOS":
+                                continue
+                            if not isinstance(attrs.get("name"), str) or not re.fullmatch(
+                                    r"Archive - (?:macOS|iOS|visionOS|tvOS)", attrs["name"]):
+                                return False
+                            archives.append(finished)
+                    elif (attrs.get("executionProgress") == "RUNNING" and attrs.get("actionType") == "TEST"
+                          and attrs.get("completionStatus") is None and attrs.get("finishedDate") is None
+                          and isinstance(attrs.get("name"), str) and re.fullmatch(
+                              r"TestFlight (?:Internal|External) Testing - (?:macOS|iOS|visionOS|tvOS)", attrs["name"])):
+                        distribution.append(timestamp(attrs.get("startedDate")))
+                    else:
+                        return False
+                except (ValueError, OverflowError):
+                    return False
+            url = data["links"].get("next")
+            if url is not None and (not isinstance(url, str) or not url):
+                return False
+        return bool(archives and distribution and min(distribution) >= max(archives))
+
     def snapshot(self) -> dict:
         url = ORIGIN + f"/v1/ciProducts/{self.product_id}/buildRuns?limit=200&fields%5BciBuildRuns%5D=number,executionProgress"
         deadline = time.monotonic() + 90
         seen_urls, seen_ids = set(), set()
         maximum = 0
+        completed_maximum = 0
+        unfinished = []
         while url:
             if url in seen_urls or len(seen_urls) >= 100 or time.monotonic() >= deadline:
                 raise ValueError("Cloud build history is incomplete or changing; retry preflight.")
@@ -169,14 +243,22 @@ class CloudBuildCounter:
                 attrs = item.get("attributes")
                 if not isinstance(attrs, dict) or type(attrs.get("number")) is not int or attrs["number"] < 1:
                     raise ValueError("Cloud build number is missing or invalid.")
-                if attrs.get("executionProgress") != "COMPLETE":
+                progress = attrs.get("executionProgress")
+                if progress not in ("COMPLETE", "RUNNING"):
                     raise ValueError("Cloud has an active, queued or unknown-state build. Wait for it to finish before allocating a release number.")
+                if progress == "RUNNING":
+                    unfinished.append((item["id"], attrs["number"]))
+                else:
+                    completed_maximum = max(completed_maximum, attrs["number"])
                 maximum = max(maximum, attrs["number"])
             url = data["links"].get("next")
             if url is not None and (not isinstance(url, str) or not url):
                 raise ValueError("Malformed Cloud pagination link.")
         if not maximum:
             raise ValueError("No Cloud build history exists; configure the initial counter explicitly.")
+        for run_id, number in unfinished:
+            if number >= completed_maximum or not self._only_lingering_distribution(run_id, deadline):
+                raise ValueError(f"Cloud has an active, queued or unknown-state build ({number}). Wait for it to finish before allocating a release number.")
         return {"product_id": self.product_id, "max_number": maximum}
 
     def assert_unchanged(self, expected: dict, candidate: int) -> None:

--- a/scripts/prepare_release_docs.py
+++ b/scripts/prepare_release_docs.py
@@ -588,7 +588,7 @@ def rebuild_changelog_page(page: str, changelog: str, current_tag: str) -> str:
 
 LOCALIZED_TIMELINE_COPY = {
     "de": {
-        "v1.6.2": ("Zuverlässigere Dateiänderungen und App-Starts", "Erkennt externe Änderungen auf Netzlaufwerken, macht die automatische Willkommenstour abschaltbar und stabilisiert Kaufmeldungen.", ["Netzlaufwerke", "Start", "Kaufmeldungen"]),
+        "v1.6.2": ("Sichereres Speichern und zuverlässigere App-Starts", "Verbessert das Speichern externer Dokumente und erkennt Änderungen auf Netzlaufwerken, öffnet Textdateien mit unbekannten Endungen und macht die automatische Willkommenstour abschaltbar.", ["Dateisicherheit", "Textdateien", "Start"]),
         "v1.6.1": ("Vollständiges Emmet und vertraute Editorbefehle", "Erweitert Emmet-Abkürzungen in Markup und Stylesheets, stellt macOS-Editoraktionen wieder her und verbessert Syntaxfarben sowie die Leistung großer Dateien.", ["Emmet", "Editor", "Leistung"]),
         "v1.6.0": ("Große Dateien schneller und zuverlässiger bearbeiten", "Beschleunigt das Öffnen und Scrollen großer Markdown-Dateien, verbessert Eingabe und Speichern und ergänzt native HEX-Farbvorschauen unter macOS.", ["Editor", "Leistung", "Farben"]),
         "v1.5.6": ("Kompaktere, verlässlichere Editorwerkzeuge", "Macht mobile Symbolleisten übersichtlicher, setzt Markdown-Nummerierungen korrekt fort und schützt die eingeklappte Formatierungspille vor durchscheinendem Text.", ["Symbolleiste", "Markdown", "Auswahl"]),
@@ -608,7 +608,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor und Snapshots werden verlässlicher", "Verbessert Auswahl, Tastaturnavigation und Themes im macOS-Editor und erweitert den Code-Snapshot-Export.", ["Editor", "Themes", "Snapshots"]),
     },
     "da": {
-        "v1.6.2": ("Mere pålidelige filændringer og appstarter", "Registrerer eksterne ændringer på netværksdrev, gør den automatiske velkomst valgfri og stabiliserer købsbeskeder.", ["Netværk", "Opstart", "Køb"]),
+        "v1.6.2": ("Sikrere lagring og mere pålidelig opstart", "Forbedrer lagring af eksterne dokumenter og registrering af ændringer på netværksdrev, åbner tekstfiler med ukendte filendelser og gør den automatiske velkomst valgfri.", ["Filsikkerhed", "Tekstfiler", "Opstart"]),
         "v1.6.1": ("Fuld Emmet og velkendte editorhandlinger", "Udvider Emmet-forkortelser i markup og stylesheets, gendanner macOS-editorhandlinger og forbedrer syntaksfarver samt ydeevnen i store filer.", ["Emmet", "Editor", "Ydeevne"]),
         "v1.6.0": ("Hurtigere og mere pålidelig redigering af store filer", "Åbner og ruller hurtigere i store Markdown-filer, forbedrer indtastning og lagring og tilføjer native HEX-farvevisninger på macOS.", ["Editor", "Ydeevne", "Farver"]),
         "v1.5.6": ("Mere kompakte og pålidelige editorværktøjer", "Gør mobile værktøjslinjer tydeligere, fortsætter Markdown-nummerering korrekt og beskytter den sammenklappede formateringsknap mod gennemskinnende tekst.", ["Værktøjslinje", "Markdown", "Markering"]),
@@ -628,7 +628,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor og snapshots bliver mere pålidelige", "Forbedrer markering, tastaturnavigation og temaer i macOS-editoren og udvider eksporten af kodesnapshots.", ["Editor", "Temaer", "Snapshots"]),
     },
     "fr": {
-        "v1.6.2": ("Modifications de fichiers et démarrage plus fiables", "Détecte les modifications externes sur les volumes réseau, permet de désactiver l’accueil automatique et stabilise les messages d’achat.", ["Réseau", "Démarrage", "Achats"]),
+        "v1.6.2": ("Enregistrement plus sûr et démarrage plus fiable", "Améliore l’enregistrement des documents externes et la détection des modifications réseau, ouvre les fichiers texte aux extensions inconnues et rend l’accueil automatique facultatif.", ["Sécurité des fichiers", "Fichiers texte", "Démarrage"]),
         "v1.6.1": ("Emmet complet et commandes d’édition familières", "Développe les abréviations Emmet dans le balisage et les feuilles de style, restaure les actions de l’éditeur macOS et améliore les couleurs syntaxiques ainsi que les performances des grands fichiers.", ["Emmet", "Éditeur", "Performances"]),
         "v1.6.0": ("Une édition plus rapide et fiable des fichiers volumineux", "Accélère l’ouverture et le défilement des grands fichiers Markdown, fiabilise la saisie et l’enregistrement et ajoute des aperçus de couleurs HEX natifs sur macOS.", ["Éditeur", "Performances", "Couleurs"]),
         "v1.5.6": ("Des outils d’édition plus compacts et fiables", "Clarifie les barres d’outils mobiles, poursuit correctement la numérotation Markdown et empêche le texte de traverser la pastille de formatage repliée.", ["Barre d’outils", "Markdown", "Sélection"]),
@@ -648,7 +648,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Éditeur et instantanés plus fiables", "Améliore la sélection, la navigation au clavier et les thèmes dans l’éditeur macOS, tout en enrichissant l’export d’instantanés de code.", ["Éditeur", "Thèmes", "Instantanés"]),
     },
     "es": {
-        "v1.6.2": ("Cambios de archivos e inicio más fiables", "Detecta cambios externos en volúmenes de red, permite desactivar la bienvenida automática y estabiliza los mensajes de compra.", ["Red", "Inicio", "Compras"]),
+        "v1.6.2": ("Guardado más seguro e inicio más fiable", "Mejora el guardado de documentos externos y la detección de cambios en red, abre archivos de texto con extensiones desconocidas y permite desactivar la bienvenida automática.", ["Seguridad de archivos", "Archivos de texto", "Inicio"]),
         "v1.6.1": ("Emmet completo y acciones de edición habituales", "Expande abreviaturas Emmet en marcado y hojas de estilo, restaura las acciones del editor de macOS y mejora los colores de sintaxis y el rendimiento de archivos grandes.", ["Emmet", "Editor", "Rendimiento"]),
         "v1.6.0": ("Edición más rápida y fiable de archivos grandes", "Acelera la apertura y el desplazamiento de archivos Markdown grandes, mejora la escritura y el guardado y añade vistas previas nativas de colores HEX en macOS.", ["Editor", "Rendimiento", "Colores"]),
         "v1.5.6": ("Herramientas de edición más compactas y fiables", "Aclara las barras móviles, continúa correctamente la numeración Markdown e impide que el texto atraviese la píldora de formato contraída.", ["Barra", "Markdown", "Selección"]),
@@ -668,7 +668,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor y capturas más fiables", "Mejora la selección, la navegación por teclado y los temas del editor de macOS, y amplía la exportación de capturas de código.", ["Editor", "Temas", "Capturas"]),
     },
     "ja": {
-        "v1.6.2": ("ファイル変更の検出と起動の信頼性を改善", "ネットワークボリュームの外部変更を検出し、自動ウェルカム画面を無効にする設定を追加して、購入メッセージを安定させます。", ["ネットワーク", "起動", "購入"]),
+        "v1.6.2": ("より安全な保存と安定した起動", "外部ドキュメントの保存とネットワーク上の変更検出を改善し、未知の拡張子のテキストファイルを開けるようにしました。自動ウェルカム画面も無効にできます。", ["ファイルの安全性", "テキストファイル", "起動"]),
         "v1.6.1": ("完全な Emmet と使い慣れた編集操作", "マークアップとスタイルシートの Emmet 略語を展開し、macOS エディタの操作を復元して、構文カラーと大きなファイルの性能を改善します。", ["Emmet", "エディタ", "パフォーマンス"]),
         "v1.6.0": ("大きなファイルをより速く確実に編集", "大きな Markdown ファイルの表示とスクロールを高速化し、入力と保存の安定性を向上。macOS ではネイティブの HEX カラープレビューを追加しました。", ["エディタ", "パフォーマンス", "カラー"]),
         "v1.5.6": ("よりコンパクトで確実な編集ツール", "モバイルのツールバーを整理し、Markdown の番号付きリストを正しく継続し、折りたたんだ書式ピルへの文字の透過を防ぎます。", ["ツールバー", "Markdown", "選択"]),
@@ -688,7 +688,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("エディタとスナップショットをさらに信頼性向上", "macOS エディタの選択、キーボード操作、テーマを改善し、コードスナップショットの書き出しを拡充します。", ["エディタ", "テーマ", "スナップショット"]),
     },
     "zh-Hans": {
-        "v1.6.2": ("更可靠的文件变更检测与启动体验", "检测网络卷上的外部修改，允许关闭自动欢迎界面，并改善购买提示的稳定性。", ["网络", "启动", "购买"]),
+        "v1.6.2": ("更安全的保存与更可靠的启动", "改进外部文档保存和网络文件变更检测，支持打开未知扩展名的文本文件，并允许关闭自动欢迎界面。", ["文件安全", "文本文件", "启动"]),
         "v1.6.1": ("完整 Emmet 与熟悉的编辑操作", "扩展标记和样式表中的 Emmet 缩写，恢复 macOS 编辑器操作，并改进语法颜色和大型文件性能。", ["Emmet", "编辑器", "性能"]),
         "v1.6.0": ("更快速、更可靠的大文件编辑", "加快大型 Markdown 文件的打开和滚动，提升输入与保存的可靠性，并在 macOS 上新增原生 HEX 颜色预览。", ["编辑器", "性能", "颜色"]),
         "v1.5.6": ("更紧凑、更可靠的编辑工具", "简化移动工具栏，正确续排 Markdown 编号列表，并防止编辑器文字透过折叠的格式工具胶囊。", ["工具栏", "Markdown", "选择"]),


### PR DESCRIPTION
Integrates all pending document-safety and Cloud-preflight fixes into develop: background save snapshots, fresh post-replacement metadata, queued encoding requests, faithful text loading, local recovery copies, and save-before-close behavior. Updates reviewed Unreleased notes and six localized 1.6.2 summaries. macOS 27-only work remains separate. Verification: 113 merged-state macOS tests passed; 31 release-workflow tests passed; offline release rehearsal passed with candidate build 1029. The four-platform matrix passed before integration, and hosted integration checks plus final release gates are pending. Actual Nextcloud device upload verification remains pending and is documented; no server-sync guarantee is claimed.