### PR TITLE
Clean up architecture diagram rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,10 +454,11 @@ Platform-specific availability is tracked in the [Platform Matrix](#platform-mat
 
 ## Architecture At A Glance
 
-The current stable editor separates scene presentation, document ownership, native rendering, and optional services. The diagram is also available as a [scalable SVG](docs/images/architecture-at-a-glance.svg); Mermaid remains below as an accessible, editable source. Arrows show ownership or data exchange; they are not a claim that every operation runs on a background thread.
+The current stable editor separates scene presentation, document ownership, native rendering, and optional services. The [scalable SVG](docs/images/architecture-at-a-glance.svg) is the canonical rendered diagram; its Mermaid source is retained in a non-rendered comment for accessible editing. Arrows show ownership or data exchange; they are not a claim that every operation runs on a background thread.
 
 ![Neon Vision Editor architecture at a glance](docs/images/architecture-at-a-glance.svg)
 
+<!--
 ```mermaid
 flowchart TB
   subgraph PLATFORM[Platform and scene presentation]
@@ -522,6 +523,7 @@ flowchart TB
   class INFRA infra;
   class POLICY,DIRECT,STORE distribution;
 ```
+-->
 
 - **Ownership:** `ContentView` owns scene presentation; each window has an `@MainActor` `EditorViewModel`. `TabCommandQueue` serializes asynchronous tab mutations, while `TabData` keeps UI identity, document resource identity, and content revisions distinct.
 - **Storage:** `EditorDocument` is the bounded read/edit contract, not the load/save controller. `TabData` currently uses `FileBackedTextDocument` for both URL-backed files and content initialized in memory. Eligible large local files retain disk source ranges plus replacement pieces; the loader completes their line index before transferring ownership to the main actor. Saves preserve encoding and line endings and use the existing conflict and atomic-replacement flow.

--- a/docs/images/architecture-at-a-glance.svg
+++ b/docs/images/architecture-at-a-glance.svg
@@ -6,6 +6,10 @@
     <style>.bg{fill:#0d1117}.group{fill:#161d27;stroke:#334155;stroke-width:2}.title{fill:#f8fafc;font:700 26px -apple-system,BlinkMacSystemFont,"SF Pro Display",sans-serif}.label{fill:#cbd5e1;font:600 14px -apple-system,BlinkMacSystemFont,"SF Pro Text",sans-serif}.body{fill:#e2e8f0;font:14px -apple-system,BlinkMacSystemFont,"SF Pro Text",sans-serif}.small{fill:#94a3b8;font:12px -apple-system,BlinkMacSystemFont,"SF Pro Text",sans-serif}.box{rx:10;stroke-width:2}.platform{fill:#172554;stroke:#3b82f6}.app{fill:#052e2b;stroke:#10b981}.core{fill:#431407;stroke:#f97316}.infra{fill:#2e1065;stroke:#a855f7}.dist{fill:#500724;stroke:#ec4899}.edge{stroke:#94a3b8;stroke-width:2;fill:none;marker-end:url(#arrow)}</style>
   </defs>
   <rect class="bg" width="1400" height="900"/>
+  <!-- Connectors are painted first so cards remain legible above them. -->
+  <g>
+    <path class="edge" d="M300 203 H650"/><path class="edge" d="M595 203 H650"/><path class="edge" d="M800 242 V376 H320"/><path class="edge" d="M800 242 V376 H730"/><path class="edge" d="M320 415 H350"/><path class="edge" d="M195 454 V478"/><path class="edge" d="M475 454 V478"/><path class="edge" d="M600 510 H730"/><path class="edge" d="M1010 415 H1040"/><path class="edge" d="M800 242 V666 H310"/><path class="edge" d="M800 242 V666 H630"/><path class="edge" d="M1155 242 V666 H1190"/>
+  </g>
   <text class="title" x="56" y="58">Neon Vision Editor — Architecture At A Glance</text>
   <text class="small" x="56" y="84">Stable v1.6.3 · arrows show ownership or data exchange, not thread guarantees</text>
   <rect class="group" x="40" y="110" width="1320" height="170" rx="14"/><text class="label" x="64" y="138">PLATFORM AND SCENE PRESENTATION</text>
@@ -29,6 +33,5 @@
   <rect class="box infra" x="630" y="666" width="240" height="72"/><text class="body" x="750" y="694" text-anchor="middle">AI Chat and providers</text><text class="small" x="750" y="716" text-anchor="middle">explicit context · Keychain</text>
   <rect class="box infra" x="910" y="666" width="240" height="72"/><text class="body" x="1030" y="694" text-anchor="middle">Recovery and annotations</text><text class="small" x="1030" y="716" text-anchor="middle">drafts · PDF notes · preferences</text>
   <rect class="box dist" x="1190" y="666" width="130" height="72"/><text class="body" x="1255" y="694" text-anchor="middle">Distribution</text><text class="small" x="1255" y="716" text-anchor="middle">App Store / Sparkle</text>
-  <path class="edge" d="M300 203 H650"/><path class="edge" d="M595 203 H650"/><path class="edge" d="M800 242 V376 H320"/><path class="edge" d="M800 242 V376 H730"/><path class="edge" d="M320 415 H350"/><path class="edge" d="M195 454 V478"/><path class="edge" d="M475 454 V478"/><path class="edge" d="M600 510 H730"/><path class="edge" d="M1010 415 H1040"/><path class="edge" d="M800 242 V666 H310"/><path class="edge" d="M800 242 V666 H630"/><path class="edge" d="M1155 242 V666 H1190"/>
   <text class="small" x="64" y="862">Fast tab activation: select → bind existing bounded viewport → draw first frame; layout, preview, indexing, and metadata work are cancellable and deferred.</text>
 </svg>


### PR DESCRIPTION
## Summary
- remove the duplicate rendered Mermaid diagram from the README
- keep the Mermaid source non-rendered for editing/accessibility
- draw SVG connectors behind cards so labels remain unobstructed

## Verification
- xmllint --noout docs/images/architecture-at-a-glance.svg
- git diff --check

Documentation-only change.

## Summary by Sourcery

Clean up the architecture diagram presentation and source in the README.

Enhancements:
- Make the SVG the canonical rendered architecture diagram while retaining Mermaid source in a non-rendered README comment for accessibility and editing.
- Adjust architecture diagram connector layering so card labels remain unobstructed.

Documentation:
- Remove the duplicate rendered Mermaid diagram from the README.