### PR TITLE
Complete v1.7.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 - Keeps native document tabs, sidebars, editor surfaces, and Settings visually consistent across macOS, iOS, and iPadOS window modes.
 - Applies appearance and layout changes immediately when switching Light, Dark, or System mode.
+- Makes tab switching and Settings navigation feel immediate while preserving the native platform controls.
 
 ### Highlights
 


### PR DESCRIPTION
Adds the third Why Upgrade bullet required by the release notes quality gate.

## Summary by Sourcery

Documentation:
- Add the third “Why Upgrade” bullet to the v1.7.0 release notes, highlighting responsive tab switching and Settings navigation while retaining native platform controls.