### PR TITLE
Skip pre-release CI for appcast-only updates

### DIFF
--- a/.github/workflows/pre-release-ci.yml
+++ b/.github/workflows/pre-release-ci.yml
@@ -9,6 +9,8 @@ on:
       - "README.md"
       - "CHANGELOG.md"
       - "docs/**"
+      - "appcast.xml"
+      - "site/appcast.xml"
 
 permissions:
   contents: read


### PR DESCRIPTION
Prevent generated appcast-only publication PRs from entering the general pre-release CI workflow.

## Summary by Sourcery

Skip the general pre-release CI workflow for appcast-only publication updates.

Enhancements:
- Exclude appcast-only changes from the general pre-release CI workflow.

CI:
- Update pre-release CI path filters to recognize appcast files as excluded-only changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-release validation workflows to ignore appcast file changes in pull-request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->