### PR TITLE
Fix architecture diagram README rendering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@ Last updated: 2026-09-07 (v1.6.3 release-aligned architecture)
 
 Neon Vision Editor is a native Swift 6 editor for macOS, iOS, iPadOS, and visionOS. The app favors a small editor-first surface: fast file access, lightweight project navigation, native text editing, syntax highlighting, structured document inspection, Markdown/HTML/SVG/PDF/PNG preview, project-level Markdown/PDF cards, Finder Quick Look previews, PDF highlights and attached Markdown notes, Git and terminal helpers on macOS, remote-session clients on supported Apple platforms, and optional contextual AI assistance.
 
-The visual summary in [`docs/images/architecture-at-a-glance.svg`](docs/images/architecture-at-a-glance.svg) is the stable architecture snapshot for the README and release documentation. The Mermaid block in `README.md` is its accessible, editable companion; update both when ownership boundaries or platform services change.
+The visual summary in [`docs/images/architecture-at-a-glance.svg`](docs/images/architecture-at-a-glance.svg) is the stable architecture snapshot for the README and release documentation. Its editable Mermaid source is [`docs/images/architecture-at-a-glance.mmd`](docs/images/architecture-at-a-glance.mmd); update both when ownership boundaries or platform services change.
 
 <!-- RELEASE_ARCHITECTURE_ALIGNMENT:START -->
 ## Current Release Alignment

--- a/README.md
+++ b/README.md
@@ -454,11 +454,11 @@ Platform-specific availability is tracked in the [Platform Matrix](#platform-mat
 
 ## Architecture At A Glance
 
-The current stable editor separates scene presentation, document ownership, native rendering, and optional services. The [scalable SVG](docs/images/architecture-at-a-glance.svg) is the canonical rendered diagram; its Mermaid source is retained in a non-rendered comment for accessible editing. Arrows show ownership or data exchange; they are not a claim that every operation runs on a background thread.
+The current stable editor separates scene presentation, document ownership, native rendering, and optional services. The [scalable SVG](docs/images/architecture-at-a-glance.svg) is the canonical rendered diagram. The editable [Mermaid source](docs/images/architecture-at-a-glance.mmd) is kept beside it; arrows show ownership or data exchange, not thread guarantees.
 
 ![Neon Vision Editor architecture at a glance](docs/images/architecture-at-a-glance.svg)
 
-<!--
+<details hidden>
 ```mermaid
 flowchart TB
   subgraph PLATFORM[Platform and scene presentation]
@@ -523,7 +523,7 @@ flowchart TB
   class INFRA infra;
   class POLICY,DIRECT,STORE distribution;
 ```
--->
+</details>
 
 - **Ownership:** `ContentView` owns scene presentation; each window has an `@MainActor` `EditorViewModel`. `TabCommandQueue` serializes asynchronous tab mutations, while `TabData` keeps UI identity, document resource identity, and content revisions distinct.
 - **Storage:** `EditorDocument` is the bounded read/edit contract, not the load/save controller. `TabData` currently uses `FileBackedTextDocument` for both URL-backed files and content initialized in memory. Eligible large local files retain disk source ranges plus replacement pieces; the loader completes their line index before transferring ownership to the main actor. Saves preserve encoding and line endings and use the existing conflict and atomic-replacement flow.

--- a/docs/images/architecture-at-a-glance.mmd
+++ b/docs/images/architecture-at-a-glance.mmd
@@ -1,0 +1,14 @@
+flowchart TB
+  MAC["macOS SwiftUI + AppKit"] --> SCENE["ContentView: panes, focus, selection"]
+  TOUCH["iPhone / iPad / visionOS"] --> SCENE
+  SCENE --> VM["EditorViewModel"] --> TABS["TabCommandQueue + TabData"] --> DOC["EditorDocument"] --> STORAGE["FileBackedTextDocument"]
+  TABS --> EDITOR["Native editors: Core Text / UITextView"]
+  TABS --> FAST["Fast activation: bind viewport, draw first frame, defer work"]
+  EDITOR --> SERVICES["Syntax, Emmet, completion"]
+  SCENE --> PREVIEW["Markdown / HTML / SVG / PDF preview and export"]
+  OBS["NSFilePresenter + metadata polling"] --> VM
+  SCENE --> SEARCH["Project index and search (.gitignore)"]
+  SCENE --> AI["AI chat and providers (explicit context)"]
+  VM <--> REMOTE["Remote sessions"]
+  VM --> RECOVERY["Recovery, Keychain, PDF annotations"]
+  SCENE --> POLICY["ReleaseRuntimePolicy"] --> DIST["App Store / direct macOS distribution"]


### PR DESCRIPTION
## Summary
- remove the old inline Mermaid rendering from the visible README
- keep the editable Mermaid source in docs/images/architecture-at-a-glance.mmd
- retain the SVG as the only visible architecture-at-a-glance diagram
- preserve SVG connectors behind cards

## Verification
- xmllint --noout docs/images/architecture-at-a-glance.svg
- git diff --check

Documentation-only change.

## Summary by Sourcery

Align the architecture documentation with the canonical SVG diagram and separately maintained Mermaid source.

Enhancements:
- Use the architecture SVG as the sole visible README diagram while keeping its Mermaid source as a linked editable file.

Documentation:
- Update architecture documentation to reference the standalone Mermaid source and preserve the SVG diagram’s connector layering.