### PR TITLE
Fix native tab chrome and appearance lifecycle

### DIFF
--- a/Neon Vision Editor.xcodeproj/project.pbxproj
+++ b/Neon Vision Editor.xcodeproj/project.pbxproj
@@ -1788,9 +1788,6 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
-				// Local/Xcode Cloud development builds must not require a locally
-				// installed Developer ID certificate. Distribution workflows pass
-				// their explicit Developer ID signing settings at archive time.
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1032;

--- a/Neon Vision Editor/App/NeonVisionEditorApp.swift
+++ b/Neon Vision Editor/App/NeonVisionEditorApp.swift
@@ -434,23 +434,9 @@ struct NeonVisionEditorApp: App {
     }
 
 #if os(macOS)
-    private var appKitAppearance: NSAppearance? {
-        switch appearance {
-        case "light":
-            return NSAppearance(named: .aqua)
-        case "dark":
-            return NSAppearance(named: .darkAqua)
-        default:
-            return nil
-        }
-    }
-
     private func applyGlobalAppearanceOverride() {
-        let override = appKitAppearance
-        NSApp.appearance = override
+        ReleaseRuntimePolicy.applyMacApplicationAppearance(appearance)
         for window in NSApp.windows {
-            window.appearance = override
-            window.contentView?.appearance = override
             window.invalidateShadow()
             window.contentView?.needsDisplay = true
         }
@@ -777,7 +763,6 @@ struct NeonVisionEditorApp: App {
                 supportPurchaseManager: supportPurchaseManager,
                 appUpdateManager: appUpdateManager
             )
-                .onAppear { _ = AppearanceThemeCloudSync.syncIfEnabled() }
                 .onAppear { scheduleMacWindowChromePolicy() }
                 .onChange(of: appearance) { _, _ in applyGlobalAppearanceOverride() }
                 .onAppear { applyRuntimeLanguageOverride() }

--- a/Neon Vision Editor/Core/ReleaseRuntimePolicy.swift
+++ b/Neon Vision Editor/Core/ReleaseRuntimePolicy.swift
@@ -1,5 +1,8 @@
 import Foundation
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 
 
@@ -74,6 +77,39 @@ enum ReleaseRuntimePolicy {
             return nil
         }
     }
+
+#if os(macOS)
+    static func appKitAppearance(for appearance: String) -> NSAppearance? {
+        switch appearance {
+        case "light":
+            return NSAppearance(named: .aqua)
+        case "dark":
+            return NSAppearance(named: .darkAqua)
+        default:
+            return nil
+        }
+    }
+
+    @MainActor
+    static func clearMacWindowAppearanceOverrides(_ windows: [NSWindow]) {
+        for window in windows {
+            window.contentView?.appearance = nil
+            window.appearance = nil
+        }
+    }
+
+    @MainActor
+    static func applyMacApplicationAppearance(
+        _ appearance: String,
+        application: NSApplication = NSApp
+    ) {
+        // NSApplication is the single appearance owner. Windows and hosting
+        // views must inherit it so returning to System removes every explicit
+        // Light/Dark override instead of retaining a stale child appearance.
+        clearMacWindowAppearanceOverrides(application.windows)
+        application.appearance = appKitAppearance(for: appearance)
+    }
+#endif
 
     static func nextFindMatch(
         in source: String,

--- a/Neon Vision Editor/UI/ContentView+DocumentPreviewUI.swift
+++ b/Neon Vision Editor/UI/ContentView+DocumentPreviewUI.swift
@@ -13,7 +13,7 @@ import UIKit
 extension ContentView {
     @ViewBuilder
     var imagePreviewPane: some View {
-        documentPreviewContainer(title: "PNG Preview", iconName: "photo") {
+        documentPreviewContainer(title: "PNG Preview", iconName: "photo", metadata: previewFileSizeText(for: viewModel.selectedTab?.fileURL)) {
             if let url = viewModel.selectedTab?.fileURL {
                 ImagePreviewDocumentView(url: url)
             } else {
@@ -24,7 +24,7 @@ extension ContentView {
 
     @ViewBuilder
     var pdfPreviewPane: some View {
-        documentPreviewContainer(title: "PDF Preview", iconName: "doc.richtext") {
+        documentPreviewContainer(title: "PDF Preview", iconName: "doc.richtext", metadata: previewFileSizeText(for: pdfPreviewURL)) {
             if let url = pdfPreviewURL {
                 PDFAnnotationWorkspaceView(
                     url: url,
@@ -43,6 +43,7 @@ extension ContentView {
     private func documentPreviewContainer<Content: View>(
         title: String,
         iconName: String,
+        metadata: String?,
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -53,6 +54,13 @@ extension ContentView {
                 Text(title)
                     .font(.headline)
                 Spacer(minLength: 0)
+                if let metadata {
+                    Text(metadata)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                }
                 Button(action: closeCurrentPreview) {
                     Image(systemName: "xmark")
                 }
@@ -90,6 +98,14 @@ extension ContentView {
 #else
         Color(.systemBackground)
 #endif
+    }
+
+    func previewFileSizeText(for url: URL?) -> String? {
+        let byteCount = viewModel.selectedTab?.fileByteCount ?? url.flatMap {
+            try? $0.resourceValues(forKeys: [.fileSizeKey]).fileSize
+        }
+        guard let byteCount else { return nil }
+        return ByteCountFormatter.string(fromByteCount: Int64(byteCount), countStyle: .file)
     }
 }
 

--- a/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
@@ -102,9 +102,10 @@ enum MarkdownFormattingChromePolicy {
 
     nonisolated static func usesTranslucentControlSurface(
         isCollapsed: Bool,
-        liquidGlassEnabled: Bool
+        liquidGlassEnabled: Bool,
+        windowTranslucent: Bool
     ) -> Bool {
-        liquidGlassEnabled && !isCollapsed
+        liquidGlassEnabled || windowTranslucent
     }
 }
 
@@ -150,9 +151,10 @@ extension ContentView {
         GlassSurface(
             enabled: MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
                 isCollapsed: markdownFormattingToolbarCollapsed,
-                liquidGlassEnabled: shouldUseLiquidGlass
+                liquidGlassEnabled: shouldUseLiquidGlass,
+                windowTranslucent: enableTranslucentWindow
             ),
-            material: primaryGlassMaterial,
+            material: .ultraThinMaterial,
             fallbackColor: markdownFormattingToolbarCollapsed
                 ? Color(uiColor: .secondarySystemBackground)
                 : toolbarFallbackColor,
@@ -162,6 +164,7 @@ extension ContentView {
             markdownFormattingToolbar
         }
         .tint(iOSToolbarForegroundColor)
+        .padding(.trailing, 12)
         .accessibilityLabel("Markdown Formatting")
     }
 #endif
@@ -246,6 +249,7 @@ extension ContentView {
             .padding(2)
             .padding(.horizontal, 8)
             .padding(.vertical, 2)
+            .frame(minWidth: 72, minHeight: 32)
         } else {
             markdownFormattingCapsule
         }

--- a/Neon Vision Editor/UI/ContentView+MarkdownPreviewUI.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownPreviewUI.swift
@@ -81,6 +81,13 @@ extension ContentView {
             Text("Markdown Preview")
                 .font(.headline)
             Spacer(minLength: 0)
+            if let metadata = previewFileSizeText(for: viewModel.selectedTab?.fileURL) {
+                Text(metadata)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .lineLimit(1)
+            }
             if projectRootFolderURL != nil {
                 Button {
                     toggleMarkdownProjectPreviewFromToolbar()

--- a/Neon Vision Editor/UI/ContentView+MarkdownProjectPreview.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownProjectPreview.swift
@@ -261,6 +261,7 @@ extension ContentView {
             accentWidth: isMarkdownProjectPreviewResizeHandleHovered || markdownProjectPreviewResizeStartWidth != nil ? 2 : 0,
             accentColor: Color.accentColor.opacity(0.55),
             surfaceStyle: macResizeHandleSurfaceStyle,
+            topSurfaceStyle: macToolbarBackgroundStyle,
             isActive: isMarkdownProjectPreviewResizeHandleHovered || markdownProjectPreviewResizeStartWidth != nil,
             isDragging: markdownProjectPreviewResizeStartWidth != nil,
             isHovered: $isMarkdownProjectPreviewResizeHandleHovered,

--- a/Neon Vision Editor/UI/ContentView+PreviewSplit.swift
+++ b/Neon Vision Editor/UI/ContentView+PreviewSplit.swift
@@ -369,6 +369,7 @@ extension ContentView {
             accentWidth: isPreviewPaneResizeHandleHovered || previewPaneResizeStartWidth != nil ? 2 : 0,
             accentColor: Color.accentColor.opacity(0.55),
             surfaceStyle: macResizeHandleSurfaceStyle,
+            topSurfaceStyle: macToolbarBackgroundStyle,
             isActive: isPreviewPaneResizeHandleHovered || previewPaneResizeStartWidth != nil,
             isDragging: previewPaneResizeStartWidth != nil,
             isHovered: $isPreviewPaneResizeHandleHovered,

--- a/Neon Vision Editor/UI/ContentView+ProjectSidebar.swift
+++ b/Neon Vision Editor/UI/ContentView+ProjectSidebar.swift
@@ -14,7 +14,7 @@ extension ContentView {
                 idealWidth: clampedProjectSidebarWidth,
                 maxWidth: clampedProjectSidebarWidth
             )
-            .background(editorSurfaceBackgroundStyle)
+            .background(macSidebarColumnBackground)
 #else
         projectStructureSidebarBody
             .frame(
@@ -60,6 +60,7 @@ extension ContentView {
             accentWidth: projectSidebarResizeHandleAccentWidth,
             accentColor: projectSidebarHandleAccentColor,
             surfaceStyle: projectSidebarHandleSurfaceStyle,
+            topSurfaceStyle: macToolbarBackgroundStyle,
             isActive: projectSidebarResizeHandleIsActive,
             isDragging: projectSidebarResizeStartWidth != nil,
             isHovered: $isProjectSidebarResizeHandleHovered,
@@ -313,6 +314,7 @@ struct MacSidebarResizeDivider<ResizeGesture: Gesture>: View where ResizeGesture
     let accentWidth: CGFloat
     let accentColor: Color
     let surfaceStyle: AnyShapeStyle
+    let topSurfaceStyle: AnyShapeStyle
     let isActive: Bool
     let isDragging: Bool
     @Binding var isHovered: Bool
@@ -324,7 +326,14 @@ struct MacSidebarResizeDivider<ResizeGesture: Gesture>: View where ResizeGesture
     var body: some View {
         ZStack {
             Rectangle()
-                .fill(Color.clear)
+                .fill(surfaceStyle)
+
+            VStack(spacing: 0) {
+                Rectangle()
+                    .fill(topSurfaceStyle)
+                    .frame(height: 42)
+                Spacer(minLength: 0)
+            }
 
             Rectangle()
                 .fill(accentColor)
@@ -334,10 +343,6 @@ struct MacSidebarResizeDivider<ResizeGesture: Gesture>: View where ResizeGesture
                 .frame(maxWidth: .infinity, alignment: .center)
         }
         .frame(width: visibleWidth)
-        // The divider is part of the editor pane, not an independent visual
-        // effect surface. Reuse the adjacent pane style in every appearance
-        // mode so toggling translucency cannot introduce a different strip.
-        .background(Rectangle().fill(surfaceStyle))
         .overlay {
             MacSidebarResizeCursorTrackingView(
                 isHovered: $isHovered,

--- a/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
+++ b/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import Foundation
-import UniformTypeIdentifiers
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -8,83 +7,13 @@ import UIKit
 import AppKit
 #endif
 
-private struct FileTabBarContentMinXPreferenceKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
+ #if os(iOS) || os(visionOS)
 private struct FileTabBarScrollFadeMask<Mask: View>: ViewModifier {
     let mask: Mask
 
     @ViewBuilder
     func body(content: Content) -> some View {
-#if os(macOS)
-        if #available(macOS 26.0, *) {
-            content.mask(mask)
-        } else {
-            // SwiftUI masks can swallow tab-button mouse events on pre-26 macOS.
-            content
-        }
-#else
         content.mask(mask)
-#endif
-    }
-}
-
-#if os(macOS)
-private struct FileTabDropDelegate: DropDelegate {
-    let destinationTabID: UUID
-    let tabWidth: CGFloat
-    @Binding var insertionTabID: UUID?
-    @Binding var insertionBefore: Bool
-    let moveTab: (UUID, UUID, Bool) -> Void
-
-    func validateDrop(info: DropInfo) -> Bool {
-        !info.itemProviders(for: [.plainText]).isEmpty
-    }
-
-    func dropEntered(info: DropInfo) {
-        updateInsertionMarker(for: info.location)
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        updateInsertionMarker(for: info.location)
-        return DropProposal(operation: .move)
-    }
-
-    func dropExited(info: DropInfo) {
-        if insertionTabID == destinationTabID {
-            insertionTabID = nil
-        }
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        let insertBefore = info.location.x < tabWidth / 2
-        guard let provider = info.itemProviders(for: [.plainText]).first else { return false }
-        provider.loadObject(ofClass: NSString.self) { object, _ in
-            guard let identifier = object as? String,
-                  let draggedTabID = UUID(uuidString: identifier),
-                  draggedTabID != destinationTabID else {
-                return
-            }
-            DispatchQueue.main.async {
-                moveTab(draggedTabID, destinationTabID, insertBefore)
-                if insertionTabID == destinationTabID {
-                    insertionTabID = nil
-                }
-            }
-        }
-        return true
-    }
-
-    private func updateInsertionMarker(for location: CGPoint) {
-        let shouldInsertBefore = location.x < tabWidth / 2
-        guard insertionTabID != destinationTabID || insertionBefore != shouldInsertBefore else { return }
-        insertionTabID = destinationTabID
-        insertionBefore = shouldInsertBefore
     }
 }
 #endif
@@ -795,13 +724,78 @@ extension ContentView {
     var tabBarView: some View {
         VStack(spacing: 0) {
 #if os(macOS)
-            if #available(macOS 26.0, *) {
-                scrollableFileTabBar
-            } else {
-                macLegacyFileTabBar
+            MacNativeFileTabBar(
+                tabs: viewModel.tabs.map {
+                    MacNativeFileTabSnapshot(
+                        id: $0.id,
+                        title: $0.name,
+                        isDirty: $0.isDirty,
+                        isRemote: $0.isRemoteDocument,
+                        isReadOnly: $0.isReadOnlyPreview
+                    )
+                },
+                selectedTabID: viewModel.selectedTabID,
+                usesOpaqueEditorCanvas: opaqueEditorSurfaceMac,
+                onSelect: { viewModel.selectTab(id: $0) },
+                onClose: { tabID in
+                    guard let tab = viewModel.tabs.first(where: { $0.id == tabID }) else { return }
+                    requestCloseTab(tab)
+                },
+                onMove: { sourceID, destinationID, insertBefore in
+                    reorderDroppedTab(
+                        draggedTabID: sourceID,
+                        destinationTabID: destinationID,
+                        insertBefore: insertBefore
+                    )
+                },
+                onAdd: { viewModel.addNewTab() }
+            )
+            // Keep the AppKit representable and the divider as explicit
+            // siblings in the 42-point strip. Without a child height,
+            // VStack can compress the representable's fitting size and make
+            // its scroll view clip the tab layer at the bottom.
+            .frame(height: 41)
+#elseif os(iOS)
+            GlassSurface(
+                // Window translucency must keep the tab strip on a material
+                // surface even when the optional Liquid Glass toolbar style is
+                // disabled; otherwise the fallback color paints an opaque band.
+                enabled: shouldUseLiquidGlass || enableTranslucentWindow,
+                material: primaryGlassMaterial,
+                fallbackColor: toolbarFallbackColor,
+                shape: .rounded(18),
+                chromeStyle: .single
+            ) {
+                MobileNativeFileTabBar(
+                    tabs: viewModel.tabs.map {
+                        MobileNativeFileTabSnapshot(
+                            id: $0.id,
+                            title: $0.name,
+                            isDirty: $0.isDirty,
+                            isRemote: $0.isRemoteDocument,
+                            isReadOnly: $0.isReadOnlyPreview
+                        )
+                    },
+                    selectedTabID: viewModel.selectedTabID,
+                    onSelect: { viewModel.selectTab(id: $0) },
+                    onClose: { tabID in
+                        guard let tab = viewModel.tabs.first(where: { $0.id == tabID }) else { return }
+                        requestCloseTab(tab)
+                    },
+                    onMove: { sourceID, destinationID, insertBefore in
+                        reorderDroppedTab(
+                            draggedTabID: sourceID,
+                            destinationTabID: destinationID,
+                            insertBefore: insertBefore
+                        )
+                    },
+                    onAdd: { viewModel.addNewTab() }
+                )
             }
-#else
+#elseif os(visionOS)
             scrollableFileTabBar
+#else
+            EmptyView()
 #endif
 #if os(iOS) || os(visionOS)
             EmptyView()
@@ -811,7 +805,12 @@ extension ContentView {
         }
         .frame(minHeight: 42, maxHeight: 42, alignment: .center)
 #if os(macOS)
-        .background(editorSurfaceBackgroundStyle.opacity(usesAnySidebarTabTransition ? 0 : 1))
+        .background(macToolbarBackgroundStyle)
+#elseif os(iOS)
+        // Keep the full-width strip on the same surface as the project bar
+        // and editor. The inner GlassSurface supplies the rounded chrome;
+        // this outer surface prevents a mismatched band around it.
+        .background(editorSurfaceBackgroundStyle)
 #else
         .background(
             enableTranslucentWindow
@@ -823,6 +822,22 @@ extension ContentView {
 #endif
     }
 
+#if os(macOS) || os(iOS)
+    private func reorderDroppedTab(
+        draggedTabID: UUID,
+        destinationTabID: UUID,
+        insertBefore: Bool
+    ) {
+        guard draggedTabID != destinationTabID else { return }
+        if insertBefore {
+            viewModel.moveTab(tabID: draggedTabID, beforeTabID: destinationTabID)
+        } else {
+            viewModel.moveTab(tabID: draggedTabID, afterTabID: destinationTabID)
+        }
+    }
+#endif
+
+#if os(visionOS)
     private var scrollableFileTabBar: some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
@@ -840,47 +855,14 @@ extension ContentView {
                     .padding(.leading, tabBarLeadingPadding)
                     .padding(.trailing, 10)
                     .padding(.vertical, 6)
-                    .background(fileTabBarOffsetReader)
             }
             .onChange(of: viewModel.selectedTabID) { _, selectedTabID in
                 guard let selectedTabID else { return }
                 proxy.scrollTo(selectedTabID)
             }
         }
-        .coordinateSpace(name: fileTabBarCoordinateSpaceName)
-        .onPreferenceChange(FileTabBarContentMinXPreferenceKey.self) { minX in
-            let isScrolled = minX < tabBarLeadingPadding - 1
-            if fileTabBarIsScrolledUnderTOCEdge != isScrolled {
-                fileTabBarIsScrolledUnderTOCEdge = isScrolled
-            }
-        }
         .modifier(FileTabBarScrollFadeMask(mask: fileTabBarScrollMask))
     }
-
-#if os(macOS)
-    private var macLegacyFileTabBar: some View {
-        fileTabBarContent
-            .padding(5)
-            .background(
-                fileTabBarContainerShape
-                    .fill(Color.secondary.opacity(0.065))
-            )
-            .overlay(
-                fileTabBarContainerShape
-                    .stroke(Color.secondary.opacity(0.10), lineWidth: 1)
-            )
-            .clipShape(fileTabBarContainerShape)
-            .padding(.leading, tabBarLeadingPadding)
-            .padding(.trailing, 10)
-            .padding(.vertical, 6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .onAppear {
-                if fileTabBarIsScrolledUnderTOCEdge {
-                    fileTabBarIsScrolledUnderTOCEdge = false
-                }
-            }
-    }
-#endif
 
     private var fileTabBarContent: some View {
         HStack(spacing: 6) {
@@ -919,8 +901,6 @@ extension ContentView {
 
     private func fileTabItem(for tab: TabData) -> some View {
         let isSelected = viewModel.selectedTabID == tab.id
-        let wasPreviouslySelected = previousSelectedTabID == tab.id && !isSelected
-        let isDropTarget = tabDropInsertionTabID == tab.id
         return HStack(spacing: 8) {
             fileTabSelectButton(for: tab, isSelected: isSelected)
             fileTabCloseButton(for: tab)
@@ -929,63 +909,8 @@ extension ContentView {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(isSelected ? Color.accentColor.opacity(0.24) : Color.secondary.opacity(0.07))
         )
-        .overlay(alignment: isDropTarget && !tabDropInsertionBefore ? .trailing : .leading) {
-#if os(macOS)
-            if isSelected || wasPreviouslySelected || isDropTarget {
-                Capsule()
-                    .fill(isDropTarget || isSelected ? Color.accentColor : Color.yellow)
-                    .frame(width: isSelected ? 4 : 3)
-                    .padding(.vertical, 3)
-                    .accessibilityHidden(true)
-            }
-#endif
-        }
         .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-#if os(macOS)
-        .onTapGesture {
-            viewModel.selectTab(id: tab.id)
-        }
-        .onTapGesture(count: 2) {
-            requestCloseTab(tab)
-        }
-        .draggable(tab.id.uuidString)
-        .background {
-            GeometryReader { proxy in
-                Color.clear
-                    .contentShape(Rectangle())
-                    .onDrop(
-                        of: [UTType.plainText.identifier],
-                        delegate: FileTabDropDelegate(
-                            destinationTabID: tab.id,
-                            tabWidth: proxy.size.width,
-                            insertionTabID: $tabDropInsertionTabID,
-                            insertionBefore: $tabDropInsertionBefore,
-                            moveTab: reorderDroppedTab
-                        )
-                    )
-            }
-        }
-        .accessibilityHint(isSelected
-            ? "Selected. Drag this tab onto the left or right half of another tab to reorder tabs."
-            : "Drag onto the left or right half of another tab to reorder tabs.")
-#endif
     }
-
-#if os(macOS)
-    private func reorderDroppedTab(
-        draggedTabID: UUID,
-        destinationTabID: UUID,
-        insertBefore: Bool
-    ) {
-        guard draggedTabID != destinationTabID else { return }
-        if insertBefore {
-            viewModel.moveTab(tabID: draggedTabID, beforeTabID: destinationTabID)
-        } else {
-            viewModel.moveTab(tabID: draggedTabID, afterTabID: destinationTabID)
-        }
-        tabDropInsertionTabID = nil
-    }
-#endif
 
     private func fileTabSelectButton(for tab: TabData, isSelected: Bool) -> some View {
         Button {
@@ -1039,59 +964,20 @@ extension ContentView {
         .help("Close \(tab.name)")
     }
 
-    private var usesSubtleTOCTransition: Bool {
-#if os(macOS)
-        usesTOCSplitChromeCleanup && fileTabBarIsScrolledUnderTOCEdge
-#else
-        false
-#endif
-    }
-
     private var usesMarkdownPreviewTabTransition: Bool {
         isMarkdownPreviewSplitVisible
     }
 
-#if os(macOS)
-    private var usesProjectSidebarTabTransition: Bool {
-        showProjectStructureSidebar && projectNavigatorPlacement == .trailing && !brainDumpLayoutEnabled && !focusModeEnabled
-    }
-
-    private var usesTrailingTabTransition: Bool {
-        usesMarkdownPreviewTabTransition || usesProjectSidebarTabTransition
-    }
-
-    private var usesAnySidebarTabTransition: Bool {
-        usesSubtleTOCTransition || usesMarkdownPreviewTabTransition || usesProjectSidebarTabTransition
-    }
-
-    private var usesTOCSplitChromeCleanup: Bool {
-        shouldUseSplitView
-    }
-#else
     private var usesTrailingTabTransition: Bool {
         usesMarkdownPreviewTabTransition
-    }
-#endif
-
-    private var fileTabBarCoordinateSpaceName: String {
-        "FileTabBarScroll"
-    }
-
-    private var fileTabBarOffsetReader: some View {
-        GeometryReader { proxy in
-            Color.clear.preference(
-                key: FileTabBarContentMinXPreferenceKey.self,
-                value: proxy.frame(in: .named(fileTabBarCoordinateSpaceName)).minX
-            )
-        }
     }
 
     @ViewBuilder
     private var fileTabBarScrollMask: some View {
-        if usesSubtleTOCTransition || usesTrailingTabTransition {
+        if usesTrailingTabTransition {
             LinearGradient(
                 stops: [
-                    .init(color: usesSubtleTOCTransition ? .clear : .black, location: 0),
+                    .init(color: .black, location: 0),
                     .init(color: .black, location: 0.035),
                     .init(color: .black, location: 0.965),
                     .init(color: usesTrailingTabTransition ? .clear : .black, location: 1)
@@ -1104,24 +990,21 @@ extension ContentView {
         }
     }
 
-#if os(macOS)
-    @ViewBuilder
-    private var tabBarBottomDivider: some View {
-        if usesAnySidebarTabTransition {
-            Divider()
-                .opacity(0.22)
-                .padding(.leading, 18)
-                .padding(.trailing, usesTrailingTabTransition ? 18 : 0)
-        } else {
-            Divider()
-                .opacity(0.45)
-        }
-    }
-#endif
 
     private var fileTabBarContainerShape: RoundedRectangle {
         RoundedRectangle(cornerRadius: 14, style: .continuous)
     }
+#endif
+
+#if os(macOS)
+    @ViewBuilder
+    private var tabBarBottomDivider: some View {
+        Divider()
+            .opacity(isMarkdownPreviewSplitVisible ? 0.22 : 0.32)
+            .padding(.leading, isMarkdownPreviewSplitVisible ? 18 : 0)
+            .padding(.trailing, isMarkdownPreviewSplitVisible ? 18 : 0)
+    }
+#endif
 
     private var vimStatusSuffix: String {
 #if os(macOS)

--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -753,10 +753,6 @@ struct ContentView: View {
     @State var projectRefreshStatusIsPending: Bool = false
     @State var projectFolderMonitorSource: DispatchSourceFileSystemObject? = nil
     @State var pendingProjectFolderRefreshWorkItem: DispatchWorkItem? = nil
-    @State var fileTabBarIsScrolledUnderTOCEdge: Bool = false
-    @State var tabDropInsertionTabID: UUID? = nil
-    @State var tabDropInsertionBefore: Bool = true
-    @State var previousSelectedTabID: UUID? = nil
     @State var quickSwitcherRecentItemIDs: [String] = []
     @State var recentFilesRefreshToken: UUID = UUID()
     @State var sharedImportsRefreshToken: UUID = UUID()
@@ -1149,6 +1145,12 @@ struct ContentView: View {
             guard let titlebarView else { return false }
             let point = titlebarView.convert(event.locationInWindow, from: nil)
             guard titlebarView.bounds.contains(point) else { return false }
+            // The transparent titlebar can extend over the editor content. Only
+            // the upper chrome band is a drag surface; otherwise a click that
+            // begins on selected text would be promoted to a window drag and
+            // leave the editor selection visibly marked during the move.
+            let dragBandHeight = min(88, max(44, titlebarView.bounds.height * 0.35))
+            guard point.y >= titlebarView.bounds.maxY - dragBandHeight else { return false }
             guard let hitView = titlebarView.hitTest(point) else { return true }
             var candidate: NSView? = hitView
             while let view = candidate, view !== titlebarView {
@@ -1186,13 +1188,13 @@ struct ContentView: View {
             switch modeRaw {
             case "subtle":
                 whiteLevel = isDarkMode ? 0.18 : 0.90
-                translucentAlpha = 0.92
+                translucentAlpha = 0.96
             case "vibrant":
                 whiteLevel = isDarkMode ? 0.12 : 0.82
-                translucentAlpha = 0.84
+                translucentAlpha = 0.90
             default:
                 whiteLevel = isDarkMode ? 0.15 : 0.86
-                translucentAlpha = 0.88
+                translucentAlpha = 0.93
             }
             return NSColor(calibratedWhite: whiteLevel, alpha: translucent ? translucentAlpha : 1)
         }
@@ -1217,7 +1219,11 @@ struct ContentView: View {
         )
     }
     private var macOpaqueEditorCanvasColor: Color {
-        currentEditorTheme(colorScheme: colorScheme).background
+        // Keep opaque-canvas mode readable while allowing a small amount of
+        // the native window surface to blend through. This is intentionally
+        // subtle; the editor remains visually solid without the hard slab
+        // produced by a fully opaque theme color.
+        currentEditorTheme(colorScheme: colorScheme).background.opacity(0.94)
     }
     private var macEditorSurfaceBackgroundStyle: AnyShapeStyle {
         if enableTranslucentWindow {
@@ -1235,11 +1241,29 @@ struct ContentView: View {
         return AnyShapeStyle(macSolidSurfaceColor)
     }
 
-    private var macToolbarBackgroundStyle: AnyShapeStyle {
+    var macToolbarBackgroundStyle: AnyShapeStyle {
         if enableTranslucentWindow {
+            // The NSWindow owns the translucent chrome surface. Keep SwiftUI
+            // clear here so the toolbar and tab strip reveal that same window
+            // material instead of stacking an opaque bar material over it.
             return macUnifiedTranslucentMaterialStyle
         }
+        if opaqueEditorSurfaceMac {
+            // Opaque editor mode uses the editor theme for the side columns as
+            // well. Continue that surface through the toolbar and tab strip so
+            // the upper chrome does not become a separate window-colored band.
+            return macEditorSurfaceBackgroundStyle
+        }
         return AnyShapeStyle(macSolidSurfaceColor)
+    }
+
+    var macSidebarColumnBackground: some View {
+        ZStack(alignment: .top) {
+            Rectangle().fill(editorSurfaceBackgroundStyle)
+            Rectangle()
+                .fill(macToolbarBackgroundStyle)
+                .frame(height: 42)
+        }
     }
 
     private var macInterPaneBackgroundStyle: AnyShapeStyle {
@@ -1352,10 +1376,6 @@ struct ContentView: View {
         if UIDevice.current.userInterfaceIdiom == .pad {
             // Keep tabs clear of iPad window controls in narrow/multitasking layouts.
             return horizontalSizeClass == .compact ? 112 : 10
-        }
-#else
-        if shouldUseSplitView {
-            return 4
         }
 #endif
         return 10
@@ -2471,6 +2491,7 @@ struct ContentView: View {
                     VStack(spacing: 0) {
                         if usesAppOwnedIOSSplitChromeLayout {
                             iOSUnifiedToolbarHost
+                            iOSUnifiedDocumentChromeHost
                         }
                         NavigationSplitView {
 #if os(iOS)
@@ -2490,6 +2511,7 @@ struct ContentView: View {
                         .toolbar(.hidden, for: .navigationBar)
                         .background(editorSurfaceBackgroundStyle)
                     }
+                    .background(editorSurfaceBackgroundStyle)
                 } else {
                     editorView
                 }
@@ -2782,7 +2804,6 @@ struct ContentView: View {
             }
             .onChange(of: viewModel.selectedTabID) { previousTabID, selectedTabID in
                 guard previousTabID != selectedTabID else { return }
-                previousSelectedTabID = previousTabID
                 if activeSplitSecondaryTabID == nil {
                     splitSecondaryTabID = nil
                 }
@@ -3562,6 +3583,7 @@ struct ContentView: View {
                     DetachedPreviewWindowPresenter(
                         isPresented: contentView.$showDetachedPreviewWindow,
                         title: contentView.previewTitle,
+                        metadata: contentView.previewFileSizeText(for: contentView.viewModel.selectedTab?.fileURL),
                         html: contentView.detachedPreviewHTML,
                         baseURL: contentView.detachedPreviewBaseURL
                     )
@@ -3997,7 +4019,11 @@ struct ContentView: View {
                 }
             )
                 .frame(minWidth: 200, idealWidth: 250, maxWidth: 600)
+#if os(macOS)
+                .background(Color.clear)
+#else
                 .background(editorSurfaceBackgroundStyle)
+#endif
         } else {
             EmptyView()
         }
@@ -4733,7 +4759,7 @@ struct ContentView: View {
             if shouldUseSplitView {
                 sidebarView
                     .frame(width: clampedTOCSidebarWidth)
-                    .background(editorSurfaceBackgroundStyle)
+                    .background(macSidebarColumnBackground)
                 tocSidebarResizeHandle
             }
             editorView
@@ -4769,6 +4795,7 @@ struct ContentView: View {
             // window. A solid theme color creates a white strip in translucent
             // mode even though both adjacent panes use the window material.
             surfaceStyle: macInterPaneBackgroundStyle,
+            topSurfaceStyle: macToolbarBackgroundStyle,
             isActive: isTOCSidebarResizeHandleHovered || tocSidebarResizeStartWidth != nil,
             isDragging: tocSidebarResizeStartWidth != nil,
             isHovered: $isTOCSidebarResizeHandleHovered,
@@ -5169,7 +5196,7 @@ struct ContentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
 #if os(iOS) || os(visionOS)
-        let contentWithTopChrome = useIOSUnifiedTopHost
+        let contentWithTopChrome = useIOSUnifiedTopHost && !usesAppOwnedIOSSplitChromeLayout
             ? AnyView(
                 content.safeAreaInset(edge: .top, spacing: 0) {
                     if usesAppOwnedIOSSplitChromeLayout {

--- a/Neon Vision Editor/UI/EditorTextView+iOS.swift
+++ b/Neon Vision Editor/UI/EditorTextView+iOS.swift
@@ -1699,13 +1699,14 @@ final class LineNumberedTextViewContainer: UIView {
 
     func applyLineNumberColors(editorBackground: UIColor, textColor: UIColor, translucentBackgroundEnabled: Bool) {
         backgroundColor = translucentBackgroundEnabled ? .clear : editorBackground
-        #if os(visionOS)
+        // The gutter is part of the editor surface, not a system sidebar.
+        // Painting secondarySystemBackground here made it remain opaque white
+        // in iPad translucent mode while the text canvas correctly showed the
+        // window material.
         lineNumberView.backgroundColor = translucentBackgroundEnabled ? .clear : editorBackground
-        divider.backgroundColor = textColor.withAlphaComponent(0.16)
-        #else
-        lineNumberView.backgroundColor = UIColor.secondarySystemBackground.withAlphaComponent(0.65)
-        divider.backgroundColor = UIColor.separator.withAlphaComponent(0.6)
-        #endif
+        divider.backgroundColor = translucentBackgroundEnabled
+            ? textColor.withAlphaComponent(0.16)
+            : UIColor.separator.withAlphaComponent(0.6)
         lineNumberView.textColor = textColor.withAlphaComponent(0.70)
     }
 

--- a/Neon Vision Editor/UI/MacNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MacNativeFileTabBar.swift
@@ -1,0 +1,649 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+struct MacNativeFileTabSnapshot: Equatable, Identifiable {
+    let id: UUID
+    let title: String
+    let isDirty: Bool
+    let isRemote: Bool
+    let isReadOnly: Bool
+}
+
+struct MacNativeFileTabBar: NSViewRepresentable {
+    let tabs: [MacNativeFileTabSnapshot]
+    let selectedTabID: UUID?
+    let usesOpaqueEditorCanvas: Bool
+    let onSelect: (UUID) -> Void
+    let onClose: (UUID) -> Void
+    let onMove: (UUID, UUID, Bool) -> Void
+    let onAdd: () -> Void
+
+    func makeNSView(context: Context) -> MacNativeFileTabBarView {
+        let view = MacNativeFileTabBarView()
+        configure(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: MacNativeFileTabBarView, context: Context) {
+        configure(nsView)
+    }
+
+    private func configure(_ view: MacNativeFileTabBarView) {
+        view.onSelect = onSelect
+        view.onClose = onClose
+        view.onMove = onMove
+        view.onAdd = onAdd
+        view.usesOpaqueEditorCanvas = usesOpaqueEditorCanvas
+        view.apply(tabs: tabs, selectedTabID: selectedTabID)
+    }
+}
+
+@MainActor
+final class MacNativeFileTabBarView: NSView {
+    var onSelect: ((UUID) -> Void)?
+    var onClose: ((UUID) -> Void)?
+    var onMove: ((UUID, UUID, Bool) -> Void)?
+    var onAdd: (() -> Void)?
+
+    private let scrollView = NSScrollView()
+    private let tabsView = MacNativeFileTabDocumentView()
+    private let addButton = NSButton()
+    private let scrollEdgeMask = CAGradientLayer()
+    private var tabViewsByID: [UUID: MacNativeFileTabItemView] = [:]
+    private(set) var orderedTabIDs: [UUID] = []
+    private(set) var selectedTabID: UUID?
+    private(set) var scrollEdgeFadeState = (left: false, right: false)
+    var usesOpaqueEditorCanvas = false
+
+    var managedTabViewCount: Int { tabViewsByID.count }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+
+        scrollView.drawsBackground = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.hasVerticalScroller = false
+        scrollView.horizontalScrollElasticity = .automatic
+        scrollView.verticalScrollElasticity = .none
+        scrollView.scrollerStyle = .overlay
+        scrollView.documentView = tabsView
+        scrollView.wantsLayer = true
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        scrollEdgeMask.startPoint = CGPoint(x: 0, y: 0.5)
+        scrollEdgeMask.endPoint = CGPoint(x: 1, y: 0.5)
+        scrollView.layer?.mask = scrollEdgeMask
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(scrollBoundsDidChange),
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView
+        )
+        addSubview(scrollView)
+
+        addButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "New Tab")
+        addButton.imagePosition = .imageOnly
+        addButton.bezelStyle = .accessoryBarAction
+        addButton.controlSize = .small
+        addButton.target = self
+        addButton.action = #selector(addTab)
+        addButton.toolTip = "New Tab"
+        addButton.setAccessibilityLabel("New Tab")
+        addButton.setAccessibilityHelp("Creates a new untitled tab")
+        addSubview(addButton)
+
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var isFlipped: Bool { true }
+
+    override func layout() {
+        super.layout()
+        let leadingInset: CGFloat = 8
+        let tabToButtonSpacing: CGFloat = 8
+        let buttonWidth: CGFloat = 36
+        let trailingInset: CGFloat = 10
+        let buttonX = bounds.width - trailingInset - buttonWidth
+        addButton.frame = NSRect(x: buttonX, y: 6, width: buttonWidth, height: max(24, bounds.height - 12))
+        scrollView.frame = NSRect(
+            x: leadingInset,
+            y: 0,
+            width: max(0, buttonX - tabToButtonSpacing - leadingInset),
+            height: max(0, bounds.height)
+        )
+        // The document view must fill the clip viewport. Deriving its height
+        // from contentSize can reuse a stale/short document height during a
+        // relayout, making the scroll view clip the rounded tab layers at the
+        // bottom (most visible against dark chrome).
+        tabsView.frame.size.height = scrollView.contentView.bounds.height
+        tabsView.layoutTabs(viewportWidth: scrollView.contentSize.width)
+        updateScrollEdgeMask()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        // The representable can retain its NSView while SwiftUI replaces the
+        // toolbar/editor surface. Refresh the item layers from the container
+        // so their semantic colors are resolved against the new appearance.
+        for tabView in tabViewsByID.values {
+            tabView.refreshForContainerAppearanceChange()
+        }
+    }
+
+    func apply(tabs: [MacNativeFileTabSnapshot], selectedTabID: UUID?) {
+        let incomingIDs = Set(tabs.map(\.id))
+        let staleIDs = tabViewsByID.keys.filter { !incomingIDs.contains($0) }
+        for staleID in staleIDs {
+            tabViewsByID.removeValue(forKey: staleID)?.removeFromSuperview()
+        }
+
+        orderedTabIDs = tabs.map(\.id)
+        self.selectedTabID = selectedTabID
+        var orderedViews: [MacNativeFileTabItemView] = []
+        orderedViews.reserveCapacity(tabs.count)
+
+        for snapshot in tabs {
+            let tabView: MacNativeFileTabItemView
+            if let existing = tabViewsByID[snapshot.id] {
+                tabView = existing
+            } else {
+                tabView = MacNativeFileTabItemView(tabID: snapshot.id)
+                tabView.onSelect = { [weak self] id in self?.onSelect?(id) }
+                tabView.onClose = { [weak self] id in self?.onClose?(id) }
+                tabViewsByID[snapshot.id] = tabView
+            }
+            tabView.apply(
+                snapshot: snapshot,
+                isSelected: snapshot.id == selectedTabID,
+                usesOpaqueEditorCanvas: usesOpaqueEditorCanvas
+            )
+            orderedViews.append(tabView)
+        }
+
+        tabsView.setTabViews(orderedViews)
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+        if let selectedTabID, let selectedView = tabViewsByID[selectedTabID] {
+            selectedView.scrollToVisible(selectedView.bounds)
+        }
+    }
+
+    func selectTabForTesting(_ id: UUID) {
+        onSelect?(id)
+    }
+
+    func closeTabForTesting(_ id: UUID) {
+        onClose?(id)
+    }
+
+    func moveTabForTesting(_ source: UUID, destination: UUID, before: Bool) {
+        onMove?(source, destination, before)
+    }
+
+    func selectionIndicatorFrameForTesting(_ id: UUID) -> NSRect? {
+        tabViewsByID[id]?.selectionIndicatorFrameForTesting
+    }
+
+    func visualStateForTesting(_ id: UUID) -> (backgroundAlpha: CGFloat, borderWidth: CGFloat, borderAlpha: CGFloat)? {
+        tabViewsByID[id]?.visualStateForTesting
+    }
+
+    func outlineGeometryForTesting(_ id: UUID) -> (pathBounds: CGRect, viewBounds: CGRect)? {
+        tabViewsByID[id]?.outlineGeometryForTesting
+    }
+
+    func outlineZPositionForTesting(_ id: UUID) -> CGFloat? {
+        tabViewsByID[id]?.outlineZPositionForTesting
+    }
+
+    func setHoveredForTesting(_ id: UUID, hovered: Bool) {
+        tabViewsByID[id]?.setHoveredForTesting(hovered)
+    }
+
+    func titleLayoutForTesting(_ id: UUID) -> (titleFrame: NSRect, tabBounds: NSRect)? {
+        tabViewsByID[id]?.titleLayoutForTesting
+    }
+
+    var addButtonLayoutForTesting: (buttonFrame: NSRect, tabsFrame: NSRect) {
+        (addButton.frame, scrollView.frame)
+    }
+
+    var horizontalScrollLayoutForTesting: (documentWidth: CGFloat, viewportWidth: CGFloat) {
+        (tabsView.frame.width, scrollView.contentSize.width)
+    }
+
+    func scrollToEndForTesting() {
+        let destination = max(0, tabsView.frame.width - scrollView.contentSize.width)
+        scrollView.contentView.scroll(to: NSPoint(x: destination, y: 0))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        updateScrollEdgeMask()
+    }
+
+    func selectAdjacentTab(from id: UUID, offset: Int) {
+        guard let index = orderedTabIDs.firstIndex(of: id) else { return }
+        let destinationIndex = index + offset
+        guard orderedTabIDs.indices.contains(destinationIndex) else { return }
+        let destinationID = orderedTabIDs[destinationIndex]
+        onSelect?(destinationID)
+        window?.makeFirstResponder(tabViewsByID[destinationID])
+    }
+
+    @objc private func addTab() {
+        onAdd?()
+    }
+
+    @objc private func scrollBoundsDidChange() {
+        updateScrollEdgeMask()
+    }
+
+    private func updateScrollEdgeMask() {
+        let viewportWidth = scrollView.contentSize.width
+        let maximumOffset = max(0, tabsView.frame.width - viewportWidth)
+        let offset = min(max(0, scrollView.contentView.bounds.minX), maximumOffset)
+        let showsLeftFade = offset > 0.5
+        let showsRightFade = maximumOffset - offset > 0.5
+        scrollEdgeFadeState = (showsLeftFade, showsRightFade)
+
+        let opaque = NSColor.black.cgColor
+        let clear = NSColor.clear.cgColor
+        scrollEdgeMask.frame = scrollView.bounds
+        scrollEdgeMask.colors = [
+            showsLeftFade ? clear : opaque,
+            opaque,
+            opaque,
+            showsRightFade ? clear : opaque
+        ]
+        scrollEdgeMask.locations = [0, 0.035, 0.965, 1]
+    }
+}
+
+@MainActor
+private final class MacNativeFileTabDocumentView: NSView {
+    private var tabViews: [MacNativeFileTabItemView] = []
+
+    override var isFlipped: Bool { true }
+
+    func setTabViews(_ views: [MacNativeFileTabItemView]) {
+        guard tabViews.map(\.tabID) != views.map(\.tabID) else { return }
+        tabViews = views
+        subviews = views
+        needsLayout = true
+    }
+
+    func layoutTabs(viewportWidth: CGFloat) {
+        let count = tabViews.count
+        guard count > 0 else {
+            frame.size.width = viewportWidth
+            return
+        }
+
+        let spacing: CGFloat = 5
+        let totalSpacing = spacing * CGFloat(max(0, count - 1))
+        let contentWidth = tabViews.reduce(0) { $0 + $1.preferredWidth } + totalSpacing
+        frame.size.width = max(viewportWidth, contentWidth)
+        var x: CGFloat = 0
+        for tabView in tabViews {
+            let width = tabView.preferredWidth
+            // Keep a full-pixel breathing room around the rounded layer. The
+            // previous 5-point inset put the lower border on the scroll view's
+            // clipping boundary in dark appearance, making inactive tabs look
+            // cut off at the bottom.
+            tabView.frame = NSRect(x: x, y: 6, width: width, height: max(24, bounds.height - 12))
+            x += width + spacing
+        }
+    }
+}
+
+@MainActor
+private final class MacNativeFileTabItemView: NSView, NSDraggingSource {
+    let tabID: UUID
+    var onSelect: ((UUID) -> Void)?
+    var onClose: ((UUID) -> Void)?
+
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let remoteLabel = NSTextField(labelWithString: "Remote")
+    private let lockImage = NSImageView()
+    private let closeButton = NSButton()
+    private let divider = NSBox()
+    private let selectionIndicator = NSBox()
+    private let outlineLayer = CAShapeLayer()
+    private var trackingAreaReference: NSTrackingArea?
+    private var snapshot: MacNativeFileTabSnapshot?
+    private var isSelected = false
+    private var isHovered = false
+    private var isDragging = false
+    private var insertionBefore: Bool?
+    private var usesOpaqueEditorCanvas = false
+
+    var selectionIndicatorFrameForTesting: NSRect { selectionIndicator.frame }
+    var visualStateForTesting: (backgroundAlpha: CGFloat, borderWidth: CGFloat, borderAlpha: CGFloat) {
+        (layer?.backgroundColor?.alpha ?? 0, outlineLayer.lineWidth, outlineLayer.strokeColor?.alpha ?? 0)
+    }
+    var outlineGeometryForTesting: (pathBounds: CGRect, viewBounds: CGRect)? {
+        guard let path = outlineLayer.path else { return nil }
+        return (path.boundingBox, bounds)
+    }
+    var outlineZPositionForTesting: CGFloat { outlineLayer.zPosition }
+
+    func setHoveredForTesting(_ hovered: Bool) {
+        isHovered = hovered
+        updateAppearance()
+    }
+    var titleLayoutForTesting: (titleFrame: NSRect, tabBounds: NSRect) { (titleLabel.frame, bounds) }
+    var preferredWidth: CGFloat {
+        let titleWidth = ceil(titleLabel.intrinsicContentSize.width)
+        let remoteContribution: CGFloat = snapshot?.isRemote == true ? 51 : 0
+        let lockContribution: CGFloat = snapshot?.isReadOnly == true ? 19 : 0
+        let chromeWidth: CGFloat = 41
+        return min(256, max(128, titleWidth + remoteContribution + lockContribution + chromeWidth))
+    }
+
+    init(tabID: UUID) {
+        self.tabID = tabID
+        super.init(frame: .zero)
+        wantsLayer = true
+        outlineLayer.fillColor = NSColor.clear.cgColor
+        outlineLayer.lineJoin = .round
+        // Keep the complete outline above labels and AppKit control layers.
+        // During an appearance/material relayout those child layers can be
+        // composited after the default-z sublayer and cover its lower edge.
+        outlineLayer.zPosition = 10
+        outlineLayer.needsDisplayOnBoundsChange = true
+        layer?.addSublayer(outlineLayer)
+        registerForDraggedTypes([.string])
+
+        titleLabel.lineBreakMode = .byTruncatingMiddle
+        titleLabel.maximumNumberOfLines = 1
+        titleLabel.font = .systemFont(ofSize: 12)
+        addSubview(titleLabel)
+
+        remoteLabel.font = .systemFont(ofSize: 9, weight: .semibold)
+        remoteLabel.textColor = .secondaryLabelColor
+        remoteLabel.alignment = .center
+        remoteLabel.wantsLayer = true
+        remoteLabel.layer?.cornerRadius = 5
+        remoteLabel.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.12).cgColor
+        addSubview(remoteLabel)
+
+        lockImage.image = NSImage(systemSymbolName: "lock.fill", accessibilityDescription: "Read Only")
+        lockImage.contentTintColor = .secondaryLabelColor
+        lockImage.imageScaling = .scaleProportionallyDown
+        addSubview(lockImage)
+
+        closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Close Tab")
+        closeButton.imagePosition = .imageOnly
+        closeButton.bezelStyle = .inline
+        closeButton.isBordered = false
+        closeButton.controlSize = .small
+        closeButton.image = closeButton.image?.withSymbolConfiguration(.init(pointSize: 9, weight: .medium))
+        closeButton.target = self
+        closeButton.action = #selector(closeTab)
+        addSubview(closeButton)
+
+        divider.boxType = .separator
+        addSubview(divider)
+
+        selectionIndicator.boxType = .custom
+        selectionIndicator.borderWidth = 0
+        selectionIndicator.fillColor = .controlAccentColor
+        selectionIndicator.cornerRadius = 1
+        addSubview(selectionIndicator)
+
+        setAccessibilityElement(true)
+        setAccessibilityRole(.radioButton)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 36, 49: // Return or Space
+            onSelect?(tabID)
+        case 123: // Left Arrow
+            enclosingBar?.selectAdjacentTab(from: tabID, offset: -1)
+        case 124: // Right Arrow
+            enclosingBar?.selectAdjacentTab(from: tabID, offset: 1)
+        default:
+            super.keyDown(with: event)
+        }
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        onSelect?(tabID)
+        return true
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearance()
+    }
+
+    func refreshForContainerAppearanceChange() {
+        updateAppearance()
+        needsLayout = true
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingAreaReference {
+            removeTrackingArea(trackingAreaReference)
+        }
+        let tracking = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(tracking)
+        trackingAreaReference = tracking
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+        updateAppearance()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+        insertionBefore = nil
+        updateAppearance()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        onSelect?(tabID)
+        if event.clickCount == 2 {
+            onClose?(tabID)
+        }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard !isDragging else { return }
+        isDragging = true
+        let pasteboardItem = NSPasteboardItem()
+        pasteboardItem.setString(tabID.uuidString, forType: .string)
+        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+        draggingItem.setDraggingFrame(bounds, contents: bitmapImageRepForCachingDisplay(in: bounds))
+        beginDraggingSession(with: [draggingItem], event: event, source: self)
+    }
+
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        .move
+    }
+
+    func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
+        isDragging = false
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        updateInsertion(for: sender)
+        return .move
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        updateInsertion(for: sender)
+        return .move
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        insertionBefore = nil
+        updateAppearance()
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        defer {
+            insertionBefore = nil
+            updateAppearance()
+        }
+        guard let value = sender.draggingPasteboard.string(forType: .string),
+              let sourceID = UUID(uuidString: value),
+              sourceID != tabID else { return false }
+        let before = insertionBefore ?? true
+        guard let bar = enclosingBar else { return false }
+        bar.onMove?(sourceID, tabID, before)
+        return true
+    }
+
+    override func draggingEnded(_ sender: NSDraggingInfo) {
+        insertionBefore = nil
+        updateAppearance()
+    }
+
+    override func layout() {
+        super.layout()
+        let borderWidth: CGFloat = 0.5
+        let borderInset = borderWidth / 2
+        outlineLayer.frame = bounds
+        outlineLayer.contentsScale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
+        outlineLayer.lineWidth = borderWidth
+        outlineLayer.path = CGPath(
+            roundedRect: bounds.insetBy(dx: borderInset, dy: borderInset),
+            cornerWidth: 7 - borderInset,
+            cornerHeight: 7 - borderInset,
+            transform: nil
+        )
+        let closeWidth: CGFloat = 22
+        let sidePadding: CGFloat = 10
+        let remoteWidth: CGFloat = snapshot?.isRemote == true ? 45 : 0
+        let lockWidth: CGFloat = snapshot?.isReadOnly == true ? 14 : 0
+        let remoteGap: CGFloat = remoteWidth > 0 ? 6 : 0
+        let lockGap: CGFloat = lockWidth > 0 ? 5 : 0
+
+        closeButton.frame = NSRect(x: bounds.width - closeWidth - 4, y: 2, width: closeWidth, height: bounds.height - 4)
+        remoteLabel.frame = NSRect(x: sidePadding, y: max(7, bounds.height - 20), width: remoteWidth, height: 15)
+        let titleX = sidePadding + remoteWidth + remoteGap
+        let titleWidth = max(12, bounds.width - titleX - closeWidth - lockWidth - lockGap - 5)
+        titleLabel.frame = NSRect(x: titleX, y: max(7, bounds.height - 22), width: titleWidth, height: 18)
+        lockImage.frame = NSRect(x: titleLabel.frame.maxX + lockGap, y: max(9, bounds.height - 18), width: lockWidth, height: 12)
+        divider.frame = NSRect(x: bounds.width + 2, y: 7, width: 1, height: max(0, bounds.height - 14))
+        selectionIndicator.frame = NSRect(
+            x: insertionBefore == nil ? 8 : (insertionBefore == true ? -3 : bounds.width + 1),
+            y: insertionBefore == nil ? bounds.height - 2 : 3,
+            width: insertionBefore == nil ? max(0, bounds.width - 16) : 2,
+            height: insertionBefore == nil ? 2 : bounds.height - 6
+        )
+    }
+
+    func apply(
+        snapshot: MacNativeFileTabSnapshot,
+        isSelected: Bool,
+        usesOpaqueEditorCanvas: Bool
+    ) {
+        self.snapshot = snapshot
+        self.isSelected = isSelected
+        self.usesOpaqueEditorCanvas = usesOpaqueEditorCanvas
+        titleLabel.stringValue = snapshot.title + (snapshot.isDirty ? " •" : "")
+        titleLabel.font = .systemFont(ofSize: 12, weight: isSelected ? .semibold : .regular)
+        titleLabel.textColor = isSelected ? .labelColor : .secondaryLabelColor
+        remoteLabel.isHidden = !snapshot.isRemote
+        lockImage.isHidden = !snapshot.isReadOnly
+        closeButton.toolTip = "Close \(snapshot.title)"
+        closeButton.setAccessibilityLabel("Close \(snapshot.title)")
+        setAccessibilityLabel(accessibilityLabel(for: snapshot))
+        setAccessibilityValue(isSelected ? "Selected" : "Not selected")
+        setAccessibilityHelp("Press to select this tab. Use the left and right arrow keys to move between tabs.")
+        updateAppearance()
+        needsLayout = true
+    }
+
+    private var enclosingBar: MacNativeFileTabBarView? {
+        var candidate = superview
+        while let view = candidate {
+            if let bar = view as? MacNativeFileTabBarView { return bar }
+            candidate = view.superview
+        }
+        return nil
+    }
+
+    private func updateInsertion(for sender: NSDraggingInfo) {
+        let point = convert(sender.draggingLocation, from: nil)
+        insertionBefore = point.x < bounds.midX
+        updateAppearance()
+    }
+
+    private func updateAppearance() {
+        let isDarkAppearance = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let stateColor: NSColor? = if snapshot?.isDirty == true {
+            .systemOrange
+        } else if isSelected {
+            .controlAccentColor
+        } else {
+            nil
+        }
+        let fillColor: NSColor
+        if let stateColor {
+            fillColor = stateColor.withAlphaComponent(snapshot?.isDirty == true ? 0.13 : 0.105)
+        } else if isHovered {
+            fillColor = .labelColor.withAlphaComponent(0.075)
+        } else {
+            // Opaque light editor chrome is close to white, so the very low
+            // contrast used by translucent/dark surfaces makes inactive tabs
+            // visually disappear. Keep them quiet, but give each tab a clear
+            // surface boundary in light mode.
+            fillColor = .labelColor.withAlphaComponent(isDarkAppearance ? 0.025 : 0.055)
+        }
+        layer?.backgroundColor = fillColor.cgColor
+        layer?.cornerRadius = 7
+        layer?.borderWidth = 0
+        // Resolve the inactive outline to a concrete color before handing it
+        // to Core Animation. Retaining separatorColor's dynamic CGColor lets
+        // AppKit's material/hover recomposition replace the resolved contrast,
+        // which is why the border could flash once and then disappear.
+        let inactiveOutlineColor = NSColor(
+            calibratedWhite: isDarkAppearance ? 1 : 0,
+            alpha: !isDarkAppearance && usesOpaqueEditorCanvas ? 0.32 : (isDarkAppearance ? 0.34 : 0.28)
+        )
+        outlineLayer.strokeColor = stateColor != nil
+            ? stateColor?.withAlphaComponent(0.24).cgColor
+            : inactiveOutlineColor.cgColor
+        closeButton.isHidden = !(isSelected || isHovered || snapshot?.isDirty == true)
+        selectionIndicator.isHidden = insertionBefore == nil && stateColor == nil
+        selectionIndicator.fillColor = insertionBefore == nil ? (stateColor ?? .controlAccentColor) : .keyboardFocusIndicatorColor
+        divider.isHidden = true
+        needsLayout = true
+    }
+
+    private func accessibilityLabel(for snapshot: MacNativeFileTabSnapshot) -> String {
+        var parts = [snapshot.title, snapshot.isRemote ? "remote document" : "local document"]
+        if snapshot.isReadOnly { parts.append("read only") }
+        if snapshot.isDirty { parts.append("unsaved changes") }
+        return parts.joined(separator: ", ")
+    }
+
+    @objc private func closeTab() {
+        onClose?(tabID)
+    }
+}
+#endif

--- a/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
@@ -1,0 +1,479 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+struct MobileNativeFileTabSnapshot: Equatable, Identifiable {
+    let id: UUID
+    let title: String
+    let isDirty: Bool
+    let isRemote: Bool
+    let isReadOnly: Bool
+}
+
+struct MobileNativeFileTabBar: UIViewRepresentable {
+    let tabs: [MobileNativeFileTabSnapshot]
+    let selectedTabID: UUID?
+    let onSelect: (UUID) -> Void
+    let onClose: (UUID) -> Void
+    let onMove: (UUID, UUID, Bool) -> Void
+    let onAdd: () -> Void
+
+    func makeUIView(context: Context) -> MobileNativeFileTabBarView {
+        let view = MobileNativeFileTabBarView()
+        configure(view)
+        return view
+    }
+
+    func updateUIView(_ uiView: MobileNativeFileTabBarView, context: Context) {
+        configure(uiView)
+    }
+
+    private func configure(_ view: MobileNativeFileTabBarView) {
+        view.onSelect = onSelect
+        view.onClose = onClose
+        view.onMove = onMove
+        view.onAdd = onAdd
+        view.apply(tabs: tabs, selectedTabID: selectedTabID)
+    }
+}
+
+@MainActor
+final class MobileNativeFileTabBarView: UIView {
+    var onSelect: ((UUID) -> Void)?
+    var onClose: ((UUID) -> Void)?
+    var onMove: ((UUID, UUID, Bool) -> Void)?
+    var onAdd: (() -> Void)?
+
+    private let scrollView = UIScrollView()
+    private let tabsView = UIView()
+    private let addButton = UIButton(type: .system)
+    private let separator = UIView()
+    private var tabViewsByID: [UUID: MobileNativeFileTabItemView] = [:]
+    private(set) var orderedTabIDs: [UUID] = []
+    private(set) var selectedTabID: UUID?
+
+    var managedTabViewCount: Int { tabViewsByID.count }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+
+        scrollView.backgroundColor = .clear
+        scrollView.alwaysBounceHorizontal = false
+        scrollView.alwaysBounceVertical = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.isDirectionalLockEnabled = true
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.addSubview(tabsView)
+        addSubview(scrollView)
+
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: "plus")
+        configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+        configuration.contentInsets = .zero
+        addButton.configuration = configuration
+        addButton.accessibilityLabel = "New Tab"
+        addButton.accessibilityHint = "Creates a new untitled tab"
+        addButton.addTarget(self, action: #selector(addTab), for: .touchUpInside)
+        addSubview(addButton)
+
+        separator.backgroundColor = .separator.withAlphaComponent(0.45)
+        separator.isAccessibilityElement = false
+        addSubview(separator)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let scale = max(1, traitCollection.displayScale)
+        let separatorHeight = 1 / scale
+        let leadingInset: CGFloat = 8
+        let buttonWidth: CGFloat = 44
+        let trailingInset: CGFloat = 4
+        let spacing: CGFloat = 4
+        let buttonX = max(leadingInset, bounds.width - trailingInset - buttonWidth)
+
+        separator.frame = CGRect(x: 0, y: bounds.height - separatorHeight, width: bounds.width, height: separatorHeight)
+        addButton.frame = CGRect(x: buttonX, y: 0, width: buttonWidth, height: max(0, bounds.height - separatorHeight))
+        scrollView.frame = CGRect(
+            x: leadingInset,
+            y: 0,
+            width: max(0, buttonX - spacing - leadingInset),
+            height: max(0, bounds.height - separatorHeight)
+        )
+        layoutTabs(viewportWidth: scrollView.bounds.width)
+    }
+
+    func apply(
+        tabs: [MobileNativeFileTabSnapshot],
+        selectedTabID: UUID?,
+    ) {
+        let incomingIDs = Set(tabs.map(\.id))
+        for staleID in tabViewsByID.keys.filter({ !incomingIDs.contains($0) }) {
+            tabViewsByID.removeValue(forKey: staleID)?.removeFromSuperview()
+        }
+
+        orderedTabIDs = tabs.map(\.id)
+        self.selectedTabID = selectedTabID
+
+        for snapshot in tabs {
+            let tabView: MobileNativeFileTabItemView
+            if let existing = tabViewsByID[snapshot.id] {
+                tabView = existing
+            } else {
+                tabView = MobileNativeFileTabItemView(tabID: snapshot.id)
+                tabView.onSelect = { [weak self] id in self?.onSelect?(id) }
+                tabView.onClose = { [weak self] id in self?.onClose?(id) }
+                tabView.onMove = { [weak self] source, destination, before in
+                    self?.onMove?(source, destination, before)
+                }
+                tabViewsByID[snapshot.id] = tabView
+                tabsView.addSubview(tabView)
+            }
+            tabView.apply(
+                snapshot: snapshot,
+                isSelected: snapshot.id == selectedTabID,
+                allowsReordering: traitCollection.userInterfaceIdiom == .pad
+            )
+        }
+
+        for (index, id) in orderedTabIDs.enumerated() {
+            guard let tabView = tabViewsByID[id] else { continue }
+            tabsView.insertSubview(tabView, at: index)
+        }
+
+        setNeedsLayout()
+        layoutIfNeeded()
+        scrollSelectedTabToVisible(animated: window != nil)
+    }
+
+    private func layoutTabs(viewportWidth: CGFloat) {
+        let count = orderedTabIDs.count
+        guard count > 0 else {
+            tabsView.frame = CGRect(x: 0, y: 0, width: viewportWidth, height: scrollView.bounds.height)
+            scrollView.contentSize = tabsView.bounds.size
+            return
+        }
+
+        let spacing: CGFloat = 5
+        let totalSpacing = spacing * CGFloat(max(0, count - 1))
+        let maximumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 220 : 188
+        let minimumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 136 : 128
+        let fittedWidth = (viewportWidth - totalSpacing) / CGFloat(count)
+        let tabWidth = min(maximumWidth, max(minimumWidth, fittedWidth))
+        let contentWidth = max(viewportWidth, tabWidth * CGFloat(count) + totalSpacing)
+        tabsView.frame = CGRect(x: 0, y: 0, width: contentWidth, height: scrollView.bounds.height)
+        scrollView.contentSize = tabsView.bounds.size
+
+        var x: CGFloat = 0
+        for id in orderedTabIDs {
+            tabViewsByID[id]?.frame = CGRect(x: x, y: 5, width: tabWidth, height: max(28, tabsView.bounds.height - 10))
+            x += tabWidth + spacing
+        }
+    }
+
+    private func scrollSelectedTabToVisible(animated: Bool) {
+        guard let selectedTabID, let selectedView = tabViewsByID[selectedTabID] else { return }
+        let visibleRect = selectedView.frame.insetBy(dx: -6, dy: 0)
+        guard !scrollView.bounds.contains(visibleRect) else { return }
+        scrollView.scrollRectToVisible(visibleRect, animated: animated)
+    }
+
+    func selectTabForTesting(_ id: UUID) { onSelect?(id) }
+    func closeTabForTesting(_ id: UUID) { onClose?(id) }
+    func moveTabForTesting(_ source: UUID, destination: UUID, before: Bool) {
+        onMove?(source, destination, before)
+    }
+    func addTabForTesting() { onAdd?() }
+
+    func visualStateForTesting(_ id: UUID) -> (selected: Bool, previous: Bool, dirty: Bool)? {
+        tabViewsByID[id]?.visualStateForTesting
+    }
+
+    func accessibilityStateForTesting(_ id: UUID) -> (label: String?, traits: UIAccessibilityTraits)? {
+        guard let view = tabViewsByID[id] else { return nil }
+        return (view.accessibilityLabel, view.accessibilityTraits)
+    }
+
+    func accessibilityActionsForTesting(_ id: UUID) -> [String]? {
+        tabViewsByID[id]?.accessibilityCustomActions?.map(\.name)
+    }
+
+    func tabFrameForTesting(_ id: UUID) -> CGRect? { tabViewsByID[id]?.frame }
+
+    var addButtonFrameForTesting: CGRect { addButton.frame }
+    var scrollViewFrameForTesting: CGRect { scrollView.frame }
+    var horizontalContentOffsetForTesting: CGFloat { scrollView.contentOffset.x }
+    var horizontalContentWidthForTesting: CGFloat { scrollView.contentSize.width }
+
+    @objc private func addTab() {
+        onAdd?()
+    }
+}
+
+@MainActor
+private final class MobileNativeFileTabItemView: UIControl, UIDragInteractionDelegate, UIDropInteractionDelegate {
+    let tabID: UUID
+    var onSelect: ((UUID) -> Void)?
+    var onClose: ((UUID) -> Void)?
+    var onMove: ((UUID, UUID, Bool) -> Void)?
+    var allowsReordering = false {
+        didSet {
+            dragInteraction.isEnabled = allowsReordering
+            updateAccessibilityActions()
+        }
+    }
+
+    private let remoteLabel = UILabel()
+    private let titleLabel = UILabel()
+    private let lockImage = UIImageView()
+    private let dirtyIndicator = UIView()
+    private let closeButton = UIButton(type: .system)
+    private let selectionIndicator = UIView()
+    private lazy var dragInteraction = UIDragInteraction(delegate: self)
+    private lazy var dropInteraction = UIDropInteraction(delegate: self)
+    private var snapshot: MobileNativeFileTabSnapshot?
+    private var isCurrentSelection = false
+    private var insertionBefore: Bool?
+
+    var visualStateForTesting: (selected: Bool, previous: Bool, dirty: Bool) {
+        (isCurrentSelection, false, snapshot?.isDirty == true)
+    }
+
+    init(tabID: UUID) {
+        self.tabID = tabID
+        super.init(frame: .zero)
+        layer.cornerCurve = .continuous
+        layer.cornerRadius = 8
+        layer.borderWidth = 0.5
+        clipsToBounds = false
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        addTarget(self, action: #selector(selectTab), for: .touchUpInside)
+
+        remoteLabel.text = "Remote"
+        remoteLabel.font = .systemFont(ofSize: 9, weight: .semibold)
+        remoteLabel.textColor = .secondaryLabel
+        remoteLabel.textAlignment = .center
+        remoteLabel.layer.cornerRadius = 5
+        remoteLabel.layer.backgroundColor = UIColor.tintColor.withAlphaComponent(0.12).cgColor
+        remoteLabel.clipsToBounds = true
+        remoteLabel.isAccessibilityElement = false
+        addSubview(remoteLabel)
+
+        titleLabel.font = .systemFont(ofSize: 12)
+        titleLabel.textColor = .secondaryLabel
+        titleLabel.lineBreakMode = .byTruncatingMiddle
+        titleLabel.numberOfLines = 1
+        titleLabel.isAccessibilityElement = false
+        addSubview(titleLabel)
+
+        lockImage.image = UIImage(systemName: "lock.fill")
+        lockImage.tintColor = .secondaryLabel
+        lockImage.contentMode = .scaleAspectFit
+        lockImage.isAccessibilityElement = false
+        addSubview(lockImage)
+
+        dirtyIndicator.backgroundColor = .systemOrange
+        dirtyIndicator.layer.cornerRadius = 3
+        dirtyIndicator.isAccessibilityElement = false
+        addSubview(dirtyIndicator)
+
+        var closeConfiguration = UIButton.Configuration.plain()
+        closeConfiguration.image = UIImage(systemName: "xmark")
+        closeConfiguration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 10, weight: .semibold)
+        closeConfiguration.contentInsets = .zero
+        closeButton.configuration = closeConfiguration
+        closeButton.accessibilityHint = "Closes this editor tab"
+        closeButton.addTarget(self, action: #selector(closeTab), for: .touchUpInside)
+        addSubview(closeButton)
+
+        selectionIndicator.backgroundColor = .tintColor
+        selectionIndicator.layer.cornerRadius = 1
+        selectionIndicator.isAccessibilityElement = false
+        addSubview(selectionIndicator)
+
+        addInteraction(dragInteraction)
+        addInteraction(dropInteraction)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let closeWidth: CGFloat = 36
+        let sidePadding: CGFloat = 10
+        let remoteWidth: CGFloat = snapshot?.isRemote == true ? 43 : 0
+        let lockWidth: CGFloat = snapshot?.isReadOnly == true ? 13 : 0
+        let dirtyWidth: CGFloat = snapshot?.isDirty == true ? 6 : 0
+        let remoteGap: CGFloat = remoteWidth > 0 ? 6 : 0
+        let lockGap: CGFloat = lockWidth > 0 ? 4 : 0
+        let dirtyGap: CGFloat = dirtyWidth > 0 ? 5 : 0
+
+        closeButton.frame = CGRect(x: bounds.width - closeWidth, y: 0, width: closeWidth, height: bounds.height)
+        remoteLabel.frame = CGRect(x: sidePadding, y: max(7, bounds.height - 22), width: remoteWidth, height: 15)
+        let titleX = sidePadding + remoteWidth + remoteGap
+        let reservedWidth = closeWidth + lockWidth + lockGap + dirtyWidth + dirtyGap + 4
+        titleLabel.frame = CGRect(
+            x: titleX,
+            y: max(6, bounds.height - 23),
+            width: max(12, bounds.width - titleX - reservedWidth),
+            height: 18
+        )
+        lockImage.frame = CGRect(x: titleLabel.frame.maxX + lockGap, y: max(8, bounds.height - 20), width: lockWidth, height: 13)
+        dirtyIndicator.frame = CGRect(x: lockImage.frame.maxX + dirtyGap, y: bounds.midY - 3, width: dirtyWidth, height: dirtyWidth)
+        selectionIndicator.frame = CGRect(x: 8, y: bounds.height - 2, width: max(0, bounds.width - 16), height: 2)
+
+        if let insertionBefore {
+            selectionIndicator.frame = CGRect(
+                x: insertionBefore ? -2 : bounds.width,
+                y: 3,
+                width: 2,
+                height: max(0, bounds.height - 6)
+            )
+        }
+    }
+
+    func apply(
+        snapshot: MobileNativeFileTabSnapshot,
+        isSelected: Bool,
+        allowsReordering: Bool
+    ) {
+        self.snapshot = snapshot
+        isCurrentSelection = isSelected
+        titleLabel.text = snapshot.title
+        titleLabel.font = .systemFont(ofSize: 12, weight: isSelected ? .semibold : .regular)
+        titleLabel.textColor = isSelected ? .label : .secondaryLabel
+        remoteLabel.isHidden = !snapshot.isRemote
+        lockImage.isHidden = !snapshot.isReadOnly
+        dirtyIndicator.isHidden = !snapshot.isDirty
+        closeButton.accessibilityLabel = "Close \(snapshot.title)"
+        accessibilityLabel = accessibilityLabel(for: snapshot)
+        accessibilityValue = isSelected ? "Selected" : nil
+        accessibilityHint = allowsReordering
+            ? "Double tap to select. Drag to reorder tabs."
+            : "Double tap to select this editor tab."
+        accessibilityTraits = isSelected ? [.button, .selected] : .button
+        self.allowsReordering = allowsReordering
+        updateAppearance()
+        setNeedsLayout()
+    }
+
+    override var isHighlighted: Bool {
+        didSet { updateAppearance() }
+    }
+
+    private func updateAppearance() {
+        let fillColor: UIColor
+        if isCurrentSelection {
+            fillColor = tintColor.withAlphaComponent(0.14)
+        } else if isHighlighted {
+            fillColor = UIColor.label.withAlphaComponent(0.10)
+        } else {
+            // Keep inactive tabs legible against both light and dark toolbar
+            // materials without introducing the heavy gray slab seen in the
+            // system secondary fill on translucent surfaces.
+            fillColor = UIColor.label.withAlphaComponent(0.055)
+        }
+        backgroundColor = fillColor
+        layer.borderColor = isCurrentSelection
+            ? tintColor.withAlphaComponent(0.28).cgColor
+            : UIColor.separator.withAlphaComponent(0.18).cgColor
+        selectionIndicator.isHidden = insertionBefore == nil && !isCurrentSelection
+        selectionIndicator.backgroundColor = insertionBefore == nil ? tintColor : .systemBlue
+    }
+
+    private func updateAccessibilityActions() {
+        var actions = [
+            UIAccessibilityCustomAction(name: "Close Tab", target: self, selector: #selector(closeForAccessibility))
+        ]
+        guard allowsReordering else {
+            accessibilityCustomActions = actions
+            return
+        }
+        actions.append(contentsOf: [
+            UIAccessibilityCustomAction(name: "Move Tab Left", target: self, selector: #selector(moveLeftForAccessibility)),
+            UIAccessibilityCustomAction(name: "Move Tab Right", target: self, selector: #selector(moveRightForAccessibility))
+        ])
+        accessibilityCustomActions = actions
+    }
+
+    private func accessibilityLabel(for snapshot: MobileNativeFileTabSnapshot) -> String {
+        var parts = [snapshot.title, snapshot.isRemote ? "remote document" : "local document"]
+        if snapshot.isReadOnly { parts.append("read only") }
+        if snapshot.isDirty { parts.append("unsaved changes") }
+        return parts.joined(separator: ", ")
+    }
+
+    @objc private func selectTab() { onSelect?(tabID) }
+    @objc private func closeTab() { onClose?(tabID) }
+
+    @objc private func closeForAccessibility() -> Bool {
+        onClose?(tabID)
+        return true
+    }
+
+    @objc private func moveLeftForAccessibility() -> Bool {
+        moveForAccessibility(offset: -1)
+    }
+
+    @objc private func moveRightForAccessibility() -> Bool {
+        moveForAccessibility(offset: 1)
+    }
+
+    private func moveForAccessibility(offset: Int) -> Bool {
+        guard let bar = superview?.superview?.superview as? MobileNativeFileTabBarView,
+              let index = bar.orderedTabIDs.firstIndex(of: tabID) else { return false }
+        let destinationIndex = index + offset
+        guard bar.orderedTabIDs.indices.contains(destinationIndex) else { return false }
+        onMove?(tabID, bar.orderedTabIDs[destinationIndex], offset < 0)
+        return true
+    }
+
+    func dragInteraction(_ interaction: UIDragInteraction, itemsForBeginning session: UIDragSession) -> [UIDragItem] {
+        guard allowsReordering else { return [] }
+        let provider = NSItemProvider(object: tabID.uuidString as NSString)
+        let item = UIDragItem(itemProvider: provider)
+        item.localObject = tabID
+        return [item]
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
+        guard allowsReordering,
+              let sourceID = session.items.first?.localObject as? UUID,
+              sourceID != tabID else {
+            insertionBefore = nil
+            updateAppearance()
+            return UIDropProposal(operation: .forbidden)
+        }
+        insertionBefore = session.location(in: self).x < bounds.midX
+        updateAppearance()
+        setNeedsLayout()
+        return UIDropProposal(operation: .move)
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidExit session: UIDropSession) {
+        insertionBefore = nil
+        updateAppearance()
+        setNeedsLayout()
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, performDrop session: UIDropSession) {
+        defer {
+            insertionBefore = nil
+            updateAppearance()
+            setNeedsLayout()
+        }
+        guard let sourceID = session.items.first?.localObject as? UUID,
+              sourceID != tabID else { return }
+        onMove?(sourceID, tabID, insertionBefore ?? true)
+    }
+}
+#endif

--- a/Neon Vision Editor/UI/NeonSettingsSyncModifier.swift
+++ b/Neon Vision Editor/UI/NeonSettingsSyncModifier.swift
@@ -11,9 +11,6 @@ struct AppearanceThemeSettingsSyncModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onAppear {
-                applyResult(AppearanceThemeCloudSync.syncIfEnabled())
-            }
             .onReceive(NotificationCenter.default.publisher(for: NSUbiquitousKeyValueStore.didChangeExternallyNotification)) { _ in
                 applyResult(AppearanceThemeCloudSync.syncIfEnabled())
             }

--- a/Neon Vision Editor/UI/NeonSettingsView.swift
+++ b/Neon Vision Editor/UI/NeonSettingsView.swift
@@ -941,6 +941,15 @@ struct NeonSettingsView: View {
             }
 #endif
         }
+#if os(macOS)
+        // Native macOS preferences should switch panes without the implicit
+        // TabView transition. That transition keeps the old pane in the view
+        // graph while the new pane is measured, which makes the window appear
+        // to rearrange before its final height is applied.
+        .transaction { transaction in
+            transaction.animation = nil
+        }
+#endif
 #if os(iOS) || os(visionOS)
         .animation(.easeOut(duration: 0.22), value: settingsActiveTab)
 #endif
@@ -1230,9 +1239,18 @@ struct NeonSettingsView: View {
             SettingsWindowConfigurator(
                 minSize: macSettingsWindowSize.min,
                 idealSize: macSettingsWindowSize.ideal,
-                preferredContentHeight: macSettingsContentHeights[settingsActiveTab].map {
-                    $0 + UI.macSettingsToolbarContentMargin
-                },
+                editorWindowNumber: WindowViewModelRegistry.shared.windowNumber(for: editorViewModel),
+                themeBackgroundRaw: colorToHex(
+                    currentEditorTheme(colorScheme: effectiveSettingsColorScheme).background
+                ),
+                opaqueEditorCanvasEnabled: opaqueEditorSurfaceMac,
+                // Keep a target available in the same update as the tab
+                // selection. The measured value replaces this estimate as
+                // soon as the selected pane reports its natural height.
+                preferredContentHeight: (
+                    macSettingsContentHeights[settingsActiveTab]
+                        ?? Self.macSettingsEstimatedContentHeight(for: settingsActiveTab)
+                ) + UI.macSettingsToolbarContentMargin,
                 translucentEnabled: usesTranslucentSettingsSurface,
                 translucencyModeRaw: macTranslucencyModeRaw,
                 appearanceRaw: appearance,
@@ -1452,19 +1470,8 @@ struct NeonSettingsView: View {
 
 #if os(macOS)
     private func applyAppearanceImmediately() {
-        let target: NSAppearance?
-        switch appearance {
-        case "light":
-            target = NSAppearance(named: .aqua)
-        case "dark":
-            target = NSAppearance(named: .darkAqua)
-        default:
-            target = nil
-        }
-        NSApp.appearance = target
+        ReleaseRuntimePolicy.applyMacApplicationAppearance(appearance)
         for window in NSApp.windows {
-            window.appearance = target
-            window.contentView?.appearance = target
             window.contentView?.needsDisplay = true
         }
     }
@@ -6426,7 +6433,9 @@ struct NeonSettingsView: View {
                   let height = heights[tabID],
                   height > 0,
                   abs((macSettingsContentHeights[tabID] ?? 0) - height) > 0.5 else { return }
-            macSettingsContentHeights[tabID] = height
+            withTransaction(Transaction(animation: nil)) {
+                macSettingsContentHeights[tabID] = height
+            }
             Self.storeMacSettingsContentHeights(macSettingsContentHeights)
         }
 #else
@@ -6528,17 +6537,26 @@ struct NeonSettingsView: View {
     }
 
     private var settingsWindowBackground: AnyShapeStyle {
-        guard usesTranslucentSettingsSurface else {
-            return AnyShapeStyle(Color(nsColor: .windowBackgroundColor))
+        let themeBackground = currentEditorTheme(colorScheme: effectiveSettingsColorScheme).background
+        if usesTranslucentSettingsSurface {
+            let nativeSurface = SettingsWindowConfigurator.settingsWindowBackgroundColor(
+                translucentEnabled: true,
+                translucencyModeRaw: macTranslucencyModeRaw,
+                appearanceRaw: appearance,
+                effectiveColorScheme: effectiveSettingsColorScheme
+            )
+            return AnyShapeStyle(Color(nsColor: nativeSurface))
         }
-        // Use the exact same calibrated color as the native window bridge. This
-        // keeps the header, tab strip, divider area, and content at one alpha.
-        return AnyShapeStyle(Color(nsColor: SettingsWindowConfigurator.settingsWindowBackgroundColor(
-            translucentEnabled: true,
-            translucencyModeRaw: macTranslucencyModeRaw,
-            appearanceRaw: appearance,
-            effectiveColorScheme: effectiveSettingsColorScheme
-        )))
+        guard opaqueEditorSurfaceMac else {
+            let nativeSurface = SettingsWindowConfigurator.settingsWindowBackgroundColor(
+                translucentEnabled: false,
+                translucencyModeRaw: macTranslucencyModeRaw,
+                appearanceRaw: appearance,
+                effectiveColorScheme: effectiveSettingsColorScheme
+            )
+            return AnyShapeStyle(Color(nsColor: nativeSurface))
+        }
+        return AnyShapeStyle(themeBackground)
     }
 #endif
 
@@ -6785,7 +6803,8 @@ struct NeonSettingsView: View {
     }
 
     private var macSettingsWindowSize: (min: NSSize, ideal: NSSize) {
-        // Keep a stable window envelope across tabs to avoid toolbar-tab jump/overflow relayout.
+        // Keep width and safety bounds stable; the configurator applies each
+        // pane's measured natural height to the native window.
         Self.macSettingsWindowSizePolicy()
     }
 
@@ -6794,6 +6813,23 @@ struct NeonSettingsView: View {
         // safe single-column layout before either form card can overlap, while
         // Toolbar retains enough room for two readable preset cards.
         (NSSize(width: 600, height: 320), NSSize(width: 900, height: 1120))
+    }
+
+    /// Supplies a deterministic target while a newly selected pane is being
+    /// mounted. SwiftUI only publishes the pane's measured height after that
+    /// mount, so waiting for the preference leaves AppKit displaying the old
+    /// window frame during the tab transition.
+    nonisolated static func macSettingsEstimatedContentHeight(for tabID: String) -> CGFloat {
+        switch tabID {
+        case "ai":
+            800
+        case "editor", "toolbar", "themes", "support", "remote", "shortcuts":
+            700
+        case "templates":
+            560
+        default:
+            760
+        }
     }
 
     nonisolated static func macSettingsInitialWindowSize() -> NSSize {
@@ -6805,12 +6841,7 @@ struct NeonSettingsView: View {
         // Bootstrap from the active pane, then replace this estimate with its
         // measured height. This matches native dynamic Preferences windows:
         // each pane gets its own natural height without a fixed global frame.
-        let fallbackContentHeight: CGFloat = switch activeTab {
-        case "ai": 800
-        case "editor", "toolbar", "themes", "support", "remote", "shortcuts": 700
-        case "templates": 560
-        default: 760
-        }
+        let fallbackContentHeight = macSettingsEstimatedContentHeight(for: activeTab)
         let contentHeight = measuredContentHeight ?? fallbackContentHeight
         let windowHeight = min(
             max(contentHeight + 20, policy.min.height),
@@ -7197,6 +7228,9 @@ private enum DefaultFileAssociation {
 struct SettingsWindowConfigurator: NSViewRepresentable {
     let minSize: NSSize
     let idealSize: NSSize
+    let editorWindowNumber: Int?
+    let themeBackgroundRaw: String
+    let opaqueEditorCanvasEnabled: Bool
     let preferredContentHeight: CGFloat?
     let translucentEnabled: Bool
     let translucencyModeRaw: String
@@ -7208,6 +7242,10 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
         var pendingApply: DispatchWorkItem?
         var lastTranslucentEnabled: Bool?
         var lastTranslucencyModeRaw: String?
+        var lastAppearanceRaw: String?
+        var lastEffectiveColorScheme: ColorScheme?
+        var lastThemeBackgroundRaw: String?
+        var lastOpaqueEditorCanvasEnabled: Bool?
         var didConfigureWindowChrome = false
         var lastPreferredContentHeight: CGFloat?
         var stableTopEdge: CGFloat?
@@ -7238,6 +7276,29 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
+        let coordinator = context.coordinator
+        let preferredHeightChanged: Bool = {
+            guard let preferredContentHeight else {
+                return coordinator.lastPreferredContentHeight != nil
+            }
+            guard let lastPreferredContentHeight = coordinator.lastPreferredContentHeight else {
+                return true
+            }
+            return abs(lastPreferredContentHeight - preferredContentHeight) > 1
+        }()
+        if coordinator.didInitialApply,
+           coordinator.lastTranslucentEnabled == translucentEnabled,
+           coordinator.lastTranslucencyModeRaw == translucencyModeRaw,
+           coordinator.lastAppearanceRaw == appearanceRaw,
+           coordinator.lastEffectiveColorScheme == effectiveColorScheme,
+           coordinator.lastThemeBackgroundRaw == themeBackgroundRaw,
+           coordinator.lastOpaqueEditorCanvasEnabled == opaqueEditorCanvasEnabled,
+           !preferredHeightChanged {
+            // Settings controls can invalidate the parent view frequently. Do
+            // not re-enter AppKit window layout for changes that do not affect
+            // the Settings window's actual chrome or surface.
+            return
+        }
         scheduleApply(to: nsView.window, coordinator: context.coordinator)
     }
 
@@ -7251,15 +7312,10 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
             apply(to: window, coordinator: coordinator)
             return
         }
-        let work = DispatchWorkItem { [weak window, weak coordinator] in
-            guard let window, let coordinator else { return }
-            apply(to: window, coordinator: coordinator)
-        }
-        coordinator.pendingApply = work
-        // The Settings scene applies its default/restored frame after the first view update.
-        // Apply a measured content height only after that layout pass has completed.
-        let delay: DispatchTimeInterval = coordinator.didInitialApply ? .milliseconds(150) : .milliseconds(0)
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        // The target height is already part of this representable update. A
+        // main-queue hop lets SwiftUI paint the old pane first and exposes the
+        // window-frame correction as visible movement, so apply synchronously.
+        apply(to: window, coordinator: coordinator)
     }
 
     private func apply(to window: NSWindow?, coordinator: Coordinator) {
@@ -7267,10 +7323,15 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
         ensureObservers(for: window, coordinator: coordinator)
         coordinator.lastTranslucentEnabled = translucentEnabled
         coordinator.lastTranslucencyModeRaw = translucencyModeRaw
+        coordinator.lastAppearanceRaw = appearanceRaw
+        coordinator.lastEffectiveColorScheme = effectiveColorScheme
+        coordinator.lastThemeBackgroundRaw = themeBackgroundRaw
+        coordinator.lastOpaqueEditorCanvasEnabled = opaqueEditorCanvasEnabled
         let isInitialLayout = !coordinator.didInitialApply
 
         if isInitialLayout {
             enforceResizableSettingsWindowBounds(on: window)
+            centerOverEditorWindow(window)
         }
 
         if !coordinator.didConfigureWindowChrome {
@@ -7295,6 +7356,9 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
             coordinator.stableTopEdge = window.frame.maxY
         }
         if let preferredContentHeight,
+           (isInitialLayout || coordinator.lastPreferredContentHeight.map {
+               abs($0 - preferredContentHeight) > 1
+           } ?? true),
            coordinator.lastPreferredContentHeight != preferredContentHeight {
             resizeHeight(
                 on: window,
@@ -7304,19 +7368,9 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
             coordinator.lastPreferredContentHeight = preferredContentHeight
         }
         window.isOpaque = !translucentEnabled
-        let windowAppearance: NSAppearance?
-        switch appearanceRaw {
-        case "light":
-            windowAppearance = NSAppearance(named: .aqua)
-        case "dark":
-            windowAppearance = NSAppearance(named: .darkAqua)
-        default:
-            // Inherit the current macOS appearance instead of retaining a
-            // previously forced Dark/Light appearance on this window.
-            windowAppearance = nil
-        }
-        window.appearance = windowAppearance
-        window.contentView?.appearance = windowAppearance
+        // The application owns the explicit Light/Dark override. The Settings
+        // window must inherit it so System mode cannot retain the prior mode.
+        ReleaseRuntimePolicy.clearMacWindowAppearanceOverrides([window])
         // Use one native surface for the titlebar and content. Without this
         // explicit titlebar background, AppKit can retain its default white
         // titlebar even while the Settings content is translucent.
@@ -7336,6 +7390,19 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
         window.contentMinSize = minSize
         window.contentMaxSize = maximumSize
         window.standardWindowButton(.zoomButton)?.isEnabled = true
+    }
+
+    private func centerOverEditorWindow(_ settingsWindow: NSWindow) {
+        guard let editorWindowNumber,
+              let editorWindow = NSApp.window(withWindowNumber: editorWindowNumber),
+              editorWindow !== settingsWindow,
+              editorWindow.isVisible else { return }
+        let editorFrame = editorWindow.frame
+        let origin = NSPoint(
+            x: editorFrame.midX - settingsWindow.frame.width / 2,
+            y: editorFrame.midY - settingsWindow.frame.height / 2
+        )
+        settingsWindow.setFrameOrigin(origin)
     }
 
     private func maximumWindowSize(for window: NSWindow) -> NSSize {
@@ -7412,24 +7479,30 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
         switch translucencyModeRaw {
         case "subtle":
             whiteLevel = isDark ? 0.18 : 0.90
-            alpha = 0.92
+            alpha = 0.96
         case "vibrant":
             whiteLevel = isDark ? 0.12 : 0.82
-            alpha = 0.84
+            alpha = 0.90
         default:
             whiteLevel = isDark ? 0.15 : 0.86
-            alpha = 0.88
+            alpha = 0.93
         }
         return NSColor(calibratedWhite: whiteLevel, alpha: alpha)
     }
 
     private func translucencyEnabledColor(enabled: Bool) -> NSColor {
-        Self.settingsWindowBackgroundColor(
+        let nativeSurface = Self.settingsWindowBackgroundColor(
             translucentEnabled: enabled,
             translucencyModeRaw: translucencyModeRaw,
             appearanceRaw: appearanceRaw,
             effectiveColorScheme: effectiveColorScheme
         )
+        if enabled || opaqueEditorCanvasEnabled {
+            let fallback = Color(nsColor: nativeSurface.withAlphaComponent(1))
+            let themeColor = NSColor(colorFromHex(themeBackgroundRaw, fallback: fallback))
+            return enabled ? nativeSurface : themeColor.withAlphaComponent(1)
+        }
+        return nativeSurface.withAlphaComponent(1)
     }
 
     private func ensureObservers(for window: NSWindow, coordinator: Coordinator) {

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -1202,6 +1202,7 @@ struct FindReplaceWindowPresenter: NSViewRepresentable {
 struct DetachedPreviewWindowPresenter: NSViewRepresentable {
     @Binding var isPresented: Bool
     let title: String
+    let metadata: String?
     let html: String
     let baseURL: URL?
     @Environment(\.colorScheme) private var colorScheme
@@ -1246,6 +1247,7 @@ struct DetachedPreviewWindowPresenter: NSViewRepresentable {
         func content() -> DetachedPreviewWindowView {
             DetachedPreviewWindowView(
                 title: self.parent.title,
+                metadata: self.parent.metadata,
                 html: self.parent.html,
                 baseURL: self.parent.baseURL,
                 editorBackground: self.parent.editorBackground,
@@ -1335,8 +1337,10 @@ struct DetachedPreviewWindowPresenter: NSViewRepresentable {
 @MainActor
 struct DetachedPreviewWindowView: View {
     static let quickLookGlassTintOpacity = 0.08
+    private static let windowCornerRadius: CGFloat = 14
 
     let title: String
+    let metadata: String?
     let html: String
     let baseURL: URL?
     let editorBackground: Color
@@ -1374,6 +1378,13 @@ struct DetachedPreviewWindowView: View {
                 Text(title)
                     .font(.headline)
                 Spacer()
+                if let metadata {
+                    Text(metadata)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                }
                 Button(action: onClose) {
                     Image(systemName: "xmark")
                 }
@@ -1389,14 +1400,15 @@ struct DetachedPreviewWindowView: View {
         }
         .background {
             if usesQuickLookTransparency {
-                Rectangle()
+                RoundedRectangle(cornerRadius: Self.windowCornerRadius, style: .continuous)
                     .fill(.thinMaterial)
                     .overlay(quickLookGlassTint)
             } else {
-                Rectangle()
+                RoundedRectangle(cornerRadius: Self.windowCornerRadius, style: .continuous)
                     .fill(surfaceBackground)
             }
         }
+        .clipShape(RoundedRectangle(cornerRadius: Self.windowCornerRadius, style: .continuous))
     }
 
     private var quickLookGlassTint: Color {

--- a/Neon Vision Editor/UI/SidebarViews.swift
+++ b/Neon Vision Editor/UI/SidebarViews.swift
@@ -93,7 +93,14 @@ struct SidebarView: View {
             #if os(macOS)
             return AnyShapeStyle(Color.clear)
             #else
-            return AnyShapeStyle(.ultraThinMaterial)
+            // Both iPad sidebars must resolve to the same surface color. Two
+            // independent materials sample different content behind each
+            // card, producing visibly different colors in translucent mode.
+            return AnyShapeStyle(
+                currentEditorTheme(colorScheme: colorScheme)
+                    .background
+                    .opacity(colorScheme == .dark ? 0.82 : 0.90)
+            )
             #endif
         }
 #if os(macOS)
@@ -319,7 +326,11 @@ struct SidebarView: View {
 
     private var sidebarOuterPaddingInsets: EdgeInsets {
 #if os(iOS)
-        EdgeInsets(top: 0, leading: 10, bottom: 10, trailing: 10)
+        // Match the project sidebar's iPad card inset on every edge so the
+        // TOC surface shares its height and boundary with the adjacent bar.
+        UIDevice.current.userInterfaceIdiom == .pad
+            ? EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 6)
+            : EdgeInsets(top: 0, leading: 10, bottom: 10, trailing: 10)
 #else
         EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 4)
 #endif
@@ -1558,7 +1569,13 @@ struct ProjectStructureSidebarView: View {
             #if os(macOS)
             return AnyShapeStyle(Color.clear)
             #else
-            return AnyShapeStyle(.ultraThinMaterial)
+            // Keep the project sidebar and TOC sidebar on one resolved color
+            // instead of compositing separate materials over different panes.
+            return AnyShapeStyle(
+                currentEditorTheme(colorScheme: colorScheme)
+                    .background
+                    .opacity(colorScheme == .dark ? 0.82 : 0.90)
+            )
             #endif
         }
 #if os(macOS)
@@ -1702,9 +1719,9 @@ struct ProjectStructureSidebarView: View {
     private var sidebarContainerBorderOverlay: some View {
 #if os(macOS)
         if translucentBackgroundEnabled {
-            // Continue the editor/window material through the boundary instead
-            // of painting a bright outline or exposing a clear hole.
-            sidebarContainerShape.stroke(sidebarSurfaceFill, lineWidth: 1.2)
+            // Keep the window material transparent while retaining a subtle
+            // edge so the sidebar remains legible against the desktop.
+            sidebarContainerShape.stroke(sidebarSurfaceStroke, lineWidth: 1.2)
         } else {
             sidebarContainerShape.stroke(sidebarSurfaceStroke, lineWidth: 1.2)
         }

--- a/Neon Vision EditorTests/ContentViewLayoutTests.swift
+++ b/Neon Vision EditorTests/ContentViewLayoutTests.swift
@@ -153,23 +153,26 @@ final class ContentViewLayoutTests: XCTestCase {
         )
     }
 
-    func testCollapsedFormattingControlUsesOpaqueSurfaceWhileExpandedControlMayUseGlass() {
-        XCTAssertFalse(
+    func testFormattingControlUsesGlassWhenEitherWindowOrToolbarTranslucencyIsEnabled() {
+        XCTAssertTrue(
             MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
                 isCollapsed: true,
-                liquidGlassEnabled: true
+                liquidGlassEnabled: false,
+                windowTranslucent: true
             )
         )
         XCTAssertTrue(
             MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
                 isCollapsed: false,
-                liquidGlassEnabled: true
+                liquidGlassEnabled: true,
+                windowTranslucent: false
             )
         )
         XCTAssertFalse(
             MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
                 isCollapsed: false,
-                liquidGlassEnabled: false
+                liquidGlassEnabled: false,
+                windowTranslucent: false
             )
         )
     }

--- a/Neon Vision EditorTests/MacNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MacNativeFileTabBarTests.swift
@@ -1,0 +1,247 @@
+#if os(macOS)
+import XCTest
+@testable import Neon_Vision_Editor
+
+@MainActor
+final class MacNativeFileTabBarTests: XCTestCase {
+    func testApplyingTabSnapshotsKeepsStableViewsAndSelection() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MacNativeFileTabBarView()
+        let initial = [
+            snapshot(id: firstID, title: "First.swift"),
+            snapshot(id: secondID, title: "Second.md")
+        ]
+
+        view.apply(tabs: initial, selectedTabID: firstID)
+        XCTAssertEqual(view.orderedTabIDs, [firstID, secondID])
+        XCTAssertEqual(view.selectedTabID, firstID)
+        XCTAssertEqual(view.managedTabViewCount, 2)
+
+        view.apply(
+            tabs: [
+                snapshot(id: secondID, title: "Renamed.md", isDirty: true),
+                snapshot(id: firstID, title: "First.swift")
+            ],
+            selectedTabID: secondID
+        )
+
+        XCTAssertEqual(view.orderedTabIDs, [secondID, firstID])
+        XCTAssertEqual(view.selectedTabID, secondID)
+        XCTAssertEqual(view.managedTabViewCount, 2)
+    }
+
+    func testRemovingTabDropsItsManagedView() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MacNativeFileTabBarView()
+        view.apply(
+            tabs: [snapshot(id: firstID, title: "One"), snapshot(id: secondID, title: "Two")],
+            selectedTabID: firstID
+        )
+
+        view.apply(tabs: [snapshot(id: secondID, title: "Two")], selectedTabID: secondID)
+
+        XCTAssertEqual(view.orderedTabIDs, [secondID])
+        XCTAssertEqual(view.managedTabViewCount, 1)
+    }
+
+    func testNativeTabActionsRetainExistingViewModelRouting() {
+        let sourceID = UUID()
+        let destinationID = UUID()
+        let view = MacNativeFileTabBarView()
+        var selectedID: UUID?
+        var closedID: UUID?
+        var move: (UUID, UUID, Bool)?
+        view.onSelect = { selectedID = $0 }
+        view.onClose = { closedID = $0 }
+        view.onMove = { move = ($0, $1, $2) }
+
+        view.selectTabForTesting(sourceID)
+        view.closeTabForTesting(destinationID)
+        view.moveTabForTesting(sourceID, destination: destinationID, before: false)
+
+        XCTAssertEqual(selectedID, sourceID)
+        XCTAssertEqual(closedID, destinationID)
+        XCTAssertEqual(move?.0, sourceID)
+        XCTAssertEqual(move?.1, destinationID)
+        XCTAssertEqual(move?.2, false)
+    }
+
+    func testKeyboardAdjacentSelectionUsesOrderedTabsAndStopsAtEdges() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MacNativeFileTabBarView()
+        var selectedIDs: [UUID] = []
+        view.onSelect = { selectedIDs.append($0) }
+        view.apply(
+            tabs: [snapshot(id: firstID, title: "One"), snapshot(id: secondID, title: "Two")],
+            selectedTabID: firstID
+        )
+
+        view.selectAdjacentTab(from: firstID, offset: 1)
+        view.selectAdjacentTab(from: firstID, offset: -1)
+        view.selectAdjacentTab(from: secondID, offset: 1)
+
+        XCTAssertEqual(selectedIDs, [secondID])
+    }
+
+    func testSelectedIndicatorStartsAtTheSelectedTabsLeadingEdge() throws {
+        let selectedID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 32))
+        view.apply(
+            tabs: [snapshot(id: UUID(), title: "One"), snapshot(id: selectedID, title: "Two")],
+            selectedTabID: selectedID
+        )
+
+        let indicatorFrame = try XCTUnwrap(view.selectionIndicatorFrameForTesting(selectedID))
+        XCTAssertEqual(indicatorFrame.minX, 8)
+        XCTAssertGreaterThan(indicatorFrame.width, 100)
+    }
+
+    func testInactiveTabsKeepAVisibleTranslucentBoundary() throws {
+        let inactiveID = UUID()
+        let selectedID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 32))
+        view.apply(
+            tabs: [snapshot(id: inactiveID, title: "Inactive"), snapshot(id: selectedID, title: "Selected")],
+            selectedTabID: selectedID
+        )
+
+        let inactiveState = try XCTUnwrap(view.visualStateForTesting(inactiveID))
+        XCTAssertGreaterThan(inactiveState.backgroundAlpha, 0)
+        XCTAssertEqual(inactiveState.borderWidth, 0.5)
+
+        let outline = try XCTUnwrap(view.outlineGeometryForTesting(inactiveID))
+        XCTAssertEqual(outline.pathBounds.minX, 0.25, accuracy: 0.001)
+        XCTAssertEqual(outline.pathBounds.minY, 0.25, accuracy: 0.001)
+        XCTAssertEqual(outline.pathBounds.maxX, outline.viewBounds.maxX - 0.25, accuracy: 0.001)
+        XCTAssertEqual(outline.pathBounds.maxY, outline.viewBounds.maxY - 0.25, accuracy: 0.001)
+    }
+
+    func testInactiveOutlineIsCompositedAboveTabControls() throws {
+        let id = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.apply(tabs: [snapshot(id: id, title: "Document")], selectedTabID: nil)
+
+        let state = try XCTUnwrap(view.visualStateForTesting(id))
+        XCTAssertGreaterThan(state.borderWidth, 0)
+        XCTAssertEqual(view.outlineZPositionForTesting(id), 10)
+
+        let borderBeforeHover = state.borderAlpha
+        view.setHoveredForTesting(id, hovered: true)
+        let borderDuringHover = try XCTUnwrap(view.visualStateForTesting(id)).borderAlpha
+        XCTAssertEqual(borderDuringHover, borderBeforeHover, accuracy: 0.001)
+    }
+
+    func testOpaqueLightCanvasUsesAVisibleInactiveOutline() throws {
+        let inactiveID = UUID()
+        let selectedID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.appearance = NSAppearance(named: .aqua)
+        view.usesOpaqueEditorCanvas = true
+        view.apply(
+            tabs: [snapshot(id: inactiveID, title: "Inactive"), snapshot(id: selectedID, title: "Selected")],
+            selectedTabID: selectedID
+        )
+
+        let inactiveState = try XCTUnwrap(view.visualStateForTesting(inactiveID))
+        XCTAssertEqual(inactiveState.borderAlpha, 0.32, accuracy: 0.001)
+
+        view.apply(
+            tabs: [snapshot(id: inactiveID, title: "Inactive"), snapshot(id: selectedID, title: "Selected")],
+            selectedTabID: inactiveID
+        )
+
+        let previouslySelectedState = try XCTUnwrap(view.visualStateForTesting(selectedID))
+        XCTAssertEqual(previouslySelectedState.borderAlpha, 0.32, accuracy: 0.001)
+    }
+
+    func testTabTitleIsAlignedTowardTheBottomEdge() throws {
+        let id = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 300, height: 42))
+        view.apply(tabs: [snapshot(id: id, title: "Document")], selectedTabID: id)
+
+        let layout = try XCTUnwrap(view.titleLayoutForTesting(id))
+        XCTAssertLessThanOrEqual(layout.tabBounds.height - layout.titleFrame.maxY, 5)
+        XCTAssertGreaterThan(layout.titleFrame.midY, layout.tabBounds.midY)
+    }
+
+    func testNewTabButtonHasDeliberateSpacingFromTabsAndWindowEdge() {
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.layoutSubtreeIfNeeded()
+
+        let layout = view.addButtonLayoutForTesting
+        XCTAssertEqual(layout.buttonFrame.width, 36)
+        XCTAssertGreaterThanOrEqual(layout.buttonFrame.minX - layout.tabsFrame.maxX, 8)
+        XCTAssertGreaterThanOrEqual(view.bounds.maxX - layout.buttonFrame.maxX, 10)
+    }
+
+    func testFilenameWidthsAreBoundedAndOverflowScrollsWithEdgeFades() {
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 520, height: 42))
+        let tabs = (0..<6).map { index in
+            snapshot(id: UUID(), title: "A-very-long-professional-document-name-\(index).swift")
+        }
+        view.apply(tabs: tabs, selectedTabID: tabs.first?.id)
+
+        let initial = view.horizontalScrollLayoutForTesting
+        XCTAssertGreaterThan(initial.documentWidth, initial.viewportWidth)
+        XCTAssertFalse(view.scrollEdgeFadeState.left)
+        XCTAssertTrue(view.scrollEdgeFadeState.right)
+
+        view.scrollToEndForTesting()
+        XCTAssertTrue(view.scrollEdgeFadeState.left)
+        XCTAssertFalse(view.scrollEdgeFadeState.right)
+    }
+
+    func testTabWidthTracksFilenameWithinStandardAndDoubleWidthLimits() throws {
+        let shortID = UUID()
+        let longID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 700, height: 42))
+        view.apply(
+            tabs: [
+                snapshot(id: shortID, title: "a.swift"),
+                snapshot(id: longID, title: String(repeating: "long-file-name-", count: 8) + ".swift")
+            ],
+            selectedTabID: shortID
+        )
+
+        let shortWidth = try XCTUnwrap(view.titleLayoutForTesting(shortID)?.tabBounds.width)
+        let longWidth = try XCTUnwrap(view.titleLayoutForTesting(longID)?.tabBounds.width)
+        XCTAssertEqual(shortWidth, 128)
+        XCTAssertGreaterThan(longWidth, shortWidth)
+        XCTAssertEqual(longWidth, 256)
+    }
+
+    func testDirtyColorSupersedesSelectionColor() throws {
+        let dirtyID = UUID()
+        let previousID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.apply(
+            tabs: [
+                snapshot(id: dirtyID, title: "Dirty", isDirty: true),
+                snapshot(id: previousID, title: "Previous")
+            ],
+            selectedTabID: dirtyID
+        )
+
+        let dirty = try XCTUnwrap(view.visualStateForTesting(dirtyID))
+        let previous = try XCTUnwrap(view.visualStateForTesting(previousID))
+        XCTAssertGreaterThan(dirty.backgroundAlpha, previous.backgroundAlpha)
+    }
+
+    private func snapshot(
+        id: UUID,
+        title: String,
+        isDirty: Bool = false
+    ) -> MacNativeFileTabSnapshot {
+        MacNativeFileTabSnapshot(
+            id: id,
+            title: title,
+            isDirty: isDirty,
+            isRemote: false,
+            isReadOnly: false
+        )
+    }
+}
+#endif

--- a/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
@@ -1,0 +1,158 @@
+#if os(iOS)
+import UIKit
+import XCTest
+@testable import Neon_Vision_Editor
+
+@MainActor
+final class MobileNativeFileTabBarTests: XCTestCase {
+    func testApplyingSnapshotsKeepsStableViewsAndSelectionHistory() throws {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MobileNativeFileTabBarView()
+
+        view.apply(
+            tabs: [snapshot(id: firstID, title: "First.swift"), snapshot(id: secondID, title: "Second.md")],
+            selectedTabID: firstID,
+        )
+        XCTAssertEqual(view.orderedTabIDs, [firstID, secondID])
+        XCTAssertEqual(view.managedTabViewCount, 2)
+
+        view.apply(
+            tabs: [snapshot(id: secondID, title: "Renamed.md", isDirty: true), snapshot(id: firstID, title: "First.swift")],
+            selectedTabID: secondID,
+        )
+
+        XCTAssertEqual(view.orderedTabIDs, [secondID, firstID])
+        XCTAssertEqual(view.selectedTabID, secondID)
+        XCTAssertEqual(view.managedTabViewCount, 2)
+        XCTAssertEqual(try XCTUnwrap(view.visualStateForTesting(secondID)).selected, true)
+        XCTAssertEqual(try XCTUnwrap(view.visualStateForTesting(secondID)).dirty, true)
+    }
+
+    func testRemovingTabDropsItsManagedView() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MobileNativeFileTabBarView()
+        view.apply(
+            tabs: [snapshot(id: firstID, title: "One"), snapshot(id: secondID, title: "Two")],
+            selectedTabID: firstID,
+        )
+
+        view.apply(tabs: [snapshot(id: secondID, title: "Two")], selectedTabID: secondID)
+
+        XCTAssertEqual(view.orderedTabIDs, [secondID])
+        XCTAssertEqual(view.managedTabViewCount, 1)
+    }
+
+    func testNativeActionsRetainExistingViewModelRouting() {
+        let sourceID = UUID()
+        let destinationID = UUID()
+        let view = MobileNativeFileTabBarView()
+        var selectedID: UUID?
+        var closedID: UUID?
+        var move: (UUID, UUID, Bool)?
+        var addCount = 0
+        view.onSelect = { selectedID = $0 }
+        view.onClose = { closedID = $0 }
+        view.onMove = { move = ($0, $1, $2) }
+        view.onAdd = { addCount += 1 }
+
+        view.selectTabForTesting(sourceID)
+        view.closeTabForTesting(destinationID)
+        view.moveTabForTesting(sourceID, destination: destinationID, before: false)
+        view.addTabForTesting()
+
+        XCTAssertEqual(selectedID, sourceID)
+        XCTAssertEqual(closedID, destinationID)
+        XCTAssertEqual(move?.0, sourceID)
+        XCTAssertEqual(move?.1, destinationID)
+        XCTAssertEqual(move?.2, false)
+        XCTAssertEqual(addCount, 1)
+    }
+
+    func testSelectedTabAccessibilityIncludesStateAndMetadata() throws {
+        let id = UUID()
+        let view = MobileNativeFileTabBarView()
+        view.apply(
+            tabs: [MobileNativeFileTabSnapshot(
+                id: id,
+                title: "Notes.md",
+                isDirty: true,
+                isRemote: true,
+                isReadOnly: true
+            )],
+            selectedTabID: id,
+        )
+
+        let state = try XCTUnwrap(view.accessibilityStateForTesting(id))
+        XCTAssertEqual(state.label, "Notes.md, remote document, read only, unsaved changes")
+        XCTAssertTrue(state.traits.contains(.button))
+        XCTAssertTrue(state.traits.contains(.selected))
+        XCTAssertEqual(view.accessibilityActionsForTesting(id)?.first, "Close Tab")
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            XCTAssertEqual(view.accessibilityActionsForTesting(id), ["Close Tab", "Move Tab Left", "Move Tab Right"])
+        }
+    }
+
+    func testAddButtonStaysOutsideHorizontallyScrollingTabs() {
+        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 390, height: 42))
+        view.apply(
+            tabs: (0..<12).map { snapshot(id: UUID(), title: "Document \($0)") },
+            selectedTabID: nil,
+        )
+        view.layoutIfNeeded()
+
+        XCTAssertEqual(view.addButtonFrameForTesting.width, 44)
+        XCTAssertGreaterThanOrEqual(view.addButtonFrameForTesting.minX - view.scrollViewFrameForTesting.maxX, 4)
+        XCTAssertEqual(view.scrollViewFrameForTesting.minX, 8)
+    }
+
+    func testSelectingOverflowingLastTabScrollsItIntoView() throws {
+        let ids = (0..<12).map { _ in UUID() }
+        let lastID = try XCTUnwrap(ids.last)
+        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 390, height: 42))
+        view.apply(
+            tabs: ids.enumerated().map { snapshot(id: $0.element, title: "Document \($0.offset)") },
+            selectedTabID: lastID,
+        )
+        view.layoutIfNeeded()
+
+        XCTAssertGreaterThan(view.horizontalContentWidthForTesting, view.scrollViewFrameForTesting.width)
+        XCTAssertGreaterThan(view.horizontalContentOffsetForTesting, 0)
+        XCTAssertGreaterThan(try XCTUnwrap(view.tabFrameForTesting(lastID)).minX, view.scrollViewFrameForTesting.width)
+    }
+
+    func testLargeSnapshotUpdateReusesViewsWithinInteractiveBudget() {
+        let ids = (0..<250).map { _ in UUID() }
+        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 1_024, height: 42))
+        let initial = ids.enumerated().map { snapshot(id: $0.element, title: "Document \($0.offset)") }
+        view.apply(tabs: initial, selectedTabID: ids.first)
+
+        let start = ProcessInfo.processInfo.systemUptime
+        view.apply(
+            tabs: initial.reversed().enumerated().map {
+                snapshot(id: $0.element.id, title: $0.element.title, isDirty: $0.offset.isMultiple(of: 3))
+            },
+            selectedTabID: ids.last,
+        )
+        let elapsed = ProcessInfo.processInfo.systemUptime - start
+
+        XCTAssertEqual(view.managedTabViewCount, ids.count)
+        XCTAssertLessThan(elapsed, 1)
+    }
+
+    private func snapshot(
+        id: UUID,
+        title: String,
+        isDirty: Bool = false
+    ) -> MobileNativeFileTabSnapshot {
+        MobileNativeFileTabSnapshot(
+            id: id,
+            title: title,
+            isDirty: isDirty,
+            isRemote: false,
+            isReadOnly: false
+        )
+    }
+}
+#endif

--- a/Neon Vision EditorTests/ReleaseRuntimePolicyTests.swift
+++ b/Neon Vision EditorTests/ReleaseRuntimePolicyTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 @testable import Neon_Vision_Editor
 
 
@@ -21,6 +24,48 @@ final class ReleaseRuntimePolicyTests: XCTestCase {
         XCTAssertNil(ReleaseRuntimePolicy.preferredColorScheme(for: "system"))
         XCTAssertNil(ReleaseRuntimePolicy.preferredColorScheme(for: "unknown"))
     }
+
+#if os(macOS)
+    func testMacAppearanceMappingAndSystemInheritance() {
+        XCTAssertEqual(ReleaseRuntimePolicy.appKitAppearance(for: "light")?.name, .aqua)
+        XCTAssertEqual(ReleaseRuntimePolicy.appKitAppearance(for: "dark")?.name, .darkAqua)
+        XCTAssertNil(ReleaseRuntimePolicy.appKitAppearance(for: "system"))
+
+        let originalApplicationAppearance = NSApp.appearance
+        let originalWindowAppearances = NSApp.windows.map {
+            ($0, $0.appearance, $0.contentView?.appearance)
+        }
+        defer {
+            NSApp.appearance = originalApplicationAppearance
+            for (window, windowAppearance, contentAppearance) in originalWindowAppearances {
+                window.appearance = windowAppearance
+                window.contentView?.appearance = contentAppearance
+            }
+        }
+
+        ReleaseRuntimePolicy.applyMacApplicationAppearance("light")
+        XCTAssertEqual(NSApp.appearance?.name, .aqua)
+        ReleaseRuntimePolicy.applyMacApplicationAppearance("dark")
+        XCTAssertEqual(NSApp.appearance?.name, .darkAqua)
+        ReleaseRuntimePolicy.applyMacApplicationAppearance("system")
+        XCTAssertNil(NSApp.appearance)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = NSView(frame: window.contentLayoutRect)
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.contentView?.appearance = NSAppearance(named: .darkAqua)
+
+        ReleaseRuntimePolicy.clearMacWindowAppearanceOverrides([window])
+
+        XCTAssertNil(window.appearance)
+        XCTAssertNil(window.contentView?.appearance)
+    }
+#endif
 
     func testFindNextMovesCursorForwardAndWraps() {
         let text = "alpha beta alpha"

--- a/Neon Vision EditorTests/WindowTranslucencyTests.swift
+++ b/Neon Vision EditorTests/WindowTranslucencyTests.swift
@@ -124,9 +124,9 @@ final class WindowTranslucencyTests: XCTestCase {
             effectiveColorScheme: .dark
         )
 
-        XCTAssertEqual(subtle.alphaComponent, 0.92, accuracy: 0.001)
-        XCTAssertEqual(balanced.alphaComponent, 0.88, accuracy: 0.001)
-        XCTAssertEqual(vibrant.alphaComponent, 0.84, accuracy: 0.001)
+        XCTAssertEqual(subtle.alphaComponent, 0.96, accuracy: 0.001)
+        XCTAssertEqual(balanced.alphaComponent, 0.93, accuracy: 0.001)
+        XCTAssertEqual(vibrant.alphaComponent, 0.90, accuracy: 0.001)
         XCTAssertGreaterThan(subtle.alphaComponent, balanced.alphaComponent)
         XCTAssertLessThan(vibrant.alphaComponent, balanced.alphaComponent)
         XCTAssertEqual(disabled, NSColor.windowBackgroundColor)


### PR DESCRIPTION
## Summary
- replace legacy tab chrome with native platform implementations
- keep tab borders stable across hover and appearance changes
- synchronize settings/window appearance and sidebar/editor surfaces

## Verification
- focused macOS MacNativeFileTabBarTests: 13/13 passed
- git diff --check passed

After merge, prepare the v1.7.0 release from develop and promote it through the protected main workflow.

## Summary by Sourcery

Adopt native platform tab chrome and unify appearance lifecycle handling across editor, settings, sidebar, and preview surfaces.

New Features:
- Replace custom macOS tab chrome with native AppKit tabs and add native iOS tab controls with selection, closing, reordering, scrolling, and accessibility support.
- Display file-size metadata in document and detached preview headers.

Bug Fixes:
- Stabilize macOS tab borders and appearance across hover, selection, scrolling, and light/dark transitions.
- Ensure System appearance clears stale window and content-view overrides.
- Prevent titlebar drag handling from interfering with editor interactions.

Enhancements:
- Synchronize window, sidebar, editor, toolbar, settings, and preview surfaces across translucency and appearance modes.
- Improve macOS settings-window sizing, positioning, and pane transitions.
- Align sidebar, resize-divider, editor gutter, and mobile chrome surfaces for consistent translucent and opaque rendering.

Tests:
- Add focused macOS and mobile native tab-bar coverage.
- Update layout, appearance, translucency, and runtime policy tests for the revised behavior.