### PR TITLE
Fix mobile editor rendering, caret spacing, and selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ## [Unreleased]
 
+### Fixes
+
+- Corrects mobile line-number updates while typing and scrolling, and removes the fixed width ceiling that clipped long unwrapped lines.
+- Adds three lines of bottom editing space and keeps context below the active caret on iOS/iPadOS and visionOS.
+- Adds triple-tap logical-line selection and an accessible Select Line action in the mobile editor.
+- Displays Markdown bold and italic source text using font styling while preserving markup, escapes, and code blocks.
+
 ## [v1.6.2] - 2026-09-05
 
 ### Why Upgrade

--- a/Neon Vision Editor/UI/EditorTextView+iOS.swift
+++ b/Neon Vision Editor/UI/EditorTextView+iOS.swift
@@ -116,6 +116,7 @@ final class EditorInputTextView: UITextView {
         let tabWidth: Int
         let fontName: String
         let fontSize: CGFloat
+        let letterSpacing: CGFloat
         let width: CGFloat
     }
 
@@ -323,13 +324,14 @@ final class EditorInputTextView: UITextView {
         return offsets
     }
 
-    func cachedNoWrapWidth(visibleWidth: CGFloat, tabWidth: Int, font: UIFont, compute: () -> CGFloat) -> CGFloat {
+    func cachedNoWrapWidth(visibleWidth: CGFloat, tabWidth: Int, font: UIFont, letterSpacing: CGFloat = 0, compute: () -> CGFloat) -> CGFloat {
         if let cache = noWrapWidthCache,
            cache.revision == textMetricsRevision,
            abs(cache.visibleWidth - visibleWidth) < 0.5,
            cache.tabWidth == tabWidth,
            cache.fontName == font.fontName,
-           abs(cache.fontSize - font.pointSize) < 0.01 {
+           abs(cache.fontSize - font.pointSize) < 0.01,
+           cache.letterSpacing == letterSpacing {
             return cache.width
         }
         let width = compute()
@@ -339,6 +341,7 @@ final class EditorInputTextView: UITextView {
             tabWidth: tabWidth,
             fontName: font.fontName,
             fontSize: font.pointSize,
+            letterSpacing: letterSpacing,
             width: width
         )
         return width
@@ -493,6 +496,7 @@ final class EditorInputTextView: UITextView {
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
+        installLineSelectionGesture()
         #if !os(visionOS)
         inputAccessoryView = makeKeyboardAccessoryView()
         #endif
@@ -507,6 +511,7 @@ final class EditorInputTextView: UITextView {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        installLineSelectionGesture()
         #if !os(visionOS)
         inputAccessoryView = makeKeyboardAccessoryView()
         #endif
@@ -521,6 +526,76 @@ final class EditorInputTextView: UITextView {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+    }
+
+    private func installLineSelectionGesture() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(selectTappedLine(_:)))
+        tap.numberOfTapsRequired = 3
+        tap.delaysTouchesBegan = false
+        tap.delaysTouchesEnded = false
+        addGestureRecognizer(tap)
+        accessibilityCustomActions = [UIAccessibilityCustomAction(
+            name: "Select Line", target: self, selector: #selector(selectCurrentLogicalLine))]
+    }
+
+    @objc private func selectTappedLine(_ gesture: UITapGestureRecognizer) {
+        guard gesture.state == .ended, isSelectable,
+              let position = closestPosition(to: gesture.location(in: self)) else { return }
+        selectLogicalLine(at: offset(from: beginningOfDocument, to: position))
+    }
+
+    @objc private func selectCurrentLogicalLine() -> Bool {
+        guard isSelectable else { return false }
+        selectLogicalLine(at: selectedRange.location)
+        return true
+    }
+
+    func selectLogicalLine(at location: Int) {
+        guard isSelectable else { return }
+        let source = textStorage.string as NSString
+        let caret = min(max(0, location), source.length)
+        selectedRange = source.lineRange(for: NSRange(location: caret, length: 0))
+        delegate?.textViewDidChangeSelection?(self)
+    }
+
+    var editingLineHeight: CGFloat {
+        let paragraph = typingAttributes[.paragraphStyle] as? NSParagraphStyle
+        return (font?.lineHeight ?? 20) * max(1, paragraph?.lineHeightMultiple ?? 1)
+    }
+
+    func revealCaretWithContext() {
+        guard isFirstResponder, selectedRange.length == 0,
+              let position = selectedTextRange?.end else { return }
+        var rect = caretRect(for: position)
+        rect.size.height += editingLineHeight * 3
+        // Commit the viewport before syntax styling captures/restores its anchor.
+        // UITextView's deferred scroll-to-rect can otherwise be lost to that restore.
+        let inset = adjustedContentInset
+        var target = contentOffset
+        if rect.maxY > bounds.maxY - inset.bottom {
+            target.y = rect.maxY - bounds.height + inset.bottom
+        } else if rect.minY < bounds.minY + inset.top {
+            target.y = rect.minY - inset.top
+        }
+        if rect.maxX > bounds.maxX - inset.right {
+            target.x = rect.maxX - bounds.width + inset.right
+        } else if rect.minX < bounds.minX + inset.left {
+            target.x = rect.minX - inset.left
+        }
+        target.y = min(max(-inset.top, target.y), max(-inset.top, contentSize.height - bounds.height + inset.bottom))
+        target.x = min(max(-inset.left, target.x), max(-inset.left, contentSize.width - bounds.width + inset.right))
+        if target != contentOffset { setContentOffset(target, animated: false) }
+    }
+
+    func expandUnwrappedEditingLineIfNeeded() {
+        guard !preferredShouldWrapText else { return }
+        let source = textStorage.string as NSString
+        let line = source.lineRange(for: NSRange(location: min(selectedRange.location, source.length), length: 0))
+        let width = (source.substring(with: line) as NSString).size(withAttributes: typingAttributes).width + 32
+        if width > preferredTextContainerWidth {
+            preferredTextContainerWidth = width
+            enforcePreferredWrapLayout()
+        }
     }
 
     func setBracketAccessoryVisible(_ visible: Bool) {
@@ -727,6 +802,7 @@ final class EditorInputTextView: UITextView {
     override func layoutSubviews() {
         super.layoutSubviews()
         enforcePreferredWrapLayout()
+        (superview as? LineNumberedTextViewContainer)?.lineNumberView.setNeedsDisplay()
         if rendersInvisibleCharacters || rendersIndentationGuides {
             invisibleCharactersOverlayView?.requestRedraw()
         }
@@ -1448,9 +1524,11 @@ final class LineNumberGutterView: UIView {
         let layoutManager = textView.layoutManager
         guard !lineStarts.isEmpty else { return }
 
-        let visibleRect = CGRect(origin: textView.contentOffset, size: textView.bounds.size).insetBy(dx: 0, dy: -80)
+        // TextKit rectangles are in text-container coordinates, not scroll-view coordinates.
+        let visibleRect = CGRect(
+            x: 0, y: textView.contentOffset.y - textView.textContainerInset.top - 80,
+            width: textView.textContainer.size.width, height: textView.bounds.height + 160)
         let glyphRange = layoutManager.glyphRange(forBoundingRect: visibleRect, in: textView.textContainer)
-        if glyphRange.length == 0 { return }
 
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .right
@@ -1462,6 +1540,15 @@ final class LineNumberGutterView: UIView {
         let rightPadding: CGFloat = 6
         let textContainerTop = textView.textContainerInset.top
         let contentOffsetY = textView.contentOffset.y
+        if glyphRange.length == 0 {
+            // Empty documents and the final empty paragraph have no glyphs.
+            let extra = layoutManager.extraLineFragmentRect
+            let y = (extra.isEmpty ? 0 : extra.minY) + textContainerTop - contentOffsetY
+            NSString(string: String(lineStarts.count)).draw(
+                in: CGRect(x: 0, y: y, width: bounds.width - rightPadding, height: font.lineHeight),
+                withAttributes: attrs)
+            return
+        }
         let stickyTopY = textContainerTop + 1
         let visibleStartChar = layoutManager.characterIndexForGlyph(at: glyphRange.location)
         let stickyLineIndex = lineNumberForCharacterIndex(visibleStartChar)
@@ -1490,6 +1577,13 @@ final class LineNumberGutterView: UIView {
             let lineNumber = stickyLineIndex + 1
             let drawRect = CGRect(x: 0, y: stickyTopY, width: bounds.width - rightPadding, height: font.lineHeight)
             NSString(string: String(lineNumber)).draw(in: drawRect, withAttributes: attrs)
+        }
+        if !layoutManager.extraLineFragmentRect.isEmpty,
+           !drawnLineIndices.contains(lineStarts.count - 1) {
+            let y = layoutManager.extraLineFragmentRect.minY + textContainerTop - contentOffsetY
+            NSString(string: String(lineStarts.count)).draw(
+                in: CGRect(x: 0, y: y, width: bounds.width - rightPadding, height: font.lineHeight),
+                withAttributes: attrs)
         }
     }
 
@@ -1608,11 +1702,12 @@ final class LineNumberedTextViewContainer: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         syncEditorInsets()
+        lineNumberView.setNeedsDisplay()
         currentLineHighlightOverlayView.setNeedsDisplay()
     }
 
     private func syncEditorInsets() {
-        let desiredTextInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+        let desiredTextInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8 + textView.editingLineHeight * 3, right: 8)
         if textView.textContainerInset != desiredTextInsets {
             textView.textContainerInset = desiredTextInsets
         }
@@ -1880,26 +1975,14 @@ struct CustomTextEditor: UIViewRepresentable {
         let tabWidth = max(1, indentWidth)
         let font = textView.font ?? resolvedUIFont()
         guard let editorTextView = textView as? EditorInputTextView else { return minimumScrollableWidth }
-        return editorTextView.cachedNoWrapWidth(visibleWidth: visibleWidth, tabWidth: tabWidth, font: font) {
-            let nsText = text as NSString
-            let sampleLimit = min(nsText.length, 120_000)
-            var maxColumns = 0
-            var currentColumns = 0
-            for index in 0..<sampleLimit {
-                let unit = nsText.character(at: index)
-                if unit == 10 || unit == 13 {
-                    maxColumns = max(maxColumns, currentColumns)
-                    currentColumns = 0
-                } else if unit == 9 {
-                    currentColumns += tabWidth
-                } else {
-                    currentColumns += 1
-                }
-            }
-            maxColumns = max(maxColumns, currentColumns)
-            let columnWidth = NSString(string: "W").size(withAttributes: [.font: font]).width
-            let measuredWidth = ceil(CGFloat(maxColumns) * max(1, columnWidth)) + textView.textContainerInset.left + textView.textContainerInset.right + 32
-            return max(minimumScrollableWidth, min(measuredWidth, 20_000))
+        return editorTextView.cachedNoWrapWidth(visibleWidth: visibleWidth, tabWidth: tabWidth, font: font, letterSpacing: letterSpacing) {
+            // Measure actual glyph advances, including fallback fonts, tabs and kerning.
+            // Character counts cannot bound CJK/emoji or proportional-font line widths.
+            var attributes = textView.typingAttributes
+            attributes[.font] = font
+            attributes[.kern] = letterSpacing
+            let measuredWidth = ceil((text as NSString).size(withAttributes: attributes).width) + 32
+            return max(minimumScrollableWidth, measuredWidth)
         }
     }
 
@@ -3047,6 +3130,7 @@ struct CustomTextEditor: UIViewRepresentable {
 
             var coloredRanges: [(NSRange, UIColor)] = []
             var emphasizedRanges: [(NSRange, SyntaxFontEmphasis)] = []
+            let markdownFonts = isMarkdownSyntaxLanguage(language) ? markdownSourceFontRanges(text) : []
 
             if let fastRanges = fastSyntaxColorRanges(
                 language: language,
@@ -3154,6 +3238,17 @@ struct CustomTextEditor: UIViewRepresentable {
                         font = italicCommentFont
                     }
                     textView.textStorage.addAttribute(.font, value: font, range: range)
+                }
+                for span in markdownFonts {
+                    let range = NSIntersectionRange(span.range, applyRange)
+                    guard range.length > 0 else { continue }
+                    var traits: UIFontDescriptor.SymbolicTraits = []
+                    if span.bold { traits.insert(.traitBold) }
+                    if span.italic { traits.insert(.traitItalic) }
+                    if let descriptor = baseFont.fontDescriptor.withSymbolicTraits(traits) {
+                        textView.textStorage.addAttribute(.font,
+                            value: UIFont(descriptor: descriptor, size: baseFont.pointSize), range: range)
+                    }
                 }
                 let suppressLargeFileExtras = self.parent.isLargeFileMode
                 let scopeGuideVisualsSupported = supportsScopeGuideVisuals(language: self.parent.language)
@@ -3276,9 +3371,7 @@ struct CustomTextEditor: UIViewRepresentable {
                 }
             }
             if shouldRenderLineNumbers() {
-                if UIDevice.current.userInterfaceIdiom == .phone, textView.isFirstResponder {
-                    container?.lineNumberView.setNeedsDisplay()
-                } else if didApplyIncrementalMutation, let lineNumberMutation {
+                if let lineNumberMutation {
                     container?.updateLineNumbers(
                         afterReplacing: lineNumberMutation.range,
                         with: lineNumberMutation.replacement,
@@ -3286,7 +3379,8 @@ struct CustomTextEditor: UIViewRepresentable {
                         fontSize: parent.fontSize
                     )
                 } else {
-                    container?.updateLineNumbersAfterInteractiveEdit(for: textView.text, fontSize: parent.fontSize)
+                    // Undo, IME, and programmatic replacements may not supply a delta.
+                    container?.updateLineNumbers(for: textView.text, fontSize: parent.fontSize)
                 }
             }
             let nsText = (textView.text ?? "") as NSString
@@ -3294,6 +3388,8 @@ struct CustomTextEditor: UIViewRepresentable {
             pendingEditedRange = nsText.lineRange(for: NSRange(location: caretLocation, length: 0))
             updateCaretStatus()
             scheduleHighlightIfNeeded(currentText: textView.text)
+            (textView as? EditorInputTextView)?.expandUnwrappedEditingLineIfNeeded()
+            (textView as? EditorInputTextView)?.revealCaretWithContext()
         }
 
         func textViewDidChangeSelection(_ textView: UITextView) {
@@ -3305,6 +3401,7 @@ struct CustomTextEditor: UIViewRepresentable {
             let generation = selectionUpdateGeneration
             guard textView.selectedRange.length > 0 else {
                 publishSelectionState(for: textView)
+                editorTextView?.revealCaretWithContext()
                 return
             }
 

--- a/Neon Vision Editor/UI/EditorTextView.swift
+++ b/Neon Vision Editor/UI/EditorTextView.swift
@@ -681,6 +681,20 @@ func isValidRange(_ range: NSRange, utf16Length: Int) -> Bool {
     isSyntaxHighlightRangeValid(range, utf16Length: utf16Length)
 }
 
+/// Font-only ranges in the original source; markup and escaped/code text stay intact.
+nonisolated func markdownSourceFontRanges(_ source: String) -> [(range: NSRange, bold: Bool, italic: Bool)] {
+    let options = AttributedString.MarkdownParsingOptions(appliesSourcePositionAttributes: true)
+    guard let parsed = try? AttributedString(markdown: source, options: options) else { return [] }
+    return parsed.runs.compactMap { run in
+        guard let intent = run.inlinePresentationIntent,
+              !intent.contains(.code),
+              intent.contains(.stronglyEmphasized) || intent.contains(.emphasized),
+              let position = run.markdownSourcePosition,
+              let range = Range(position, in: source) else { return nil }
+        return (NSRange(range, in: source), intent.contains(.stronglyEmphasized), intent.contains(.emphasized))
+    }
+}
+
 nonisolated func fastSyntaxColorRanges(
     language: String,
     profile: SyntaxPatternProfile,

--- a/Neon Vision EditorTests/MarkdownSyntaxHighlightingTests.swift
+++ b/Neon Vision EditorTests/MarkdownSyntaxHighlightingTests.swift
@@ -8,6 +8,26 @@ import SwiftUI
 
 @MainActor
 final class MarkdownSyntaxHighlightingTests: XCTestCase {
+    func testSourceEmphasisPreservesUnicodeAndExcludesEscapesAndCode() {
+        let source = "é **bold** *italic* ***both*** `**code**` \\*plain\\*\n\n```\n**fenced**\n```"
+        let spans = markdownSourceFontRanges(source)
+        let ns = source as NSString
+        XCTAssertTrue(spans.contains { ns.substring(with: $0.range) == "bold" && $0.bold && !$0.italic })
+        XCTAssertTrue(spans.contains { ns.substring(with: $0.range) == "italic" && !$0.bold && $0.italic })
+        XCTAssertTrue(spans.contains { ns.substring(with: $0.range) == "both" && $0.bold && $0.italic })
+        XCTAssertFalse(spans.contains { ns.substring(with: $0.range).contains("code") || ns.substring(with: $0.range).contains("fenced") })
+        XCTAssertEqual(markdownSourceFontRanges("").count, 0)
+        XCTAssertEqual(markdownSourceFontRanges("unclosed **text").count, 0)
+    }
+
+    func testSourceEmphasisLargeDocumentBudget() {
+        let source = String(repeating: "Paragraph **bold** and *italic*.\n\n", count: 2_000)
+        let start = ProcessInfo.processInfo.systemUptime
+        XCTAssertEqual(markdownSourceFontRanges(source).count, 4_000)
+        let elapsed = ProcessInfo.processInfo.systemUptime - start
+        print("Markdown source emphasis (64 KB): \(elapsed) seconds")
+        XCTAssertLessThan(elapsed, 2)
+    }
     private func markdownPatterns() -> [String: Color] {
         getSyntaxPatterns(
             for: "markdown",

--- a/Neon Vision EditorTests/MobileEditorInteractionTests.swift
+++ b/Neon Vision EditorTests/MobileEditorInteractionTests.swift
@@ -1,0 +1,164 @@
+#if os(iOS)
+import XCTest
+import SwiftUI
+@testable import Neon_Vision_Editor
+
+@MainActor
+final class MobileEditorInteractionTests: XCTestCase {
+    private func editor(_ text: String, wrap: Bool = false) -> CustomTextEditor {
+        CustomTextEditor(text: .constant(text), document: nil, documentID: nil,
+            documentResourceID: "mobile-regression", storedCaretLocation: nil,
+            externalEditRevision: 0, language: "plain text", colorScheme: .light,
+            fontSize: 16, isLineWrapEnabled: .constant(wrap), isLargeFileMode: false,
+            showsCodeMinimap: false, translucentBackgroundEnabled: false,
+            showKeyboardAccessoryBar: false, showLineNumbers: true,
+            formattingPreferences: .init(boldKeywords: false, italicComments: false,
+                underlineLinks: false, boldMarkdownHeadings: false),
+            showInvisibleCharacters: false, highlightCurrentLine: false,
+            highlightMatchingBrackets: false, showIndentationGuides: false,
+            showScopeGuides: false, highlightScopeBackground: false,
+            indentStyle: "spaces", indentWidth: 4, autoIndentEnabled: false,
+            autoCloseBracketsEnabled: false, highlightRefreshToken: 0,
+            isTabLoadingContent: false, isReadOnly: false,
+            onFontSizeChange: nil, onTextMutation: nil)
+    }
+
+    private func withEditor(_ text: String, body: (LineNumberedTextViewContainer) -> Void) {
+        let host = UIHostingController(rootView: editor(text))
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+        func find(_ view: UIView) -> LineNumberedTextViewContainer? {
+            if let container = view as? LineNumberedTextViewContainer { return container }
+            return view.subviews.lazy.compactMap(find).first
+        }
+        guard let container = find(host.view) else { return XCTFail("Missing editor") }
+        body(container)
+        window.isHidden = true
+    }
+
+    func testUnwrappedLongLineKeepsLastGlyphReachable() {
+        withEditor(String(repeating: "W", count: 5_000)) { container in
+            let view = container.textView
+            view.layoutManager.ensureLayout(for: view.textContainer)
+            let last = view.layoutManager.glyphIndexForCharacter(at: view.textStorage.length - 1)
+            let rect = view.layoutManager.boundingRect(forGlyphRange: NSRange(location: last, length: 1), in: view.textContainer)
+            XCTAssertGreaterThan(rect.width, 0, "The final character must not be clipped away")
+            XCTAssertLessThanOrEqual(rect.maxX, view.textContainer.size.width)
+            XCTAssertGreaterThan(view.textContainer.size.width, 40_000)
+        }
+    }
+
+    func testUnwrappedUnicodeLineFitsItsActualTypographicWidth() {
+        let source = String(repeating: "漢", count: 5_000)
+        withEditor(source) { container in
+            let view = container.textView
+            let expected = (source as NSString).size(withAttributes: [.font: view.font!]).width
+            XCTAssertGreaterThanOrEqual(view.textContainer.size.width, expected)
+        }
+    }
+
+    func testBottomInsetReservesThreeLines() {
+        withEditor("one\ntwo") { container in
+            XCTAssertGreaterThanOrEqual(container.textView.textContainerInset.bottom,
+                (container.textView.font?.lineHeight ?? 0) * 3)
+        }
+    }
+
+    func testTripleTapRecognizerExistsWithoutDelayingOrdinaryTouches() {
+        withEditor("one\ntwo") { container in
+            let taps = (container.textView.gestureRecognizers ?? []).compactMap { $0 as? UITapGestureRecognizer }
+            XCTAssertTrue(taps.contains { $0.numberOfTapsRequired == 3 && !$0.delaysTouchesBegan })
+        }
+    }
+
+    func testLogicalLineSelectionPreservesUnicodeAndIncludesLineEnding() {
+        let view = EditorInputTextView()
+        view.text = "😀 first\r\nsecond\n"
+        view.selectLogicalLine(at: 3)
+        XCTAssertEqual((view.text as NSString).substring(with: view.selectedRange), "😀 first\r\n")
+        view.selectLogicalLine(at: view.textStorage.length)
+        XCTAssertEqual(view.selectedRange, NSRange(location: view.textStorage.length, length: 0))
+        view.isSelectable = false
+        view.selectLogicalLine(at: 0)
+        XCTAssertEqual(view.selectedRange.length, 0)
+        XCTAssertEqual(view.accessibilityCustomActions?.first?.name, "Select Line")
+    }
+
+    func testActiveTypingUpdatesLineNumbersImmediately() {
+        withEditor("one\ntwo") { container in
+            let view = container.textView
+            view.becomeFirstResponder()
+            view.selectedRange = NSRange(location: 3, length: 0)
+            view.insertText("\n")
+            XCTAssertEqual(container.lineNumberView.lineStarts, EditorLineStartIndex.offsets(in: view.text))
+        }
+    }
+
+    func testCaretHasThreeLinesOfRoomAfterTypingAtEOF() {
+        withEditor(String(repeating: "line\n", count: 50)) { container in
+            let view = container.textView
+            XCTAssertTrue(view.becomeFirstResponder())
+            view.selectedRange = NSRange(location: view.textStorage.length, length: 0)
+            view.layoutIfNeeded()
+            view.revealCaretWithContext()
+            let scrolled = expectation(description: "UIKit completes its pending layout and scroll")
+            DispatchQueue.main.async { scrolled.fulfill() }
+            wait(for: [scrolled], timeout: 2)
+            let caret = view.caretRect(for: view.endOfDocument)
+            XCTAssertGreaterThanOrEqual(view.bounds.maxY - caret.maxY, view.editingLineHeight * 3 - 1,
+                "firstResponder=\(view.isFirstResponder) bounds=\(view.bounds) content=\(view.contentSize) caret=\(caret) inset=\(view.textContainerInset)")
+        }
+    }
+
+    func testEmptyGutterAndHorizontalScrollRenderNumbers() {
+        for text in ["", "short\n" + String(repeating: "W", count: 5_000)] {
+            withEditor(text) { container in
+                container.textView.contentOffset.x = text.isEmpty ? 0 : 2_000
+                container.layoutIfNeeded()
+                let image = UIGraphicsImageRenderer(bounds: container.lineNumberView.bounds).image { _ in
+                    container.lineNumberView.draw(container.lineNumberView.bounds)
+                }
+                let attachment = XCTAttachment(image: image)
+                attachment.name = text.isEmpty ? "Empty gutter" : "Horizontally scrolled gutter"
+                attachment.lifetime = .keepAlways
+                add(attachment)
+                XCTAssertNotNil(image.cgImage)
+                let blank = UIGraphicsImageRenderer(bounds: container.lineNumberView.bounds).image { _ in }
+                XCTAssertNotEqual(image.pngData(), blank.pngData(), "The gutter must paint a line number")
+            }
+        }
+    }
+
+    func testLongLineBeyondFormerSamplingLimitIsNotClipped() {
+        let source = String(repeating: "short\n", count: 20_001) + String(repeating: "W", count: 5_000)
+        let start = ProcessInfo.processInfo.systemUptime
+        withEditor(source) { container in
+            XCTAssertGreaterThan(container.textView.textContainer.size.width, 40_000)
+        }
+        let elapsed = ProcessInfo.processInfo.systemUptime - start
+        print("Mobile long-line fixture (125 KB) open: \(elapsed) seconds")
+        XCTAssertLessThan(elapsed, 3)
+    }
+
+    func testLargeDocumentLineIndexUpdatesWithoutDocumentMutationCallback() {
+        let source = String(repeating: "line\n", count: 52_000)
+        let container = LineNumberedTextViewContainer(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        container.layoutIfNeeded()
+        container.textView.font = .monospacedSystemFont(ofSize: 16, weight: .regular)
+        // Match CustomTextEditor's TextKit 1 setup before installing the fixture.
+        container.textView.layoutManager.allowsNonContiguousLayout = true
+        let coordinator = editor(source).makeCoordinator()
+        coordinator.container = container
+        coordinator.textView = container.textView
+        container.textView.text = source
+        container.updateLineNumbers(for: source, fontSize: 16)
+        // An undo/programmatic replacement has no shouldChange delta.
+        container.textView.text = "\n" + source
+        coordinator.textViewDidChange(container.textView)
+        XCTAssertEqual(container.lineNumberView.lineStarts.count, 52_002)
+        XCTAssertEqual(container.lineNumberView.lineStarts[1], 1)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- What changed: Native unwrapped-line width measurement (including Unicode and spacing), corrected gutter coordinates/redraws and incremental/fallback line indexes, three-line bottom/caret clearance, triple-tap logical-line selection with an accessible Select Line action, and source-preserving Markdown bold/italic fonts.
- Why: Long lines were clipped by a 20,000-point ceiling, a 120,000-unit sample, and character-width estimates. Active iPhone typing and large replacements could leave stale line indexes. Bottom padding was only 8 points, and explicit line selection/inline Markdown emphasis were absent.
- Scope: Bugfix / focused editing features. Mobile UI affects iOS/iPadOS and visionOS; the shared Markdown helper also compiles on macOS. No save/persistence changes, dependencies, build-number bump, or macOS 27 agentic work.
- Linked issue/milestone: User-reported iOS editing feedback; no linked issue.

## Validation

- [x] Built on macOS
- [x] Built on iOS simulator
- [x] Built on iPad simulator
- [ ] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

Verification Level 2; shared code changed: Yes. Final four-platform matrix passed, including visionOS. Final focused suites passed 44/44 on iPhone and 44/44 on iPad using iOS/iPadOS 27 simulators. Gutter screenshot attachments were visually inspected. Generated matrix DerivedData was removed; git diff --check passed.

Reproduction and regression evidence:
- Open an unwrapped 5,000-character line: old width stopped at 20,000 points; the source must remain reachable. A 5,000-character CJK line also reproduced an underestimate of 49,502 versus approximately 79,377 required points.
- Put the long line after 120,000 UTF-16 units; it must still contribute to width calculation.
- Insert newlines while actively typing; gutter indexes must update immediately. Replace a 260 KB document without a delta; its line index must also update.
- Move the caret to EOF; three lines of clearance must remain below it. Native deferred scrolling interacted with syntax viewport restoration; the calculated offset is now applied immediately.
- Triple-tap selection is covered by recognizer configuration, logical-line/Unicode/CRLF selection tests, and the accessible action. Physical gesture arbitration remains unverified.
- Markdown parser tests cover bold, italic, combined emphasis, Unicode source ranges, escaped markers, code spans/fences, and malformed/empty input without rewriting source.

Measured fixtures: 125 KB long-line open approximately 161 ms; 64 KB Markdown source-font parsing approximately 110 ms on the iPhone simulator. These are fixture measurements, not broad device-performance guarantees.

## Checklist

- [ ] Accessibility checked (labels, focus order, no traps)
- [ ] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [x] VoiceOver impact evaluated (if UI touched)
- [x] Changelog updated (if user-facing change)
- [x] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

The Select Line label/action is covered automatically. Full physical-device VoiceOver, touch gestures, hardware-keyboard acceptance, and the reporter's exact file remain pending. The iOS debugging workflow guided simulator regression validation; this is not a claim of physical-device testing.

## Risk

- Risk level: Medium
- User-facing risk: Shared mobile layout/selection behavior; actual shipping-OS devices and exceptionally large documents still need acceptance testing. Native full-text width measurement is cached; active edits expand only the current logical line.
- Rollback plan: Revert this scoped commit through a PR. No data migration is required.

## Summary by Sourcery

Improve mobile editor rendering and interaction reliability for long lines, caret positioning, line numbering, logical-line selection, and Markdown emphasis.

New Features:
- Add triple-tap logical-line selection and an accessible Select Line action to the mobile editor.
- Apply bold and italic font styling to Markdown source text while preserving markup and code content.

Bug Fixes:
- Fix mobile line-number updates during typing, scrolling, and replacements without incremental edit information.
- Remove fixed sampling and width limits that could clip long unwrapped lines or underestimate Unicode text widths.
- Preserve three lines of bottom clearance and caret context when editing near the end of a document.
- Correct gutter rendering for horizontally scrolled, empty, and final-line states.

Enhancements:
- Improve mobile editor text measurement using actual typographic widths, including Unicode, tabs, kerning, and letter spacing.

Documentation:
- Update the changelog with mobile editor rendering, caret, selection, and Markdown styling fixes.

Tests:
- Add regression coverage for long-line measurement, Unicode widths, caret clearance, line-number updates, gutter rendering, logical-line selection, and Markdown emphasis parsing.