### PR TITLE
Skip pre-release CI for appcast-only updates

### DIFF
--- a/.github/workflows/pre-release-ci.yml
+++ b/.github/workflows/pre-release-ci.yml
@@ -9,6 +9,8 @@ on:
       - "README.md"
       - "CHANGELOG.md"
       - "docs/**"
+      - "appcast.xml"
+      - "site/appcast.xml"
 
 permissions:
   contents: read


### PR DESCRIPTION
Appcast publication PRs contain only generated XML. Exclude those files from the general pre-release CI workflow to avoid empty or workflow-file failures after release publication.

## Summary by Sourcery

Skip pre-release CI when changes are limited to generated appcast files.

Bug Fixes:
- Prevent the general pre-release CI workflow from running for appcast-only publication updates.

CI:
- Exclude generated appcast files from pre-release CI triggers.