### PR TITLE
Respect .gitignore and folder exclusions in Find in Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ### Fixes
 
+- Find in Files now applies root and nested .gitignore rules and the sidebar's Ignored Folders settings consistently, pruning excluded directories while retaining text files with unknown extensions.
 - Corrects mobile line-number updates while typing and scrolling, and removes the fixed width ceiling that clipped long unwrapped lines.
 - Adds three lines of bottom editing space and keeps context below the active caret on iOS/iPadOS and visionOS.
 - Adds triple-tap logical-line selection and an accessible Select Line action in the mobile editor.

--- a/Neon Vision Editor/Core/ProjectIgnoredFolders.swift
+++ b/Neon Vision Editor/Core/ProjectIgnoredFolders.swift
@@ -4,7 +4,7 @@ enum ProjectIgnoredFolders {
     nonisolated static let defaultsKey = "SettingsProjectSidebarIgnoredFolderNames"
     nonisolated static let defaultNames = [".git", ".build", "build", "node_modules", "DerivedData"]
     private nonisolated static let legacyDefaultNames = [".git", ".build", "node_modules", "DerivedData"]
-    nonisolated static let knownNames = defaultNames + [".swiftpm", ".derivedData", "build", "dist"]
+    nonisolated static let knownNames = defaultNames + [".swiftpm", ".derivedData", "dist"]
 
     nonisolated static var defaultRawValue: String {
         defaultNames.joined(separator: ",")

--- a/Neon Vision Editor/Core/ProjectSearchIgnoreRules.swift
+++ b/Neon Vision Editor/Core/ProjectSearchIgnoreRules.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Darwin
+
+/// Search-local rule cache. Skips symbolic links below the user-selected project.
+nonisolated final class ProjectSearchIgnoreRules {
+    private let root: URL
+    private let excludedFolders: Set<String>
+    private var rulesByDirectory: [String: [Rule]] = [:]
+
+    private struct Rule {
+        let pattern: String
+        let negated: Bool
+        let directoryOnly: Bool
+        let anchored: Bool
+
+        init?(_ line: String) {
+            var value = line
+            while value.last == " " {
+                let preceding = value.dropLast().reversed().prefix { $0 == "\\" }.count
+                if preceding % 2 == 1 { break }
+                value.removeLast()
+            }
+            guard !value.isEmpty, !value.hasPrefix("#") else { return nil }
+            negated = value.hasPrefix("!")
+            if negated { value.removeFirst() }
+            directoryOnly = value.hasSuffix("/")
+            if directoryOnly { value.removeLast() }
+            anchored = value.contains("/")
+            if value.hasPrefix("/") { value.removeFirst() }
+            guard !value.isEmpty else { return nil }
+            pattern = value
+        }
+
+        func matches(_ path: String, isDirectory: Bool) -> Bool {
+            guard !directoryOnly || isDirectory else { return false }
+            if !anchored {
+                return fnmatch(pattern, String(path.split(separator: "/").last ?? ""), 0) == 0
+            }
+            let patterns = pattern.split(separator: "/").map(String.init)
+            let components = path.split(separator: "/").map(String.init)
+            var memo: [Int: Bool] = [:]
+            func match(_ p: Int, _ c: Int) -> Bool {
+                let key = p * (components.count + 1) + c
+                if let cached = memo[key] { return cached }
+                let result: Bool
+                if p == patterns.count {
+                    result = c == components.count
+                } else if patterns[p] == "**" {
+                    // A trailing /** matches descendants, not the directory itself.
+                    result = p == patterns.count - 1
+                        ? c < components.count
+                        : match(p + 1, c) || (c < components.count && match(p, c + 1))
+                } else {
+                    result = c < components.count && fnmatch(patterns[p], components[c], 0) == 0 && match(p + 1, c + 1)
+                }
+                memo[key] = result
+                return result
+            }
+            return match(0, 0)
+        }
+    }
+
+    init(root: URL, excludedFolders: Set<String>) {
+        self.root = root.standardizedFileURL
+        self.excludedFolders = excludedFolders
+    }
+
+    func excludes(_ url: URL, isDirectory: Bool) -> Bool {
+        let path = url.standardizedFileURL.path
+        let prefix = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        guard path.hasPrefix(prefix) else { return true }
+        let components = String(path.dropFirst(prefix.count)).split(separator: "/").map(String.init)
+        var directory = root
+        var inherited: [(Int, [Rule])] = []
+        for index in components.indices {
+            let directoryPath = directory.path
+            if rulesByDirectory[directoryPath] == nil {
+                // An indexed candidate may traverse a symlinked directory even
+                // though the candidate file itself is a regular file.
+                if index > 0,
+                   (try? directory.resourceValues(forKeys: [.isSymbolicLinkKey]))?.isSymbolicLink == true {
+                    return true
+                }
+                let ignoreURL = directory.appendingPathComponent(".gitignore")
+                // Do not follow ignore-file symlinks outside the project.
+                let values = try? ignoreURL.resourceValues(forKeys: [.isSymbolicLinkKey])
+                let source = values?.isSymbolicLink == true ? "" : ((try? String(contentsOf: ignoreURL, encoding: .utf8)) ?? "")
+                rulesByDirectory[directoryPath] = source.components(separatedBy: .newlines).compactMap(Rule.init)
+            }
+            inherited.append((index, rulesByDirectory[directoryPath] ?? []))
+            let directoryComponent = index < components.count - 1 || isDirectory
+            if directoryComponent && excludedFolders.contains(components[index]) { return true }
+            var ignored = false
+            for (base, rules) in inherited {
+                let relative = components[base...index].joined(separator: "/")
+                for rule in rules where rule.matches(relative, isDirectory: directoryComponent) {
+                    ignored = !rule.negated
+                }
+            }
+            // Git cannot re-include a child of an excluded directory.
+            if ignored { return true }
+            directory.appendPathComponent(components[index])
+        }
+        return false
+    }
+}

--- a/Neon Vision Editor/UI/ContentView+Actions.swift
+++ b/Neon Vision Editor/UI/ContentView+Actions.swift
@@ -2225,10 +2225,14 @@ extension ContentView {
         candidateFiles: [URL]?,
         query: String,
         caseSensitive: Bool,
-        maxResults: Int
+        maxResults: Int,
+        ignoredFolderNames: Set<String> = Set(ProjectIgnoredFolders.defaultNames)
     ) async -> [FindInFilesMatch] {
         await Task.detached(priority: .userInitiated) {
-            let searchFiles = searchCandidateFiles(root: root, candidateFiles: candidateFiles)
+            guard maxResults > 0, !query.isEmpty else { return [] }
+            let rules = ProjectSearchIgnoreRules(root: root, excludedFolders: ignoredFolderNames)
+            let searchFiles = searchCandidateFiles(root: root, candidateFiles: candidateFiles, rules: rules)
+            guard !searchFiles.isEmpty else { return [] }
             #if os(macOS)
             if let ripgrepMatches = findInFilesWithRipgrep(
                 root: root,
@@ -2280,12 +2284,15 @@ extension ContentView {
             "--max-count",
             String(maxResults),
             caseSensitive ? "-s" : "-i",
+            "--fixed-strings",
+            "--",
             query
         ]
         if let ripgrepFileArguments = ripgrepPathArguments(root: root, candidateFiles: candidateFiles) {
             arguments.append(contentsOf: ripgrepFileArguments)
         } else {
-            arguments.append(root.path)
+            // Never widen the search when the explicit file list exceeds argv limits.
+            return nil
         }
         process.arguments = arguments
 
@@ -2330,7 +2337,7 @@ extension ContentView {
             let column = max(1, start + 1)
             let length = max(1, end - start)
             let snippet = lineText.trimmingCharacters(in: .newlines)
-            let fileURL = URL(fileURLWithPath: path)
+            let fileURL = (path.hasPrefix("/") ? URL(fileURLWithPath: path) : root.appendingPathComponent(path)).standardizedFileURL
             let lineStarts: [Int] = {
                 if let cached = lineStartsByPath[path] {
                     return cached
@@ -2358,11 +2365,17 @@ extension ContentView {
 
 #endif
 
-    private nonisolated static func searchCandidateFiles(root: URL, candidateFiles: [URL]?) -> [URL] {
-        if let candidateFiles, !candidateFiles.isEmpty {
-            return candidateFiles
+    private nonisolated static func searchCandidateFiles(root: URL, candidateFiles: [URL]?, rules: ProjectSearchIgnoreRules) -> [URL] {
+        if let candidateFiles {
+            return candidateFiles.filter {
+                guard !rules.excludes($0, isDirectory: false),
+                      let values = try? $0.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]),
+                      values.isRegularFile == true, values.isSymbolicLink != true,
+                      let size = values.fileSize, size > 0, size <= 2_000_000 else { return false }
+                return true
+            }
         }
-        return searchableProjectFiles(at: root)
+        return searchableProjectFiles(at: root, rules: rules)
     }
 
 #if os(macOS)
@@ -2394,9 +2407,9 @@ extension ContentView {
     }
 #endif
 
-    private nonisolated static func searchableProjectFiles(at root: URL) -> [URL] {
+    private nonisolated static func searchableProjectFiles(at root: URL, rules: ProjectSearchIgnoreRules) -> [URL] {
         let fm = FileManager.default
-        let keys: Set<URLResourceKey> = [.isRegularFileKey, .isHiddenKey, .fileSizeKey]
+        let keys: Set<URLResourceKey> = [.isRegularFileKey, .isDirectoryKey, .isSymbolicLinkKey, .isHiddenKey, .fileSizeKey]
         guard let enumerator = fm.enumerator(
             at: root,
             includingPropertiesForKeys: Array(keys),
@@ -2410,6 +2423,10 @@ extension ContentView {
         for case let url as URL in enumerator {
             if Task.isCancelled { break }
             guard let values = try? url.resourceValues(forKeys: keys) else { continue }
+            if values.isSymbolicLink == true || rules.excludes(url, isDirectory: values.isDirectory == true) {
+                if values.isDirectory == true { enumerator.skipDescendants() }
+                continue
+            }
             guard values.isHidden != true, values.isRegularFile == true else { continue }
             let size = values.fileSize ?? 0
             if size <= 0 || size > 2_000_000 { continue }

--- a/Neon Vision Editor/UI/ContentView+QuickSwitcherFind.swift
+++ b/Neon Vision Editor/UI/ContentView+QuickSwitcherFind.swift
@@ -609,30 +609,23 @@ extension ContentView {
 #endif
 
         findInFilesTask?.cancel()
-        let indexedProjectFileURLs = projectFileIndexSnapshot.fileURLs
-        let candidateFiles = indexedProjectFileURLs.isEmpty ? nil : indexedProjectFileURLs
-        let searchSourceMessage: String
-        if candidateFiles == nil, isProjectFileIndexing {
-            findInFilesStatusMessage = "Searching while project index updates…"
-            searchSourceMessage = "Live filesystem scan while the project index refreshes."
-        } else {
-            findInFilesStatusMessage = "Searching…"
-            if let candidateFiles {
-                searchSourceMessage = "Searching \(candidateFiles.count) indexed project files."
-            } else {
-                searchSourceMessage = "Searching the live project tree because no index is available yet."
-            }
-        }
+        // Sidebar indexes may omit unknown extensions or reflect older ignore rules.
+        // Search the live tree off the main actor with current folder exclusions.
+        let candidateFiles: [URL]? = nil
+        let searchSourceMessage = "Searching the live project tree with .gitignore and Ignored Folders exclusions."
+        findInFilesStatusMessage = "Searching…"
         findInFilesSourceMessage = searchSourceMessage
 
         let caseSensitive = findInFilesCaseSensitive
+        let ignoredFolderNames = ProjectIgnoredFolders.names(from: projectIgnoredFolderNamesRaw)
         findInFilesTask = Task {
             let results = await ContentView.findInFiles(
                 root: root,
                 candidateFiles: candidateFiles,
                 query: query,
                 caseSensitive: caseSensitive,
-                maxResults: 500
+                maxResults: 500,
+                ignoredFolderNames: ignoredFolderNames
             )
             guard !Task.isCancelled else { return }
             findInFilesResults = results

--- a/Neon Vision EditorTests/ProjectSearchIgnoreTests.swift
+++ b/Neon Vision EditorTests/ProjectSearchIgnoreTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import Neon_Vision_Editor
+
+@MainActor
+final class ProjectSearchIgnoreTests: XCTestCase {
+    private func fixture(_ files: [String: String]) throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        for (path, contents) in files {
+            let url = root.appendingPathComponent(path)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data(contents.utf8).write(to: url)
+        }
+        addTeardownBlock { try FileManager.default.removeItem(at: root) }
+        return root
+    }
+
+    func testLiveAndIndexedSearchRespectRulesAndUnknownExtensions() async throws {
+        let root = try fixture([
+            ".gitignore": "*.log\n!keep.log\ncache/\n",
+            "keep.log": "needle", "drop.log": "needle", "notes.unusual": "needle",
+            "cache/data": "needle", "node_modules/lib.js": "needle", "build/output": "needle",
+            "src/.gitignore": "local.*\n", "src/local.txt": "needle", "src/code.swift": "needle"
+        ])
+        let indexed = ["keep.log", "drop.log", "notes.unusual", "cache/data", "node_modules/lib.js",
+                       "build/output", "src/local.txt", "src/code.swift"].map { root.appendingPathComponent($0) }
+        for candidates in [nil, indexed] as [[URL]?] {
+            let results = await ContentView.findInFiles(root: root, candidateFiles: candidates, query: "needle", caseSensitive: true, maxResults: 100)
+            XCTAssertEqual(Set(results.map(\.fileURL.lastPathComponent)), ["keep.log", "notes.unusual", "code.swift"])
+        }
+    }
+
+    func testEmptyCandidatesNeverFallBackToWholeTree() async throws {
+        let root = try fixture(["notes.txt": "needle"])
+        let results = await ContentView.findInFiles(root: root, candidateFiles: [], query: "needle", caseSensitive: true, maxResults: 100)
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testLargeCandidateListDoesNotWidenSearch() async throws {
+        let root = try fixture(["keep.txt": "needle", "excluded/data.txt": "needle"])
+        let candidates = Array(repeating: root.appendingPathComponent("keep.txt"), count: 2_001)
+        let results = await ContentView.findInFiles(root: root, candidateFiles: candidates, query: "needle", caseSensitive: true, maxResults: 3, ignoredFolderNames: ["excluded"])
+        XCTAssertFalse(results.isEmpty)
+        XCTAssertTrue(results.allSatisfy { $0.fileURL.lastPathComponent == "keep.txt" })
+    }
+
+    func testLiteralQueryAndResultURL() async throws {
+        let root = try fixture(["-notes.unknown": "-n[1]", "other.txt": "-n1"])
+        let results = await ContentView.findInFiles(root: root, candidateFiles: nil, query: "-n[1]", caseSensitive: true, maxResults: 10)
+        XCTAssertEqual(results.map(\.fileURL), [root.appendingPathComponent("-notes.unknown")])
+    }
+
+    func testCustomFolderExclusionAndChangedIgnoreFile() async throws {
+        let root = try fixture(["generated/output": "needle", "keep.txt": "needle", ".gitignore": "keep.txt"])
+        let first = await ContentView.findInFiles(root: root, candidateFiles: nil, query: "needle", caseSensitive: true, maxResults: 100, ignoredFolderNames: ["generated"])
+        XCTAssertTrue(first.isEmpty)
+        try Data().write(to: root.appendingPathComponent(".gitignore"))
+        let second = await ContentView.findInFiles(root: root, candidateFiles: nil, query: "needle", caseSensitive: true, maxResults: 100, ignoredFolderNames: ["generated"])
+        XCTAssertEqual(second.map(\.fileURL.lastPathComponent), ["keep.txt"])
+    }
+
+    func testGitPatternSemantics() throws {
+        let root = try fixture([
+            ".gitignore": "# comment\n/root.txt\n*.log\n!keep.log\ncache/\na/**/generated?.[ch]\nblocked/\n!blocked/keep.txt\n\\#literal\n\\!literal\nspace\\ \ntrimmed   \n",
+            "nested/.gitignore": "!child.log\n/local.txt\n"
+        ])
+        let rules = ProjectSearchIgnoreRules(root: root, excludedFolders: [])
+        let excluded = ["root.txt", "deep/error.log", "cache/a", "a/generated1.c", "a/b/c/generated2.h",
+                        "blocked/keep.txt", "#literal", "!literal", "space ", "trimmed", "nested/local.txt"]
+        for path in excluded { XCTAssertTrue(rules.excludes(root.appendingPathComponent(path), isDirectory: false), path) }
+        let included = ["deep/root.txt", "keep.log", "deep/keep.log", "cache", "a/generated12.c",
+                        "nested/child.log", "nested/deeper/local.txt", "notes.unknown"]
+        for path in included { XCTAssertFalse(rules.excludes(root.appendingPathComponent(path), isDirectory: false), path) }
+        XCTAssertTrue(rules.excludes(root.appendingPathComponent("cache"), isDirectory: true))
+        XCTAssertTrue(rules.excludes(root.deletingLastPathComponent().appendingPathComponent("outside"), isDirectory: false))
+    }
+
+    func testDoubleStarDescendantsAndReincludedDirectory() throws {
+        let root = try fixture([".gitignore": "abc/**\noutput/*\n!output/keep/\n**/temp\n"])
+        let rules = ProjectSearchIgnoreRules(root: root, excludedFolders: [])
+        XCTAssertFalse(rules.excludes(root.appendingPathComponent("abc"), isDirectory: true))
+        XCTAssertTrue(rules.excludes(root.appendingPathComponent("abc/file"), isDirectory: false))
+        XCTAssertFalse(rules.excludes(root.appendingPathComponent("output/keep/file"), isDirectory: false))
+        XCTAssertTrue(rules.excludes(root.appendingPathComponent("output/drop/file"), isDirectory: false))
+        XCTAssertTrue(rules.excludes(root.appendingPathComponent("a/b/temp"), isDirectory: false))
+    }
+
+    func testCandidateDirectorySymlinkCannotEscapeProject() async throws {
+        let root = try fixture(["keep.txt": "needle"])
+        let outside = try fixture(["outside.txt": "needle"])
+        let alias = root.appendingPathComponent("alias")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: outside)
+        let candidate = alias.appendingPathComponent("outside.txt")
+        let rules = ProjectSearchIgnoreRules(root: root, excludedFolders: [])
+        XCTAssertTrue(rules.excludes(candidate, isDirectory: false))
+        let results = await ContentView.findInFiles(root: root, candidateFiles: [candidate], query: "needle", caseSensitive: true, maxResults: 10)
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func testIgnoreFileSymlinkIsNotRead() throws {
+        let root = try fixture(["keep.txt": "needle"])
+        let outside = try fixture(["rules": "keep.txt"])
+        try FileManager.default.createSymbolicLink(at: root.appendingPathComponent(".gitignore"), withDestinationURL: outside.appendingPathComponent("rules"))
+        let rules = ProjectSearchIgnoreRules(root: root, excludedFolders: [])
+        XCTAssertFalse(rules.excludes(root.appendingPathComponent("keep.txt"), isDirectory: false))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Platform-specific availability is tracked in the [Platform Matrix](#platform-mat
 - The terminal provides a persistent PTY shell, bounded scrollback, and ANSI colors. Its display is currently append-only: cursor-based progress rewrites and full-screen/alternate-screen programs are not supported. Remaining emulator and readiness work is tracked in [#318](https://github.com/h3pdesign/Neon-Vision-Editor/issues/318).
 - `scripts/nve` opens files from the terminal and supports `--wait`, `--new-window`, and `--line` compatibility flags.
 - Find in Files keeps results visible on Mac and iPad when a match opens, while replacement targets start unselected by default.
+- In the next release, Find in Files respects project and nested `.gitignore` files. Use the project sidebar's **Ignored Folders** menu to exclude `node_modules`, `build`, `dist`, and other listed output folders; custom paths and patterns belong in `.gitignore`. Unknown text-file extensions remain searchable. Git global excludes and tracked-file exceptions are not applied.
 - Remote Sessions are opt-in: macOS owns SSH-key login and can publish an attach code so iPhone, iPad, and Apple Vision Pro can browse, open, edit, and explicitly save supported remote text files through the Mac-hosted broker.
 - Project quick actions (`Expand All` / `Collapse All`), recent project folders, file filters for All Files, Modified, Images, PNG, PDF, and Markdown, and default ignored heavy folders (`.git`, `.build`, `node_modules`, `DerivedData`).
 


### PR DESCRIPTION
## Summary

- What changed: Apply selected-project and nested `.gitignore` rules plus the sidebar's existing Ignored Folders preference before searching. Prune excluded directories, preserve unknown-extension text files, and cache parsed rules per search.
- Why: The live scanner bypassed folder exclusions; explicit indexed paths bypassed ignore rules, and an oversized ripgrep argument list could widen the search to the entire project. Empty candidate lists no longer trigger a full scan. Literal queries and relative result paths are handled consistently.
- Second review: Reproduced and fixed an indexed candidate traversing a symlinked directory outside the selected project. Added directory-link and ignore-file-link regressions. Removed the duplicate build-folder menu entry.
- Scope: Bugfix / Feature / Docs. Seven scoped files; no dependencies, version/build bump, release publication, or macOS 27 development changes.
- Linked issue/milestone: User-requested Find in Files review; no linked issue.

## Validation

- [x] Built on macOS
- [x] Built on iOS simulator
- [x] Built on iPad simulator
- [ ] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

Verification Level 2; shared code changed: Yes. Final `scripts/ci/build_platform_matrix.sh` verification covers macOS, iOS Simulator, iPad Simulator, and visionOS. No cross-platform build failures. Generated matrix DerivedData removed.

Focused macOS tests: 14 passed (9 ProjectSearchIgnoreTests and 5 ProjectTreePerformanceTests), including the second-review symlink regression. Earlier pre-review iPhone and iPad runs each passed the original 7 search tests; those runs predate the additional symlink guard/tests. No physical-device or interactive accessibility claim.

Reproduction: Create a disposable project with `notes.unknown`, `node_modules/lib.js`, `build/output`, `ignored.log`, and `.gitignore` containing `*.log`; put the same query in each text file. The original live scanner includes all four files; expected only `notes.unknown`. Tests exercise live and indexed candidates, nested overrides, negation, anchored/directory patterns, double stars, escapes, changed ignore files, custom folder exclusions, empty lists, and oversized candidate lists.

Second-review red/green: Supply an indexed candidate `project/alias/outside.txt`, where alias points to a sibling disposable directory. Before the guard, the exclusion assertion/search test fails; after the guard, no result or ignore-file read is allowed through that directory link.

## Checklist

- [ ] Accessibility checked (labels, focus order, no traps)
- [ ] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [x] VoiceOver impact evaluated (if UI touched)
- [x] Changelog updated (if user-facing change)
- [x] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

No new interactive controls; uses the existing Ignored Folders menu. Full interactive VoiceOver/keyboard testing was not performed.

## Risk

- Risk level: Medium
- User-facing risk: Search now scans the live tree off the main actor to avoid stale or extension-filtered sidebar indexes. Excluded subtrees are pruned; very large projects and live network-provider performance are not exhaustively benchmarked. Existing live-search hidden/package and 2 MB file limits remain. These are project-local ignore semantics, not full Git status: global excludes and tracked-file exceptions are not applied.
- Rollback plan: Revert this PR's commit; no persisted-data migration is required.

## Summary by Sourcery

Ensure Find in Files searches only eligible files within the selected project while respecting project and user-configured exclusions.

Bug Fixes:
- Make Find in Files consistently honor root and nested .gitignore rules and configured Ignored Folders for both live and indexed searches.
- Prevent searches from escaping the selected project through symlinked directories or symlinked ignore files.
- Avoid broadening searches when candidate lists are empty or exceed command-line limits, and handle literal queries and relative result paths consistently.

Enhancements:
- Retain searchable text files with unknown extensions while pruning ignored directories and enforcing existing file-size and file-type limits.
- Remove the duplicate build-folder entry from the ignored-folder names.

Documentation:
- Document Find in Files ignore behavior, supported exclusions, unknown-extension handling, and the absence of global Git exclusions or tracked-file exceptions.

Tests:
- Add regression coverage for ignore-pattern semantics, nested overrides, custom exclusions, changed ignore files, empty and oversized candidate lists, literal queries, and symlink escapes.