### PR TITLE
Fix Markdown PDF exports and sync main documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ### Fixes
 
+- Fixes Markdown PDF export clipping, removes interactive code controls from exports, preserves A4 page dimensions, and uses content and code-line boundaries for pagination without blank trailing pages.
 - Find in Files now applies root and nested .gitignore rules and the sidebar's Ignored Folders settings consistently, pruning excluded directories while retaining text files with unknown extensions.
 - Corrects mobile line-number updates while typing and scrolling, and removes the fixed width ceiling that clipped long unwrapped lines.
 - Adds three lines of bottom editing space and keeps context below the active caret on iOS/iPadOS and visionOS.

--- a/Neon Vision Editor/UI/ContentView+MarkdownPreviewExport.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownPreviewExport.swift
@@ -3311,6 +3311,19 @@ extension ContentView {
           border-color: #d1d5db !important;
           -webkit-text-fill-color: #111827 !important;
         }
+        /* PDF capture uses screen media too: never export scrolling controls
+           or rely on a horizontal scrollbar to reveal document content. */
+        body.pdf-export .code-block-copy,
+        body.pdf-export .code-block-language-control {
+          display: none !important;
+        }
+        body.pdf-export pre,
+        body.pdf-export pre code {
+          white-space: pre-wrap !important;
+          overflow-wrap: anywhere !important;
+          word-break: normal !important;
+          overflow: visible !important;
+        }
         @media print {
           :root {
             color-scheme: light;

--- a/Neon Vision Editor/UI/MarkdownPreviewPDFRenderer.swift
+++ b/Neon Vision Editor/UI/MarkdownPreviewPDFRenderer.swift
@@ -35,8 +35,6 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
     private static let exportTimeoutNanoseconds: UInt64 = 30_000_000_000
     private static let exportMeasurementPadding: CGFloat = 28
     private static let onePageExportPadding: CGFloat = 8
-    private static let exportBottomSafetyMargin: CGFloat = 1024
-    private static let onePageBottomSafetyMargin: CGFloat = 24
     private static let onePageMinimumHeight: CGFloat = 120
     private static let a4PaperRect = CGRect(x: 0, y: 0, width: 595, height: 842)
 
@@ -95,8 +93,7 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
           const root = document.querySelector('.content') || body;
           const scrolling = document.scrollingElement || html;
           const exportPadding = \(Int(exportMode == .onePageFit ? Self.onePageExportPadding : Self.exportMeasurementPadding));
-          const bottomSafetyMargin = \(Int(exportMode == .onePageFit ? Self.onePageBottomSafetyMargin : Self.exportBottomSafetyMargin));
-          const minimumHeight = \(Int(exportMode == .onePageFit ? Self.onePageMinimumHeight : 900));
+          const minimumHeight = \(Int(Self.onePageMinimumHeight));
           body.style.margin = '0';
           body.style.padding = `${exportPadding}px`;
           body.style.overflow = 'visible';
@@ -122,24 +119,33 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
             rangeRect.bottom,
             lastElementRect.bottom
           );
-          const width = Math.max(
-            Math.ceil(body.scrollWidth),
-            Math.ceil(html.scrollWidth),
-            Math.ceil(scrolling.scrollWidth),
-            Math.ceil(root.scrollWidth),
-            Math.ceil(root.getBoundingClientRect().width) + exportPadding * 2,
-            \(Int(Self.a4PaperRect.width))
-          );
+          // Measure at the same width used for capture. Scroll heights include
+          // the initial viewport, which otherwise manufactures blank pages.
+          const width = window.innerWidth;
           const height = Math.max(
-            Math.ceil(body.scrollHeight),
-            Math.ceil(html.scrollHeight),
-            Math.ceil(scrolling.scrollHeight),
-            Math.ceil(scrolling.offsetHeight),
-            Math.ceil(root.scrollHeight),
-            Math.ceil(root.getBoundingClientRect().height) + exportPadding * 2,
-            Math.ceil(measuredBottom - Math.min(bodyRect.top, rootRect.top)) + exportPadding * 2 + bottomSafetyMargin,
+            Math.ceil(measuredBottom + window.scrollY) + exportPadding,
             minimumHeight
           );
+          // A code block can be taller than a page. Its rendered line boxes
+          // provide safe break positions even when no whole block fits.
+          root.querySelectorAll('pre').forEach(pre => {
+            const textWalker = document.createTreeWalker(pre, NodeFilter.SHOW_TEXT);
+            const lineRects = [];
+            while (textWalker.nextNode()) {
+              const lineRange = document.createRange();
+              lineRange.selectNodeContents(textWalker.currentNode);
+              for (const rect of lineRange.getClientRects()) {
+                if (rect.height > 0 && rect.width > 0) lineRects.push({top: rect.top, bottom: rect.bottom});
+              }
+            }
+            lineRects.sort((a, b) => a.top - b.top);
+            let bottom = null;
+            for (const rect of lineRects) {
+              if (bottom !== null && rect.top >= bottom) blockBottoms.push(Math.ceil(bottom + window.scrollY));
+              bottom = bottom === null ? rect.bottom : Math.max(bottom, rect.bottom);
+            }
+            if (bottom !== null) blockBottoms.push(Math.ceil(bottom + window.scrollY));
+          });
           return [width, height, blockBottoms];
         })();
         """
@@ -180,8 +186,8 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
         guard let values = javaScriptValue as? [Any], values.count >= 2,
               let widthNumber = values[0] as? NSNumber,
               let heightNumber = values[1] as? NSNumber else { return nil }
-        let width = max(640.0, min(8192.0, widthNumber.doubleValue))
-        let minimumHeight = exportMode == .onePageFit ? Self.onePageMinimumHeight : 900.0
+        let width = max(1.0, min(8192.0, widthNumber.doubleValue))
+        let minimumHeight = Self.onePageMinimumHeight
         let height = max(minimumHeight, heightNumber.doubleValue)
         return CGRect(x: 0, y: 0, width: width, height: height)
     }
@@ -194,6 +200,7 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
 
     private func bestEffortPDFRect(javaScriptValue: Any?, webView: WKWebView, error: Error?) -> CGRect {
         let jsRect = pdfRect(from: javaScriptValue)
+        if let jsRect, error == nil { return jsRect }
         let contentSize: CGSize
 #if os(macOS)
         contentSize = webView.enclosingScrollView?.documentView?.frame.size ?? .zero
@@ -368,7 +375,7 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
             return nil
         }
 
-        let mediaBoxInfo: [CFString: Any] = [kCGPDFContextMediaBox: paperRect]
+        let mediaBoxInfo = Self.pageInfo(for: paperRect)
         for range in pageRanges {
             let captureHeight = max(range.bottom - range.top, 1.0)
             let captureRect = CGRect(
@@ -453,7 +460,7 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
         let paperRect = Self.a4PaperRect
         let printableRect = paperRect.insetBy(dx: 36, dy: 36)
         let textFrameRect = printableRect.insetBy(dx: 0, dy: 14)
-        let pageInfo: [CFString: Any] = [kCGPDFContextMediaBox: paperRect]
+        let pageInfo = Self.pageInfo(for: paperRect)
         var currentRange = CFRange(location: 0, length: 0)
 
         repeat {
@@ -575,7 +582,7 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
             return nil
         }
 
-        let mediaBoxInfo: [CFString: Any] = [kCGPDFContextMediaBox: paperRect]
+        let mediaBoxInfo = Self.pageInfo(for: paperRect)
         for range in pageRanges {
             let sliceBottomY = max(sourceRect.minY, min(sourceRect.maxY, sourceRect.maxY - range.bottom))
             let sliceHeight = max((range.bottom - range.top) * scale, 1.0)
@@ -609,6 +616,8 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
         preferredBlockBottoms: [CGFloat],
         sliceHeight: CGFloat
     ) -> [(top: CGFloat, bottom: CGFloat)] {
+        guard sourceHeight.isFinite, sourceHeight > 0,
+              sliceHeight.isFinite, sliceHeight > 0 else { return [] }
         let sortedBottoms = preferredBlockBottoms
             .filter { $0 > 0 && $0 < sourceHeight }
             .sorted()
@@ -621,7 +630,7 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
             let tentativeBottom = min(pageTop + sliceHeight, sourceHeight)
             let minimumBottom = min(sourceHeight, pageTop + minimumFill)
             let preferredBottom = sortedBottoms.last(where: { $0 >= minimumBottom && $0 <= tentativeBottom }) ?? tentativeBottom
-            let pageBottom = max(preferredBottom, min(tentativeBottom, sourceHeight))
+            let pageBottom = tentativeBottom == sourceHeight ? sourceHeight : preferredBottom
 
             ranges.append((top: pageTop, bottom: pageBottom))
 
@@ -639,6 +648,11 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
     }
 
     // MARK: - Single Page PDF Fallbacks
+
+    private static func pageInfo(for rect: CGRect) -> [CFString: Any] {
+        var rect = rect
+        return [kCGPDFContextMediaBox: Data(bytes: &rect, count: MemoryLayout<CGRect>.size)]
+    }
 
     private func flexibleSinglePagePDFData(from data: Data) -> Data {
         stitchedSinglePagePDFDataIfNeeded(from: data) ?? data
@@ -679,7 +693,7 @@ final class MarkdownPreviewPDFRenderer: NSObject, WKNavigationDelegate {
             return nil
         }
 
-        let pageInfo: [CFString: Any] = [kCGPDFContextMediaBox: outputRect]
+        let pageInfo = Self.pageInfo(for: outputRect)
         context.beginPDFPage(pageInfo as CFDictionary)
 
         var currentTop = outputRect.maxY

--- a/Neon Vision EditorTests/MarkdownPreviewPDFRendererTests.swift
+++ b/Neon Vision EditorTests/MarkdownPreviewPDFRendererTests.swift
@@ -1,10 +1,106 @@
 import XCTest
 import SwiftUI
 import PDFKit
+import WebKit
 @testable import Neon_Vision_Editor
 
 @MainActor
 final class MarkdownPreviewPDFRendererTests: XCTestCase {
+    // Use the production Markdown converter and export CSS without invoking
+    // ContentView's document environment (these fixtures have no local images).
+    private func exportFixtureHTML(_ markdown: String, mode: ContentView.MarkdownPDFExportMode) -> String {
+        let css = ContentView().markdownPreviewCSS(template: "default", preferDarkMode: false, backgroundStyle: .template, translucentBackgroundEnabled: false)
+        let body = ContentView.markdownPreviewBodyHTML(from: markdown, dialect: .gfm, useRenderLimits: false)
+        let onePage = mode == .onePageFit ? " pdf-one-page" : ""
+        return "<!doctype html><html><head><meta charset=\"utf-8\"><style>\(css)</style></head><body class=\"default pdf-export\(onePage)\"><main class=\"content\">\(body)</main></body></html>"
+    }
+    func testPaginationUsesPreferredBlockBottomInsteadOfCuttingThroughNextBlock() {
+        let ranges = MarkdownPreviewPDFRenderer.paginatedSourceRanges(
+            sourceHeight: 2_000, preferredBlockBottoms: [800, 1_600], sliceHeight: 1_000
+        )
+        XCTAssertEqual(ranges.first?.bottom, 800, "The eligible block boundary must win over the fixed slice height.")
+        XCTAssertEqual(ranges.last?.bottom, 2_000)
+        for (previous, next) in zip(ranges, ranges.dropFirst()) {
+            XCTAssertEqual(previous.bottom, next.top)
+        }
+    }
+
+    func testPaginationRejectsInvalidDimensionsAndKeepsFinalBlockOnLastPage() {
+        for height in [CGFloat.zero, -1, .infinity, .nan] {
+            XCTAssertTrue(MarkdownPreviewPDFRenderer.paginatedSourceRanges(sourceHeight: height, preferredBlockBottoms: [], sliceHeight: 100).isEmpty)
+            XCTAssertTrue(MarkdownPreviewPDFRenderer.paginatedSourceRanges(sourceHeight: 100, preferredBlockBottoms: [], sliceHeight: height).isEmpty)
+        }
+        let ranges = MarkdownPreviewPDFRenderer.paginatedSourceRanges(sourceHeight: 900, preferredBlockBottoms: [600, 850], sliceHeight: 1_000)
+        XCTAssertEqual(ranges.count, 1)
+        XCTAssertEqual(ranges.last?.bottom, 900)
+    }
+
+    func testShortPDFDoesNotPadToBlankPages() async throws {
+        for markdown in ["", "# Short document\n\nENDMARKER"] {
+            let data = try await MarkdownPreviewPDFRenderer.render(html: exportFixtureHTML(markdown, mode: .paginatedFit), mode: .paginatedFit)
+            let document = try XCTUnwrap(PDFDocument(data: data))
+            XCTAssertEqual(document.pageCount, 1)
+            if !markdown.isEmpty { XCTAssertTrue(document.string?.contains("ENDMARKER") == true) }
+        }
+    }
+
+    func testExportCodeBlocksFitWithoutHorizontalScrollingOrInteractiveControls() async throws {
+        let markdown = "# Export fixture\n\n```text\n" + String(repeating: "long-token-", count: 30) + "END_OF_LINE\n```"
+        for mode in [ContentView.MarkdownPDFExportMode.paginatedFit, .onePageFit] {
+            let html = exportFixtureHTML(markdown, mode: mode)
+            let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 595, height: 1800))
+            let loaded = expectation(description: "Export HTML loaded")
+            let waiter = PDFExportNavigationWaiter(loaded: loaded)
+            webView.navigationDelegate = waiter
+            webView.loadHTMLString(html, baseURL: nil)
+            await fulfillment(of: [loaded], timeout: 30)
+            defer { webView.navigationDelegate = nil; webView.stopLoading() }
+            let measurements = try await webView.evaluateJavaScript("""
+            (() => {
+              const pre = document.querySelector('pre');
+              const code = pre.querySelector('code');
+              const controls = Array.from(document.querySelectorAll('.code-block-copy, .code-block-language-picker'));
+              return { overflow: Math.max(pre.scrollWidth - pre.clientWidth, code.scrollWidth - code.clientWidth),
+                       visibleControls: controls.filter(node => node.getClientRects().length > 0).length };
+            })()
+            """) as? [String: NSNumber]
+            let values = try XCTUnwrap(measurements)
+            XCTAssertLessThanOrEqual(try XCTUnwrap(values["overflow"]).doubleValue, 1, "PDF code cannot rely on an interactive horizontal scrollbar (\(mode)).")
+            XCTAssertEqual(values["visibleControls"]?.intValue, 0, "Copy buttons and language pickers must not be captured in the PDF (\(mode)).")
+            withExtendedLifetime(waiter) {}
+        }
+    }
+
+    func testExportedPDFContainsLastCodeLineAndNoCopyButton() async throws {
+        let lines = (0..<90).map { "ROW_\($0) " + String(repeating: "sample ", count: 20) + "TAIL_\($0)" }.joined(separator: "\n")
+        let markdown = "# PDF regression\n\n```text\n\(lines)\n```\n\nFINALDOCUMENTMARKER"
+        for mode in [ContentView.MarkdownPDFExportMode.paginatedFit, .onePageFit] {
+            let data = try await MarkdownPreviewPDFRenderer.render(
+                html: exportFixtureHTML(markdown, mode: mode),
+                mode: mode == .paginatedFit ? .paginatedFit : .onePageFit
+            )
+            let attachment = XCTAttachment(data: data, uniformTypeIdentifier: "com.adobe.pdf")
+            attachment.name = "pdf-export-\(mode.rawValue)"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+            let document = try XCTUnwrap(PDFDocument(data: data))
+            let text = document.string ?? ""
+            XCTAssertTrue(text.contains("FINALDOCUMENTMARKER"))
+            XCTAssertTrue(text.contains("TAIL_89"), "The right edge of the final code line must survive export.")
+            XCTAssertFalse(text.contains("Copy"), "Interactive preview buttons do not belong in a PDF.")
+            if mode == .onePageFit {
+                XCTAssertEqual(document.pageCount, 1)
+            } else {
+                XCTAssertGreaterThan(document.pageCount, 1)
+                for index in 0..<document.pageCount {
+                    let page = try XCTUnwrap(document.page(at: index))
+                    XCTAssertFalse((page.string ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, "This flowing-text fixture must not produce blank trailing pages.")
+                    XCTAssertEqual(page.bounds(for: .mediaBox).width, 595, accuracy: 1)
+                    XCTAssertEqual(page.bounds(for: .mediaBox).height, 842, accuracy: 1)
+                }
+            }
+        }
+    }
 #if os(macOS)
     func testDetachedPreviewUsesEditorBackgroundInsteadOfPreviewWhite() {
         let html = "<html><head><style>body { background: white; }</style></head><body><main class=\"content\">Preview</main></body></html>"
@@ -434,5 +530,16 @@ final class MarkdownPreviewPDFRendererTests: XCTestCase {
                 XCTAssertLessThan(html.utf8.count, 150_000)
             }
         }
+    }
+}
+
+@MainActor
+private final class PDFExportNavigationWaiter: NSObject, WKNavigationDelegate {
+    let loaded: XCTestExpectation
+    init(loaded: XCTestExpectation) { self.loaded = loaded }
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { loaded.fulfill() }
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        XCTFail(error.localizedDescription)
+        loaded.fulfill()
     }
 }

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10167&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10240&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>
@@ -180,8 +180,8 @@
 
 <p align="center"><em>Styled line chart shows per-release totals with 14-day traffic counters for clones and views.</em></p>
 <p align="center">
-  <img alt="Unique cloners (14d)" src="https://img.shields.io/static/v1?label=Unique+cloners+%2814d%29&message=236&color=7C3AED&style=for-the-badge">
-  <img alt="Unique visitors (14d)" src="https://img.shields.io/static/v1?label=Unique+visitors+%2814d%29&message=163&color=0EA5E9&style=for-the-badge">
+  <img alt="Unique cloners (14d)" src="https://img.shields.io/static/v1?label=Unique+cloners+%2814d%29&message=277&color=7C3AED&style=for-the-badge">
+  <img alt="Unique visitors (14d)" src="https://img.shields.io/static/v1?label=Unique+visitors+%2814d%29&message=194&color=0EA5E9&style=for-the-badge">
 </p>
 <p align="center">
   <img alt="Clone snapshot (UTC)" src="https://img.shields.io/static/v1?label=Clone+snapshot+%28UTC%29&message=2026-09-06&color=334155&style=flat-square">

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10240&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10258&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>

--- a/docs/images/release-download-trend-dark.svg
+++ b/docs/images/release-download-trend-dark.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-06</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 186 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 204 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 187.5 L 1070.0 203.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 187.5 L 1070.0 192.5 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,187.5 1070.0,203.8"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,187.5 1070.0,192.5"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -71,7 +71,7 @@
   <circle cx="667.1" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="935.7" cy="187.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="203.8" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="192.5" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>

--- a/docs/images/release-download-trend-dark.svg
+++ b/docs/images/release-download-trend-dark.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-06</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 114 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 186 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.1 L 1070.0 248.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 187.5 L 1070.0 203.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.1 1070.0,248.8"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,187.5 1070.0,203.8"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="667.1" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="188.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="248.8" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="187.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="203.8" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
@@ -83,15 +83,15 @@
   <text x="70" y="414" fill="#E6F3FF" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="94" y="462" fill="#C4B5FD" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>
-  <text x="94" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">236</text>
+  <text x="94" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">277</text>
   <text x="190" y="508" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="94" y="526" width="425" height="10" rx="5" fill="#15263A"/>
-  <rect x="94" y="526" width="417.9" height="10" rx="5" fill="url(#cloneFill)"/>
+  <rect x="94" y="526" width="420.4" height="10" rx="5" fill="url(#cloneFill)"/>
   <rect x="595" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="619" y="462" fill="#7DD3FC" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE VISITORS</text>
-  <text x="619" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">163</text>
+  <text x="619" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">194</text>
   <text x="715" y="508" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="619" y="526" width="425" height="10" rx="5" fill="#15263A"/>
-  <rect x="619" y="526" width="288.6" height="10" rx="5" fill="url(#viewFill)"/>
-  <text x="70" y="582" fill="#9CC3E6" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Shared scale: 0–240 events</text>
+  <rect x="619" y="526" width="294.5" height="10" rx="5" fill="url(#viewFill)"/>
+  <text x="70" y="582" fill="#9CC3E6" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Shared scale: 0–280 events</text>
 </svg>

--- a/docs/images/release-download-trend-light.svg
+++ b/docs/images/release-download-trend-light.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-06</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="884" y="70" fill="#475569" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 186 downloads</text>
+  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 204 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#94A3B8" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#CBD5E1" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 187.5 L 1070.0 203.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 187.5 L 1070.0 192.5 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,187.5 1070.0,203.8"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,187.5 1070.0,192.5"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -71,7 +71,7 @@
   <circle cx="667.1" cy="132.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="801.4" cy="216.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="935.7" cy="187.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="1070.0" cy="203.8" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="1070.0" cy="192.5" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>

--- a/docs/images/release-download-trend-light.svg
+++ b/docs/images/release-download-trend-light.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#475569" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-06</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="884" y="70" fill="#475569" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 114 downloads</text>
+  <text x="884" y="92" fill="#0F172A" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 186 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#94A3B8" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#CBD5E1" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#475569" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.1 L 1070.0 248.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 187.5 L 1070.0 203.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.1 1070.0,248.8"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,187.5 1070.0,203.8"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="266.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="667.1" cy="132.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
   <circle cx="801.4" cy="216.9" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="935.7" cy="188.1" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
-  <circle cx="1070.0" cy="248.8" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="935.7" cy="187.5" r="5" fill="#0EA5E9" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="1070.0" cy="203.8" r="8" fill="#16A34A" stroke="#FFFFFF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#334155" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
@@ -83,15 +83,15 @@
   <text x="70" y="414" fill="#0F172A" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="94" y="462" fill="#6D28D9" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>
-  <text x="94" y="508" fill="#0F172A" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">236</text>
+  <text x="94" y="508" fill="#0F172A" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">277</text>
   <text x="190" y="508" fill="#64748B" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="94" y="526" width="425" height="10" rx="5" fill="#E2E8F0"/>
-  <rect x="94" y="526" width="417.9" height="10" rx="5" fill="url(#cloneFill)"/>
+  <rect x="94" y="526" width="420.4" height="10" rx="5" fill="url(#cloneFill)"/>
   <rect x="595" y="432" width="505" height="124" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
   <text x="619" y="462" fill="#0369A1" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE VISITORS</text>
-  <text x="619" y="508" fill="#0F172A" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">163</text>
+  <text x="619" y="508" fill="#0F172A" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">194</text>
   <text x="715" y="508" fill="#64748B" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="619" y="526" width="425" height="10" rx="5" fill="#E2E8F0"/>
-  <rect x="619" y="526" width="288.6" height="10" rx="5" fill="url(#viewFill)"/>
-  <text x="70" y="582" fill="#64748B" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Shared scale: 0–240 events</text>
+  <rect x="619" y="526" width="294.5" height="10" rx="5" fill="url(#viewFill)"/>
+  <text x="70" y="582" fill="#64748B" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Shared scale: 0–280 events</text>
 </svg>

--- a/docs/images/release-download-trend.svg
+++ b/docs/images/release-download-trend.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-06</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 186 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 204 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 187.5 L 1070.0 203.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 187.5 L 1070.0 192.5 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,187.5 1070.0,203.8"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,187.5 1070.0,192.5"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -71,7 +71,7 @@
   <circle cx="667.1" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="935.7" cy="187.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="203.8" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="192.5" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>

--- a/docs/images/release-download-trend.svg
+++ b/docs/images/release-download-trend.svg
@@ -39,7 +39,7 @@
   <text x="70" y="96" fill="#9CC3E6" font-size="16" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Prior releases: 50+ downloads · latest release: 20+ · updated 2026-09-06</text>
   <rect x="862" y="46" width="268" height="58" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="884" y="70" fill="#9CC3E6" font-size="12" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">LATEST DISPLAYED RELEASE</text>
-  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 114 downloads</text>
+  <text x="884" y="92" fill="#E6F3FF" font-size="17" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">v1.6.2 · 186 downloads</text>
 
   <line x1="130" y1="320.0" x2="1070" y2="320.0" stroke="#37566F" stroke-width="1"/>
   <line x1="130" y1="270.0" x2="1070" y2="270.0" stroke="#2B4255" stroke-width="1"/>
@@ -52,10 +52,10 @@
   <text x="58" y="176.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">240</text>
   <text x="58" y="126.0" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">320</text>
 
-  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 188.1 L 1070.0 248.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
+  <path d="M 130.0 237.5 L 264.3 122.5 L 398.6 212.5 L 532.9 266.9 L 667.1 132.5 L 801.4 216.9 L 935.7 187.5 L 1070.0 203.8 L 1070 320 L 130 320 Z" fill="url(#area)"/>
 
   <polyline
-    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,188.1 1070.0,248.8"
+    points="130.0,237.5 264.3,122.5 398.6,212.5 532.9,266.9 667.1,132.5 801.4,216.9 935.7,187.5 1070.0,203.8"
     fill="none"
     stroke="url(#line)"
     stroke-width="5"
@@ -70,8 +70,8 @@
   <circle cx="532.9" cy="266.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="667.1" cy="132.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
   <circle cx="801.4" cy="216.9" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="935.7" cy="188.1" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
-  <circle cx="1070.0" cy="248.8" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="935.7" cy="187.5" r="5" fill="#00E2B8" stroke="#D7F7FF" stroke-width="2"/>
+  <circle cx="1070.0" cy="203.8" r="8" fill="#8CFF5A" stroke="#D7F7FF" stroke-width="2"/>
   <text x="130.0" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.1</text>
   <text x="264.3" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.2</text>
   <text x="398.6" y="352" text-anchor="middle" fill="#D7E8F8" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">v1.5.4</text>
@@ -83,15 +83,15 @@
   <text x="70" y="414" fill="#E6F3FF" font-size="18" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">Repository traffic · last 14 days</text>
   <rect x="70" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="94" y="462" fill="#C4B5FD" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE CLONERS</text>
-  <text x="94" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">236</text>
+  <text x="94" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">277</text>
   <text x="190" y="508" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="94" y="526" width="425" height="10" rx="5" fill="#15263A"/>
-  <rect x="94" y="526" width="417.9" height="10" rx="5" fill="url(#cloneFill)"/>
+  <rect x="94" y="526" width="420.4" height="10" rx="5" fill="url(#cloneFill)"/>
   <rect x="595" y="432" width="505" height="124" rx="14" fill="#0A1A2B" stroke="#2A4762" stroke-width="1"/>
   <text x="619" y="462" fill="#7DD3FC" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">UNIQUE VISITORS</text>
-  <text x="619" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">163</text>
+  <text x="619" y="508" fill="#E6F3FF" font-size="38" font-family="SF Pro Display, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-weight="700">194</text>
   <text x="715" y="508" fill="#9CC3E6" font-size="14" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">events</text>
   <rect x="619" y="526" width="425" height="10" rx="5" fill="#15263A"/>
-  <rect x="619" y="526" width="288.6" height="10" rx="5" fill="url(#viewFill)"/>
-  <text x="70" y="582" fill="#9CC3E6" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Shared scale: 0–240 events</text>
+  <rect x="619" y="526" width="294.5" height="10" rx="5" fill="url(#viewFill)"/>
+  <text x="70" y="582" fill="#9CC3E6" font-size="13" font-family="SF Pro Text, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">Shared scale: 0–280 events</text>
 </svg>


### PR DESCRIPTION
## Summary
- Wrap long code lines and omit interactive controls from Markdown PDF exports.
- Correct A4 media boxes, honor page boundaries, and remove blank trailing pages.
- Add regression tests and sync the latest main documentation updates.

## Verification
- 30 iOS and 33 macOS PDF tests passed.
- Original simulator document passed both export modes; all five A4 pages visually inspected.
- macOS, iOS Simulator, iPad Simulator, and visionOS build matrix passed.
- Generated personal-document PDFs are excluded from this PR.
- No release or macOS 27 changes included.

## Summary by Sourcery

Improve Markdown PDF export reliability and synchronize the latest documentation metrics.

Bug Fixes:
- Fix Markdown PDF exports so long code lines wrap, interactive controls are excluded, A4 media dimensions are preserved, and pagination avoids clipped content and blank trailing pages.

Documentation:
- Synchronize README download metrics and release trend documentation assets.

Tests:
- Add regression coverage for PDF pagination boundaries, short-document page counts, wrapped code exports, retained final code lines, omitted controls, and A4 page dimensions.