### PR TITLE
Fix hosted release archive signing

### DIFF
--- a/.github/workflows/release-github-only.yml
+++ b/.github/workflows/release-github-only.yml
@@ -279,6 +279,8 @@ jobs:
             -destination "generic/platform=macOS" \
             -archivePath "$ARCHIVE_PATH" \
             DEVELOPMENT_TEAM="$TEAM_ID" \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            CODE_SIGN_STYLE=Manual \
             archive
 
       - name: Export app


### PR DESCRIPTION
The hosted runner installs a Developer ID certificate, while the Quick Look target defaults to development signing for local builds. Pass explicit Developer ID signing settings to the hosted archive command.

## Summary by Sourcery

Use explicit Developer ID signing when creating hosted macOS release archives.

Bug Fixes:
- Configure hosted macOS release archives to use explicit Developer ID application signing instead of the Quick Look target’s development-signing default.

CI:
- Update the GitHub Actions release workflow with manual Developer ID signing settings for archive creation.