### PR TITLE
Correct published release state

### DIFF
--- a/release/prepared-release.json
+++ b/release/prepared-release.json
@@ -5,7 +5,7 @@
   "build": 1032,
   "published_tag": "v1.6.3",
   "published_build": 1031,
-  "status": "prepared",
+  "status": "published",
   "cloud": {
     "product_id": "6BA578EC-8F26-47BC-81A9-94246EAF48E0",
     "max_number": 1031


### PR DESCRIPTION
Marks the existing v1.6.4 preparation manifest as published, matching main and the public GitHub release. This unblocks the v1.7.0 release-preparation state transition.

## Summary by Sourcery

Enhancements:
- Synchronize the v1.6.4 release preparation manifest with its published status to enable the next release preparation transition.