### PR TITLE
Add localized v1.7.0 release summaries

### DIFF
--- a/scripts/prepare_release_docs.py
+++ b/scripts/prepare_release_docs.py
@@ -588,6 +588,7 @@ def rebuild_changelog_page(page: str, changelog: str, current_tag: str) -> str:
 
 LOCALIZED_TIMELINE_COPY = {
     "de": {
+        "v1.7.0": ("Native Tabs und konsistente Fensterdarstellung", "Hält Tabs, Seitenleisten, Editorflächen und Einstellungen über macOS, iOS und iPadOS hinweg konsistent und stabil.", ["Tabs", "Darstellung", "Seitenleisten"]),
         "v1.6.4": ("Stabiles Tippen und zuverlässiges Fensterziehen", "Hält den macOS-Editor beim Tippen stabil und macht leere Bereiche der nativen Symbolleiste verschiebbar, ohne ihre Aktionen zu blockieren.", ["Editor", "Fenster", "Symbolleiste"]),
         "v1.6.3": ("Sofortiger Tabwechsel und reibungsloser Editor", "Beschleunigt den Wechsel zwischen Markdown- und Quelldateien und verschiebt Vorschau- sowie Layoutarbeit aus dem ersten Anzeigeframe.", ["Editor", "Leistung", "Tabs"]),
         "v1.6.2": ("Sichereres Speichern und zuverlässigere App-Starts", "Verbessert das Speichern externer Dokumente und erkennt Änderungen auf Netzlaufwerken, öffnet Textdateien mit unbekannten Endungen und macht die automatische Willkommenstour abschaltbar.", ["Dateisicherheit", "Textdateien", "Start"]),
@@ -610,6 +611,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor und Snapshots werden verlässlicher", "Verbessert Auswahl, Tastaturnavigation und Themes im macOS-Editor und erweitert den Code-Snapshot-Export.", ["Editor", "Themes", "Snapshots"]),
     },
     "da": {
+        "v1.7.0": ("Native faner og ensartet vinduesvisning", "Holder faner, sidepaneler, editorflader og indstillinger ensartede og stabile på macOS, iOS og iPadOS.", ["Faner", "Visning", "Sidepaneler"]),
         "v1.6.4": ("Stabil indtastning og pålidelig vinduesflytning", "Holder macOS-editoren stabil under indtastning og gør tomme områder i den native værktøjslinje flytbare uden at blokere dens handlinger.", ["Editor", "Vindue", "Værktøjslinje"]),
         "v1.6.3": ("Øjeblikkeligt faneskift og mere flydende editor", "Gør skift mellem Markdown- og kildefiler hurtigere og flytter forhåndsvisnings- og layoutarbejde efter den første visning.", ["Editor", "Ydeevne", "Faner"]),
         "v1.6.2": ("Sikrere lagring og mere pålidelig opstart", "Forbedrer lagring af eksterne dokumenter og registrering af ændringer på netværksdrev, åbner tekstfiler med ukendte filendelser og gør den automatiske velkomst valgfri.", ["Filsikkerhed", "Tekstfiler", "Opstart"]),
@@ -632,6 +634,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor og snapshots bliver mere pålidelige", "Forbedrer markering, tastaturnavigation og temaer i macOS-editoren og udvider eksporten af kodesnapshots.", ["Editor", "Temaer", "Snapshots"]),
     },
     "fr": {
+        "v1.7.0": ("Onglets natifs et apparence cohérente", "Garde les onglets, barres latérales, surfaces d’édition et réglages cohérents et stables sur macOS, iOS et iPadOS.", ["Onglets", "Apparence", "Barres latérales"]),
         "v1.6.4": ("Saisie stable et déplacement fiable des fenêtres", "Stabilise l’éditeur macOS pendant la saisie et rend les espaces vides de la barre d’outils déplaçables sans bloquer ses actions.", ["Éditeur", "Fenêtre", "Barre d’outils"]),
         "v1.6.3": ("Changement d’onglet instantané et éditeur plus fluide", "Accélère le passage entre fichiers Markdown et source et reporte le travail d’aperçu et de mise en page après le premier affichage.", ["Éditeur", "Performances", "Onglets"]),
         "v1.6.2": ("Enregistrement plus sûr et démarrage plus fiable", "Améliore l’enregistrement des documents externes et la détection des modifications réseau, ouvre les fichiers texte aux extensions inconnues et rend l’accueil automatique facultatif.", ["Sécurité des fichiers", "Fichiers texte", "Démarrage"]),
@@ -654,6 +657,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Éditeur et instantanés plus fiables", "Améliore la sélection, la navigation au clavier et les thèmes dans l’éditeur macOS, tout en enrichissant l’export d’instantanés de code.", ["Éditeur", "Thèmes", "Instantanés"]),
     },
     "es": {
+        "v1.7.0": ("Pestañas nativas y apariencia coherente", "Mantiene coherentes y estables las pestañas, barras laterales, superficies del editor y Ajustes en macOS, iOS y iPadOS.", ["Pestañas", "Apariencia", "Barras laterales"]),
         "v1.6.4": ("Escritura estable y movimiento fiable de ventanas", "Estabiliza el editor de macOS al escribir y permite mover la ventana desde los espacios vacíos de la barra nativa sin bloquear sus acciones.", ["Editor", "Ventana", "Barra"]),
         "v1.6.3": ("Cambio de pestaña instantáneo y editor más fluido", "Acelera el cambio entre archivos Markdown y de código y pospone el trabajo de vista previa y diseño tras el primer dibujo.", ["Editor", "Rendimiento", "Pestañas"]),
         "v1.6.2": ("Guardado más seguro e inicio más fiable", "Mejora el guardado de documentos externos y la detección de cambios en red, abre archivos de texto con extensiones desconocidas y permite desactivar la bienvenida automática.", ["Seguridad de archivos", "Archivos de texto", "Inicio"]),
@@ -676,6 +680,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor y capturas más fiables", "Mejora la selección, la navegación por teclado y los temas del editor de macOS, y amplía la exportación de capturas de código.", ["Editor", "Temas", "Capturas"]),
     },
     "ja": {
+        "v1.7.0": ("ネイティブタブと一貫したウインドウ表示", "macOS、iOS、iPadOS でタブ、サイドバー、エディタ面、設定の表示を一貫させ、安定させます。", ["タブ", "表示", "サイドバー"]),
         "v1.6.4": ("安定した入力と確実なウインドウ移動", "macOS エディタの入力中のちらつきを抑え、ネイティブツールバーの空白部分から操作を妨げずにウインドウを移動できます。", ["エディタ", "ウインドウ", "ツールバー"]),
         "v1.6.3": ("瞬時のタブ切り替えとより滑らかなエディタ", "Markdown とソースファイルの切り替えを高速化し、プレビューとレイアウト処理を初回表示後に行います。", ["エディタ", "パフォーマンス", "タブ"]),
         "v1.6.2": ("より安全な保存と安定した起動", "外部ドキュメントの保存とネットワーク上の変更検出を改善し、未知の拡張子のテキストファイルを開けるようにしました。自動ウェルカム画面も無効にできます。", ["ファイルの安全性", "テキストファイル", "起動"]),
@@ -698,6 +703,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("エディタとスナップショットをさらに信頼性向上", "macOS エディタの選択、キーボード操作、テーマを改善し、コードスナップショットの書き出しを拡充します。", ["エディタ", "テーマ", "スナップショット"]),
     },
     "zh-Hans": {
+        "v1.7.0": ("原生标签页与一致的窗口外观", "在 macOS、iOS 和 iPadOS 上保持标签页、侧边栏、编辑器表面和设置的一致性与稳定性。", ["标签页", "外观", "侧边栏"]),
         "v1.6.4": ("稳定输入与可靠的窗口拖动", "让 macOS 编辑器输入时保持稳定，并可从原生工具栏的空白区域移动窗口，同时不影响工具栏操作。", ["编辑器", "窗口", "工具栏"]),
         "v1.6.3": ("即时标签页切换与更流畅的编辑器", "加快 Markdown 与源文件之间的切换，并将预览和布局工作延后到首帧显示之后。", ["编辑器", "性能", "标签页"]),
         "v1.6.2": ("更安全的保存与更可靠的启动", "改进外部文档保存和网络文件变更检测，支持打开未知扩展名的文本文件，并允许关闭自动欢迎界面。", ["文件安全", "文本文件", "启动"]),


### PR DESCRIPTION
Adds the required v1.7.0 localized timeline summaries for German, Danish, French, Spanish, Japanese, and Simplified Chinese so release documentation generation cannot fall back to English placeholders.

## Summary by Sourcery

Add localized v1.7.0 release summaries for all supported non-English timeline languages.

Bug Fixes:
- Add localized v1.7.0 release timeline summaries so documentation generation no longer falls back to English placeholders.

Documentation:
- Provide v1.7.0 release summaries and tags in German, Danish, French, Spanish, Japanese, and Simplified Chinese.