### PR TITLE
Sync main documentation back to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10043&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10106&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 > Platform target: **macOS 26 (Tahoe)** compatible with **macOS Sequoia**
 > Apple Silicon: tested / Intel: not tested
 > Direct GitHub release: **v1.6.2** / App Store and TestFlight availability varies by platform and review status
-> Last updated (README): **2026-09-05** for latest release **v1.6.2**
+> Last updated (README): **2026-09-06** for latest release **v1.6.2**
 
 ## What's New in v1.6.1 and v1.6.2
 
@@ -165,7 +165,7 @@
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10106&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10135&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>
@@ -184,8 +184,8 @@
   <img alt="Unique visitors (14d)" src="https://img.shields.io/static/v1?label=Unique+visitors+%2814d%29&message=163&color=0EA5E9&style=for-the-badge">
 </p>
 <p align="center">
-  <img alt="Clone snapshot (UTC)" src="https://img.shields.io/static/v1?label=Clone+snapshot+%28UTC%29&message=2026-09-05&color=334155&style=flat-square">
-  <img alt="View snapshot (UTC)" src="https://img.shields.io/static/v1?label=View+snapshot+%28UTC%29&message=2026-09-05&color=334155&style=flat-square">
+  <img alt="Clone snapshot (UTC)" src="https://img.shields.io/static/v1?label=Clone+snapshot+%28UTC%29&message=2026-09-06&color=334155&style=flat-square">
+  <img alt="View snapshot (UTC)" src="https://img.shields.io/static/v1?label=View+snapshot+%28UTC%29&message=2026-09-06&color=334155&style=flat-square">
 </p>
 
 ## Project Documentation

--- a/docs/images/release-download-trend-dark.svg
+++ b/docs/images/release-download-trend-dark.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-05</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 201 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 54 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 132.5 L 935.7 216.9 L 1070.0 194.4 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.8 L 1070.0 286.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,132.5 935.7,216.9 1070.0,194.4"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.8 1070.0,286.2"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -64,22 +64,22 @@
     filter="url(#glow)"
   />
 
-  <circle cx="130.0" cy="207.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="264.3" cy="237.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="398.6" cy="122.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="532.9" cy="212.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="667.1" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="801.4" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="194.4" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
-  <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
-  <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
-  <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
-  <text x="532.9" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
-  <text x="667.1" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
-  <text x="801.4" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
-  <text x="935.7" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
-  <text x="1070.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.1</text>
+  <circle cx="130.0" cy="237.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="264.3" cy="122.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="398.6" cy="212.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="532.9" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="667.1" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="801.4" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="188.8" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="286.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
+  <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
+  <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
+  <text x="532.9" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
+  <text x="667.1" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
+  <text x="801.4" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
+  <text x="935.7" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.1</text>
+  <text x="1070.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.2</text>
   <text x="70" y="414" fill="#E6F3FF" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="94" y="462" fill="#C4B5FD" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>

--- a/docs/images/release-download-trend-dark.svg
+++ b/docs/images/release-download-trend-dark.svg
@@ -36,10 +36,10 @@
   <rect x="24" y="24" width="1152" height="572" rx="14" stroke="#2A4762" stroke-width="1.5"/>
 
   <text x="70" y="68" fill="#E6F3FF" font-size="30" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Release downloads</text>
-  <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-05</text>
+  <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-06</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 54 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 82 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.8 L 1070.0 286.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.1 L 1070.0 268.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.8 1070.0,286.2"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.1 1070.0,268.8"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="667.1" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="188.8" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="286.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="188.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="268.8" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>

--- a/docs/images/release-download-trend-light.svg
+++ b/docs/images/release-download-trend-light.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-05</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="884" y="70" fill="#475569" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 201 downloads</text>
+  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 54 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#94A3B8" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#CBD5E1" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 132.5 L 935.7 216.9 L 1070.0 194.4 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.8 L 1070.0 286.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,132.5 935.7,216.9 1070.0,194.4"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.8 1070.0,286.2"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -64,22 +64,22 @@
     filter="url(#glow)"
   />
 
-  <circle cx="130.0" cy="207.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="264.3" cy="237.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="398.6" cy="122.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="532.9" cy="212.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="667.1" cy="266.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="801.4" cy="132.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="935.7" cy="216.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="1070.0" cy="194.4" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
-  <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
-  <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
-  <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
-  <text x="532.9" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
-  <text x="667.1" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
-  <text x="801.4" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
-  <text x="935.7" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
-  <text x="1070.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.1</text>
+  <circle cx="130.0" cy="237.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="264.3" cy="122.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="398.6" cy="212.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="532.9" cy="266.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="667.1" cy="132.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="801.4" cy="216.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="935.7" cy="188.8" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="1070.0" cy="286.2" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
+  <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
+  <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
+  <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
+  <text x="532.9" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
+  <text x="667.1" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
+  <text x="801.4" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
+  <text x="935.7" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.1</text>
+  <text x="1070.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.2</text>
   <text x="70" y="414" fill="#0F172A" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="94" y="462" fill="#6D28D9" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>

--- a/docs/images/release-download-trend-light.svg
+++ b/docs/images/release-download-trend-light.svg
@@ -36,10 +36,10 @@
   <rect x="24" y="24" width="1152" height="572" rx="14" stroke="#CBD5E1" stroke-width="1.5"/>
 
   <text x="70" y="68" fill="#0F172A" font-size="30" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Release downloads</text>
-  <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-05</text>
+  <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-06</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="884" y="70" fill="#475569" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 54 downloads</text>
+  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 82 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#94A3B8" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#CBD5E1" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.8 L 1070.0 286.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.1 L 1070.0 268.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.8 1070.0,286.2"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.1 1070.0,268.8"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="266.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="667.1" cy="132.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="801.4" cy="216.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="935.7" cy="188.8" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="1070.0" cy="286.2" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="935.7" cy="188.1" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="1070.0" cy="268.8" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>

--- a/docs/images/release-download-trend.svg
+++ b/docs/images/release-download-trend.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-05</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.1 · 201 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 54 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 207.5 L 264.3 237.5 L 398.6 122.5 L 532.9 212.5 L 667.1 266.9 L 801.4 132.5 L 935.7 216.9 L 1070.0 194.4 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.8 L 1070.0 286.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,207.5 264.3,237.5 398.6,122.5 532.9,212.5 667.1,266.9 801.4,132.5 935.7,216.9 1070.0,194.4"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.8 1070.0,286.2"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -64,22 +64,22 @@
     filter="url(#glow)"
   />
 
-  <circle cx="130.0" cy="207.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="264.3" cy="237.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="398.6" cy="122.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="532.9" cy="212.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="667.1" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="801.4" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="194.4" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
-  <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.0</text>
-  <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
-  <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
-  <text x="532.9" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
-  <text x="667.1" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
-  <text x="801.4" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
-  <text x="935.7" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
-  <text x="1070.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.1</text>
+  <circle cx="130.0" cy="237.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="264.3" cy="122.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="398.6" cy="212.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="532.9" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="667.1" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="801.4" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="188.8" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="286.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
+  <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
+  <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
+  <text x="532.9" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.5</text>
+  <text x="667.1" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.6</text>
+  <text x="801.4" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.0</text>
+  <text x="935.7" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.1</text>
+  <text x="1070.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.6.2</text>
   <text x="70" y="414" fill="#E6F3FF" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="94" y="462" fill="#C4B5FD" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>

--- a/docs/images/release-download-trend.svg
+++ b/docs/images/release-download-trend.svg
@@ -36,10 +36,10 @@
   <rect x="24" y="24" width="1152" height="572" rx="14" stroke="#2A4762" stroke-width="1.5"/>
 
   <text x="70" y="68" fill="#E6F3FF" font-size="30" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Release downloads</text>
-  <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-05</text>
+  <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-06</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 54 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 82 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.8 L 1070.0 286.2 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.1 L 1070.0 268.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.8 1070.0,286.2"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.1 1070.0,268.8"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="667.1" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="188.8" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="286.2" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="188.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="268.8" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>


### PR DESCRIPTION
## Summary

- What changed: Synchronize the latest production download-metrics documentation from main into develop.
- Why: Keep maintained branches current without promoting unreleased develop changes to main.
- Scope: Docs / branch synchronization. No release or app-code changes.
- Linked issue/milestone: User-requested branch sync.

## Validation

- [ ] Built on macOS
- [ ] Built on iOS simulator
- [ ] Built on iPad simulator
- [ ] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes): not applicable
- [x] Expected vs actual behavior documented (for bug/regression fixes): no runtime behavior changes

Verification Level 0: incoming commits are automated download-metrics documentation only. No runtime build required.

## Checklist

- [ ] Accessibility checked (labels, focus order, no traps)
- [ ] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [ ] VoiceOver impact evaluated (if UI touched)
- [ ] Changelog updated (if user-facing change)
- [x] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

## Risk

- Risk level: Low
- User-facing risk: Documentation-only merge; no app behavior or release changes.
- Rollback plan: Revert the merge commit.

## Summary by Sourcery

Synchronize the latest download metrics and related documentation assets with develop.

Enhancements:
- Refresh the README’s release download metrics, snapshot dates, and last-updated metadata.
- Update the release download trend images to reflect the latest metrics.

Documentation:
- Synchronize production download-metrics documentation into the develop branch.