### PR TITLE
Fix hosted release archive signing

### DIFF
--- a/.github/workflows/release-github-only.yml
+++ b/.github/workflows/release-github-only.yml
@@ -279,6 +279,8 @@ jobs:
             -destination "generic/platform=macOS" \
             -archivePath "$ARCHIVE_PATH" \
             DEVELOPMENT_TEAM="$TEAM_ID" \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            CODE_SIGN_STYLE=Manual \
             archive
 
       - name: Export app


### PR DESCRIPTION
Pass explicit Developer ID signing settings to the GitHub-hosted archive so the Quick Look extension uses the installed distribution certificate.

## Summary by Sourcery

Use explicit Developer ID signing settings when creating hosted macOS release archives.

Bug Fixes:
- Ensure hosted macOS release archives use the installed Developer ID Application certificate, including for the Quick Look extension.

Build:
- Configure hosted release archiving with explicit manual Developer ID code-signing settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build and Release**
  - Updated GitHub-hosted release builds to use the Developer ID Application signing identity with manual code-signing configuration.
  - Release archives are now configured for the intended macOS distribution signing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->