### PR TITLE
chore(release): prepare v1.7.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Neon Vision Editor Architecture
 
-Last updated: 2026-09-08 (v1.6.4 release-aligned architecture)
+Last updated: 2026-09-09 (v1.7.0 release-aligned architecture)
 
 Neon Vision Editor is a native Swift 6 editor for macOS, iOS, iPadOS, and visionOS. The app favors a small editor-first surface: fast file access, lightweight project navigation, native text editing, syntax highlighting, structured document inspection, Markdown/HTML/SVG/PDF/PNG preview, project-level Markdown/PDF cards, Finder Quick Look previews, PDF highlights and attached Markdown notes, Git and terminal helpers on macOS, remote-session clients on supported Apple platforms, and optional contextual AI assistance.
 
@@ -8,6 +8,14 @@ The visual summary in [`docs/images/architecture-at-a-glance.svg`](docs/images/a
 
 <!-- RELEASE_ARCHITECTURE_ALIGNMENT:START -->
 ## Current Release Alignment
+
+### v1.7.0 (2026-09-09)
+
+- Replaces the remaining legacy tab-bar paths with native platform tab implementations.
+- Preserves complete tab borders, spacing, and translucent surfaces across hover, selection, and appearance changes.
+- Aligns tab, TOC sidebar, project sidebar, line-number, and editor backgrounds in opaque and translucent modes.
+- Prevents tab borders from clipping, flashing, or disappearing during hover and theme transitions.
+- Keeps Settings content sized to the selected tab and opens the Settings window in a stable editor-relative position.
 
 ### v1.6.4 (2026-09-08)
 
@@ -17,14 +25,6 @@ The visual summary in [`docs/images/architecture-at-a-glance.svg`](docs/images/a
 - Keep long, unwrapped iPhone lines visible and stable while typing and scrolling.
 - Stops per-character document length and dirty-state changes from rebuilding the macOS editor configuration.
 - Preserves toolbar button hit-testing while supporting window dragging in the middle of the native toolbar.
-
-### v1.6.3 (2026-09-07)
-
-- The selected editor publishes its first frame before deferred layout and preview work begins.
-- Makes macOS tab switching responsive by publishing the selected editor before deferred Core Text layout and Markdown preview work runs.
-- Avoids synchronous large-file inspection and preview parsing while selecting a tab, including when switching between Markdown and source files.
-- Fixes Markdown PDF export clipping, removes interactive code controls from exports, preserves A4 page dimensions, and uses content and code-line boundaries for pagination without blank trailing pages.
-- Find in Files now applies root and nested .gitignore rules and the sidebar's Ignored Folders settings consistently, pruning excluded directories while retaining text files with unknown extensions.
 
 This block is regenerated from `CHANGELOG.md` after each stable release. The sections below remain the authoritative description of ownership and runtime boundaries.
 <!-- RELEASE_ARCHITECTURE_ALIGNMENT:END -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ## [Unreleased]
 
+## [v1.7.0] - 2026-09-09
+
 ### Why Upgrade
 
 - Keeps native document tabs, sidebars, editor surfaces, and Settings visually consistent across macOS, iOS, and iPadOS window modes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 - Keeps native document tabs, sidebars, editor surfaces, and Settings visually consistent across macOS, iOS, and iPadOS window modes.
 - Applies appearance and layout changes immediately when switching Light, Dark, or System mode.
+- Makes tab switching and Settings navigation feel immediate while preserving the native platform controls.
 
 ### Highlights
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ## [Unreleased]
 
+### Why Upgrade
+
+- Keeps native document tabs, sidebars, editor surfaces, and Settings visually consistent across macOS, iOS, and iPadOS window modes.
+- Applies appearance and layout changes immediately when switching Light, Dark, or System mode.
+
+### Highlights
+
+- Replaces the remaining legacy tab-bar paths with native platform tab implementations.
+- Preserves complete tab borders, spacing, and translucent surfaces across hover, selection, and appearance changes.
+
+### Fixes
+
+- Aligns tab, TOC sidebar, project sidebar, line-number, and editor backgrounds in opaque and translucent modes.
+- Prevents tab borders from clipping, flashing, or disappearing during hover and theme transitions.
+- Keeps Settings content sized to the selected tab and opens the Settings window in a stable editor-relative position.
+
+### Breaking changes
+
+- None.
+
+### Migration
+
+- None.
+
 ## [v1.6.4] - 2026-09-08
 
 ### Why Upgrade

--- a/Neon Vision Editor.xcodeproj/project.pbxproj
+++ b/Neon Vision Editor.xcodeproj/project.pbxproj
@@ -1788,9 +1788,6 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
-				// Local/Xcode Cloud development builds must not require a locally
-				// installed Developer ID certificate. Distribution workflows pass
-				// their explicit Developer ID signing settings at archive time.
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1032;

--- a/Neon Vision Editor.xcodeproj/project.pbxproj
+++ b/Neon Vision Editor.xcodeproj/project.pbxproj
@@ -752,7 +752,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor App Clip/Neon Vision Editor App Clip.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_PREVIEWS = YES;
@@ -763,7 +763,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -791,7 +791,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_PREVIEWS = YES;
@@ -802,7 +802,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -902,7 +902,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -956,7 +956,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1136,7 +1136,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]" = "Neon Vision Editor/Neon Vision Editor iOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Neon Vision Editor/Neon Vision Editor macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1189,7 +1189,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1302,7 +1302,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1354,7 +1354,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1391,7 +1391,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1405,7 +1405,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				REGISTER_APP_GROUPS = YES;
@@ -1431,7 +1431,7 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Share Extension/Neon Vision Editor Share Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1456,7 +1456,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1486,7 +1486,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = CS727NF72U;
@@ -1512,7 +1512,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1565,7 +1565,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1574,7 +1574,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1595,7 +1595,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1604,7 +1604,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1625,7 +1625,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1633,7 +1633,7 @@
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "h3p.Neon-Vision-Editor";
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1653,7 +1653,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1661,7 +1661,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1681,7 +1681,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1689,7 +1689,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1709,7 +1709,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1717,7 +1717,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1738,13 +1738,13 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				SDKROOT = macosx;
@@ -1763,14 +1763,14 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				SDKROOT = macosx;
@@ -1790,14 +1790,14 @@
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.6.4;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Neon Vision Editor/App/NeonVisionEditorApp.swift
+++ b/Neon Vision Editor/App/NeonVisionEditorApp.swift
@@ -434,23 +434,9 @@ struct NeonVisionEditorApp: App {
     }
 
 #if os(macOS)
-    private var appKitAppearance: NSAppearance? {
-        switch appearance {
-        case "light":
-            return NSAppearance(named: .aqua)
-        case "dark":
-            return NSAppearance(named: .darkAqua)
-        default:
-            return nil
-        }
-    }
-
     private func applyGlobalAppearanceOverride() {
-        let override = appKitAppearance
-        NSApp.appearance = override
+        ReleaseRuntimePolicy.applyMacApplicationAppearance(appearance)
         for window in NSApp.windows {
-            window.appearance = override
-            window.contentView?.appearance = override
             window.invalidateShadow()
             window.contentView?.needsDisplay = true
         }
@@ -777,7 +763,6 @@ struct NeonVisionEditorApp: App {
                 supportPurchaseManager: supportPurchaseManager,
                 appUpdateManager: appUpdateManager
             )
-                .onAppear { _ = AppearanceThemeCloudSync.syncIfEnabled() }
                 .onAppear { scheduleMacWindowChromePolicy() }
                 .onChange(of: appearance) { _, _ in applyGlobalAppearanceOverride() }
                 .onAppear { applyRuntimeLanguageOverride() }

--- a/Neon Vision Editor/Core/ReleaseRuntimePolicy.swift
+++ b/Neon Vision Editor/Core/ReleaseRuntimePolicy.swift
@@ -1,5 +1,8 @@
 import Foundation
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 
 
@@ -74,6 +77,39 @@ enum ReleaseRuntimePolicy {
             return nil
         }
     }
+
+#if os(macOS)
+    static func appKitAppearance(for appearance: String) -> NSAppearance? {
+        switch appearance {
+        case "light":
+            return NSAppearance(named: .aqua)
+        case "dark":
+            return NSAppearance(named: .darkAqua)
+        default:
+            return nil
+        }
+    }
+
+    @MainActor
+    static func clearMacWindowAppearanceOverrides(_ windows: [NSWindow]) {
+        for window in windows {
+            window.contentView?.appearance = nil
+            window.appearance = nil
+        }
+    }
+
+    @MainActor
+    static func applyMacApplicationAppearance(
+        _ appearance: String,
+        application: NSApplication = NSApp
+    ) {
+        // NSApplication is the single appearance owner. Windows and hosting
+        // views must inherit it so returning to System removes every explicit
+        // Light/Dark override instead of retaining a stale child appearance.
+        clearMacWindowAppearanceOverrides(application.windows)
+        application.appearance = appKitAppearance(for: appearance)
+    }
+#endif
 
     static func nextFindMatch(
         in source: String,

--- a/Neon Vision Editor/UI/ContentView+DocumentPreviewUI.swift
+++ b/Neon Vision Editor/UI/ContentView+DocumentPreviewUI.swift
@@ -13,7 +13,7 @@ import UIKit
 extension ContentView {
     @ViewBuilder
     var imagePreviewPane: some View {
-        documentPreviewContainer(title: "PNG Preview", iconName: "photo") {
+        documentPreviewContainer(title: "PNG Preview", iconName: "photo", metadata: previewFileSizeText(for: viewModel.selectedTab?.fileURL)) {
             if let url = viewModel.selectedTab?.fileURL {
                 ImagePreviewDocumentView(url: url)
             } else {
@@ -24,7 +24,7 @@ extension ContentView {
 
     @ViewBuilder
     var pdfPreviewPane: some View {
-        documentPreviewContainer(title: "PDF Preview", iconName: "doc.richtext") {
+        documentPreviewContainer(title: "PDF Preview", iconName: "doc.richtext", metadata: previewFileSizeText(for: pdfPreviewURL)) {
             if let url = pdfPreviewURL {
                 PDFAnnotationWorkspaceView(
                     url: url,
@@ -43,6 +43,7 @@ extension ContentView {
     private func documentPreviewContainer<Content: View>(
         title: String,
         iconName: String,
+        metadata: String?,
         @ViewBuilder content: () -> Content
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -53,6 +54,13 @@ extension ContentView {
                 Text(title)
                     .font(.headline)
                 Spacer(minLength: 0)
+                if let metadata {
+                    Text(metadata)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                }
                 Button(action: closeCurrentPreview) {
                     Image(systemName: "xmark")
                 }
@@ -90,6 +98,14 @@ extension ContentView {
 #else
         Color(.systemBackground)
 #endif
+    }
+
+    func previewFileSizeText(for url: URL?) -> String? {
+        let byteCount = viewModel.selectedTab?.fileByteCount ?? url.flatMap {
+            try? $0.resourceValues(forKeys: [.fileSizeKey]).fileSize
+        }
+        guard let byteCount else { return nil }
+        return ByteCountFormatter.string(fromByteCount: Int64(byteCount), countStyle: .file)
     }
 }
 

--- a/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
@@ -102,9 +102,10 @@ enum MarkdownFormattingChromePolicy {
 
     nonisolated static func usesTranslucentControlSurface(
         isCollapsed: Bool,
-        liquidGlassEnabled: Bool
+        liquidGlassEnabled: Bool,
+        windowTranslucent: Bool
     ) -> Bool {
-        liquidGlassEnabled && !isCollapsed
+        liquidGlassEnabled || windowTranslucent
     }
 }
 
@@ -150,9 +151,10 @@ extension ContentView {
         GlassSurface(
             enabled: MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
                 isCollapsed: markdownFormattingToolbarCollapsed,
-                liquidGlassEnabled: shouldUseLiquidGlass
+                liquidGlassEnabled: shouldUseLiquidGlass,
+                windowTranslucent: enableTranslucentWindow
             ),
-            material: primaryGlassMaterial,
+            material: .ultraThinMaterial,
             fallbackColor: markdownFormattingToolbarCollapsed
                 ? Color(uiColor: .secondarySystemBackground)
                 : toolbarFallbackColor,
@@ -162,6 +164,7 @@ extension ContentView {
             markdownFormattingToolbar
         }
         .tint(iOSToolbarForegroundColor)
+        .padding(.trailing, 12)
         .accessibilityLabel("Markdown Formatting")
     }
 #endif
@@ -246,6 +249,7 @@ extension ContentView {
             .padding(2)
             .padding(.horizontal, 8)
             .padding(.vertical, 2)
+            .frame(minWidth: 72, minHeight: 32)
         } else {
             markdownFormattingCapsule
         }

--- a/Neon Vision Editor/UI/ContentView+MarkdownPreviewUI.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownPreviewUI.swift
@@ -81,6 +81,13 @@ extension ContentView {
             Text("Markdown Preview")
                 .font(.headline)
             Spacer(minLength: 0)
+            if let metadata = previewFileSizeText(for: viewModel.selectedTab?.fileURL) {
+                Text(metadata)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .lineLimit(1)
+            }
             if projectRootFolderURL != nil {
                 Button {
                     toggleMarkdownProjectPreviewFromToolbar()

--- a/Neon Vision Editor/UI/ContentView+MarkdownProjectPreview.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownProjectPreview.swift
@@ -261,6 +261,7 @@ extension ContentView {
             accentWidth: isMarkdownProjectPreviewResizeHandleHovered || markdownProjectPreviewResizeStartWidth != nil ? 2 : 0,
             accentColor: Color.accentColor.opacity(0.55),
             surfaceStyle: macResizeHandleSurfaceStyle,
+            topSurfaceStyle: macToolbarBackgroundStyle,
             isActive: isMarkdownProjectPreviewResizeHandleHovered || markdownProjectPreviewResizeStartWidth != nil,
             isDragging: markdownProjectPreviewResizeStartWidth != nil,
             isHovered: $isMarkdownProjectPreviewResizeHandleHovered,

--- a/Neon Vision Editor/UI/ContentView+PreviewSplit.swift
+++ b/Neon Vision Editor/UI/ContentView+PreviewSplit.swift
@@ -369,6 +369,7 @@ extension ContentView {
             accentWidth: isPreviewPaneResizeHandleHovered || previewPaneResizeStartWidth != nil ? 2 : 0,
             accentColor: Color.accentColor.opacity(0.55),
             surfaceStyle: macResizeHandleSurfaceStyle,
+            topSurfaceStyle: macToolbarBackgroundStyle,
             isActive: isPreviewPaneResizeHandleHovered || previewPaneResizeStartWidth != nil,
             isDragging: previewPaneResizeStartWidth != nil,
             isHovered: $isPreviewPaneResizeHandleHovered,

--- a/Neon Vision Editor/UI/ContentView+ProjectSidebar.swift
+++ b/Neon Vision Editor/UI/ContentView+ProjectSidebar.swift
@@ -14,7 +14,7 @@ extension ContentView {
                 idealWidth: clampedProjectSidebarWidth,
                 maxWidth: clampedProjectSidebarWidth
             )
-            .background(editorSurfaceBackgroundStyle)
+            .background(macSidebarColumnBackground)
 #else
         projectStructureSidebarBody
             .frame(
@@ -60,6 +60,7 @@ extension ContentView {
             accentWidth: projectSidebarResizeHandleAccentWidth,
             accentColor: projectSidebarHandleAccentColor,
             surfaceStyle: projectSidebarHandleSurfaceStyle,
+            topSurfaceStyle: macToolbarBackgroundStyle,
             isActive: projectSidebarResizeHandleIsActive,
             isDragging: projectSidebarResizeStartWidth != nil,
             isHovered: $isProjectSidebarResizeHandleHovered,
@@ -313,6 +314,7 @@ struct MacSidebarResizeDivider<ResizeGesture: Gesture>: View where ResizeGesture
     let accentWidth: CGFloat
     let accentColor: Color
     let surfaceStyle: AnyShapeStyle
+    let topSurfaceStyle: AnyShapeStyle
     let isActive: Bool
     let isDragging: Bool
     @Binding var isHovered: Bool
@@ -324,7 +326,14 @@ struct MacSidebarResizeDivider<ResizeGesture: Gesture>: View where ResizeGesture
     var body: some View {
         ZStack {
             Rectangle()
-                .fill(Color.clear)
+                .fill(surfaceStyle)
+
+            VStack(spacing: 0) {
+                Rectangle()
+                    .fill(topSurfaceStyle)
+                    .frame(height: 42)
+                Spacer(minLength: 0)
+            }
 
             Rectangle()
                 .fill(accentColor)
@@ -334,10 +343,6 @@ struct MacSidebarResizeDivider<ResizeGesture: Gesture>: View where ResizeGesture
                 .frame(maxWidth: .infinity, alignment: .center)
         }
         .frame(width: visibleWidth)
-        // The divider is part of the editor pane, not an independent visual
-        // effect surface. Reuse the adjacent pane style in every appearance
-        // mode so toggling translucency cannot introduce a different strip.
-        .background(Rectangle().fill(surfaceStyle))
         .overlay {
             MacSidebarResizeCursorTrackingView(
                 isHovered: $isHovered,

--- a/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
+++ b/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import Foundation
-import UniformTypeIdentifiers
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -8,83 +7,13 @@ import UIKit
 import AppKit
 #endif
 
-private struct FileTabBarContentMinXPreferenceKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
+ #if os(iOS) || os(visionOS)
 private struct FileTabBarScrollFadeMask<Mask: View>: ViewModifier {
     let mask: Mask
 
     @ViewBuilder
     func body(content: Content) -> some View {
-#if os(macOS)
-        if #available(macOS 26.0, *) {
-            content.mask(mask)
-        } else {
-            // SwiftUI masks can swallow tab-button mouse events on pre-26 macOS.
-            content
-        }
-#else
         content.mask(mask)
-#endif
-    }
-}
-
-#if os(macOS)
-private struct FileTabDropDelegate: DropDelegate {
-    let destinationTabID: UUID
-    let tabWidth: CGFloat
-    @Binding var insertionTabID: UUID?
-    @Binding var insertionBefore: Bool
-    let moveTab: (UUID, UUID, Bool) -> Void
-
-    func validateDrop(info: DropInfo) -> Bool {
-        !info.itemProviders(for: [.plainText]).isEmpty
-    }
-
-    func dropEntered(info: DropInfo) {
-        updateInsertionMarker(for: info.location)
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        updateInsertionMarker(for: info.location)
-        return DropProposal(operation: .move)
-    }
-
-    func dropExited(info: DropInfo) {
-        if insertionTabID == destinationTabID {
-            insertionTabID = nil
-        }
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        let insertBefore = info.location.x < tabWidth / 2
-        guard let provider = info.itemProviders(for: [.plainText]).first else { return false }
-        provider.loadObject(ofClass: NSString.self) { object, _ in
-            guard let identifier = object as? String,
-                  let draggedTabID = UUID(uuidString: identifier),
-                  draggedTabID != destinationTabID else {
-                return
-            }
-            DispatchQueue.main.async {
-                moveTab(draggedTabID, destinationTabID, insertBefore)
-                if insertionTabID == destinationTabID {
-                    insertionTabID = nil
-                }
-            }
-        }
-        return true
-    }
-
-    private func updateInsertionMarker(for location: CGPoint) {
-        let shouldInsertBefore = location.x < tabWidth / 2
-        guard insertionTabID != destinationTabID || insertionBefore != shouldInsertBefore else { return }
-        insertionTabID = destinationTabID
-        insertionBefore = shouldInsertBefore
     }
 }
 #endif
@@ -795,13 +724,78 @@ extension ContentView {
     var tabBarView: some View {
         VStack(spacing: 0) {
 #if os(macOS)
-            if #available(macOS 26.0, *) {
-                scrollableFileTabBar
-            } else {
-                macLegacyFileTabBar
+            MacNativeFileTabBar(
+                tabs: viewModel.tabs.map {
+                    MacNativeFileTabSnapshot(
+                        id: $0.id,
+                        title: $0.name,
+                        isDirty: $0.isDirty,
+                        isRemote: $0.isRemoteDocument,
+                        isReadOnly: $0.isReadOnlyPreview
+                    )
+                },
+                selectedTabID: viewModel.selectedTabID,
+                usesOpaqueEditorCanvas: opaqueEditorSurfaceMac,
+                onSelect: { viewModel.selectTab(id: $0) },
+                onClose: { tabID in
+                    guard let tab = viewModel.tabs.first(where: { $0.id == tabID }) else { return }
+                    requestCloseTab(tab)
+                },
+                onMove: { sourceID, destinationID, insertBefore in
+                    reorderDroppedTab(
+                        draggedTabID: sourceID,
+                        destinationTabID: destinationID,
+                        insertBefore: insertBefore
+                    )
+                },
+                onAdd: { viewModel.addNewTab() }
+            )
+            // Keep the AppKit representable and the divider as explicit
+            // siblings in the 42-point strip. Without a child height,
+            // VStack can compress the representable's fitting size and make
+            // its scroll view clip the tab layer at the bottom.
+            .frame(height: 41)
+#elseif os(iOS)
+            GlassSurface(
+                // Window translucency must keep the tab strip on a material
+                // surface even when the optional Liquid Glass toolbar style is
+                // disabled; otherwise the fallback color paints an opaque band.
+                enabled: shouldUseLiquidGlass || enableTranslucentWindow,
+                material: primaryGlassMaterial,
+                fallbackColor: toolbarFallbackColor,
+                shape: .rounded(18),
+                chromeStyle: .single
+            ) {
+                MobileNativeFileTabBar(
+                    tabs: viewModel.tabs.map {
+                        MobileNativeFileTabSnapshot(
+                            id: $0.id,
+                            title: $0.name,
+                            isDirty: $0.isDirty,
+                            isRemote: $0.isRemoteDocument,
+                            isReadOnly: $0.isReadOnlyPreview
+                        )
+                    },
+                    selectedTabID: viewModel.selectedTabID,
+                    onSelect: { viewModel.selectTab(id: $0) },
+                    onClose: { tabID in
+                        guard let tab = viewModel.tabs.first(where: { $0.id == tabID }) else { return }
+                        requestCloseTab(tab)
+                    },
+                    onMove: { sourceID, destinationID, insertBefore in
+                        reorderDroppedTab(
+                            draggedTabID: sourceID,
+                            destinationTabID: destinationID,
+                            insertBefore: insertBefore
+                        )
+                    },
+                    onAdd: { viewModel.addNewTab() }
+                )
             }
-#else
+#elseif os(visionOS)
             scrollableFileTabBar
+#else
+            EmptyView()
 #endif
 #if os(iOS) || os(visionOS)
             EmptyView()
@@ -811,7 +805,12 @@ extension ContentView {
         }
         .frame(minHeight: 42, maxHeight: 42, alignment: .center)
 #if os(macOS)
-        .background(editorSurfaceBackgroundStyle.opacity(usesAnySidebarTabTransition ? 0 : 1))
+        .background(macToolbarBackgroundStyle)
+#elseif os(iOS)
+        // Keep the full-width strip on the same surface as the project bar
+        // and editor. The inner GlassSurface supplies the rounded chrome;
+        // this outer surface prevents a mismatched band around it.
+        .background(editorSurfaceBackgroundStyle)
 #else
         .background(
             enableTranslucentWindow
@@ -823,6 +822,22 @@ extension ContentView {
 #endif
     }
 
+#if os(macOS) || os(iOS)
+    private func reorderDroppedTab(
+        draggedTabID: UUID,
+        destinationTabID: UUID,
+        insertBefore: Bool
+    ) {
+        guard draggedTabID != destinationTabID else { return }
+        if insertBefore {
+            viewModel.moveTab(tabID: draggedTabID, beforeTabID: destinationTabID)
+        } else {
+            viewModel.moveTab(tabID: draggedTabID, afterTabID: destinationTabID)
+        }
+    }
+#endif
+
+#if os(visionOS)
     private var scrollableFileTabBar: some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
@@ -840,47 +855,14 @@ extension ContentView {
                     .padding(.leading, tabBarLeadingPadding)
                     .padding(.trailing, 10)
                     .padding(.vertical, 6)
-                    .background(fileTabBarOffsetReader)
             }
             .onChange(of: viewModel.selectedTabID) { _, selectedTabID in
                 guard let selectedTabID else { return }
                 proxy.scrollTo(selectedTabID)
             }
         }
-        .coordinateSpace(name: fileTabBarCoordinateSpaceName)
-        .onPreferenceChange(FileTabBarContentMinXPreferenceKey.self) { minX in
-            let isScrolled = minX < tabBarLeadingPadding - 1
-            if fileTabBarIsScrolledUnderTOCEdge != isScrolled {
-                fileTabBarIsScrolledUnderTOCEdge = isScrolled
-            }
-        }
         .modifier(FileTabBarScrollFadeMask(mask: fileTabBarScrollMask))
     }
-
-#if os(macOS)
-    private var macLegacyFileTabBar: some View {
-        fileTabBarContent
-            .padding(5)
-            .background(
-                fileTabBarContainerShape
-                    .fill(Color.secondary.opacity(0.065))
-            )
-            .overlay(
-                fileTabBarContainerShape
-                    .stroke(Color.secondary.opacity(0.10), lineWidth: 1)
-            )
-            .clipShape(fileTabBarContainerShape)
-            .padding(.leading, tabBarLeadingPadding)
-            .padding(.trailing, 10)
-            .padding(.vertical, 6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .onAppear {
-                if fileTabBarIsScrolledUnderTOCEdge {
-                    fileTabBarIsScrolledUnderTOCEdge = false
-                }
-            }
-    }
-#endif
 
     private var fileTabBarContent: some View {
         HStack(spacing: 6) {
@@ -919,8 +901,6 @@ extension ContentView {
 
     private func fileTabItem(for tab: TabData) -> some View {
         let isSelected = viewModel.selectedTabID == tab.id
-        let wasPreviouslySelected = previousSelectedTabID == tab.id && !isSelected
-        let isDropTarget = tabDropInsertionTabID == tab.id
         return HStack(spacing: 8) {
             fileTabSelectButton(for: tab, isSelected: isSelected)
             fileTabCloseButton(for: tab)
@@ -929,63 +909,8 @@ extension ContentView {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(isSelected ? Color.accentColor.opacity(0.24) : Color.secondary.opacity(0.07))
         )
-        .overlay(alignment: isDropTarget && !tabDropInsertionBefore ? .trailing : .leading) {
-#if os(macOS)
-            if isSelected || wasPreviouslySelected || isDropTarget {
-                Capsule()
-                    .fill(isDropTarget || isSelected ? Color.accentColor : Color.yellow)
-                    .frame(width: isSelected ? 4 : 3)
-                    .padding(.vertical, 3)
-                    .accessibilityHidden(true)
-            }
-#endif
-        }
         .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-#if os(macOS)
-        .onTapGesture {
-            viewModel.selectTab(id: tab.id)
-        }
-        .onTapGesture(count: 2) {
-            requestCloseTab(tab)
-        }
-        .draggable(tab.id.uuidString)
-        .background {
-            GeometryReader { proxy in
-                Color.clear
-                    .contentShape(Rectangle())
-                    .onDrop(
-                        of: [UTType.plainText.identifier],
-                        delegate: FileTabDropDelegate(
-                            destinationTabID: tab.id,
-                            tabWidth: proxy.size.width,
-                            insertionTabID: $tabDropInsertionTabID,
-                            insertionBefore: $tabDropInsertionBefore,
-                            moveTab: reorderDroppedTab
-                        )
-                    )
-            }
-        }
-        .accessibilityHint(isSelected
-            ? "Selected. Drag this tab onto the left or right half of another tab to reorder tabs."
-            : "Drag onto the left or right half of another tab to reorder tabs.")
-#endif
     }
-
-#if os(macOS)
-    private func reorderDroppedTab(
-        draggedTabID: UUID,
-        destinationTabID: UUID,
-        insertBefore: Bool
-    ) {
-        guard draggedTabID != destinationTabID else { return }
-        if insertBefore {
-            viewModel.moveTab(tabID: draggedTabID, beforeTabID: destinationTabID)
-        } else {
-            viewModel.moveTab(tabID: draggedTabID, afterTabID: destinationTabID)
-        }
-        tabDropInsertionTabID = nil
-    }
-#endif
 
     private func fileTabSelectButton(for tab: TabData, isSelected: Bool) -> some View {
         Button {
@@ -1039,59 +964,20 @@ extension ContentView {
         .help("Close \(tab.name)")
     }
 
-    private var usesSubtleTOCTransition: Bool {
-#if os(macOS)
-        usesTOCSplitChromeCleanup && fileTabBarIsScrolledUnderTOCEdge
-#else
-        false
-#endif
-    }
-
     private var usesMarkdownPreviewTabTransition: Bool {
         isMarkdownPreviewSplitVisible
     }
 
-#if os(macOS)
-    private var usesProjectSidebarTabTransition: Bool {
-        showProjectStructureSidebar && projectNavigatorPlacement == .trailing && !brainDumpLayoutEnabled && !focusModeEnabled
-    }
-
-    private var usesTrailingTabTransition: Bool {
-        usesMarkdownPreviewTabTransition || usesProjectSidebarTabTransition
-    }
-
-    private var usesAnySidebarTabTransition: Bool {
-        usesSubtleTOCTransition || usesMarkdownPreviewTabTransition || usesProjectSidebarTabTransition
-    }
-
-    private var usesTOCSplitChromeCleanup: Bool {
-        shouldUseSplitView
-    }
-#else
     private var usesTrailingTabTransition: Bool {
         usesMarkdownPreviewTabTransition
-    }
-#endif
-
-    private var fileTabBarCoordinateSpaceName: String {
-        "FileTabBarScroll"
-    }
-
-    private var fileTabBarOffsetReader: some View {
-        GeometryReader { proxy in
-            Color.clear.preference(
-                key: FileTabBarContentMinXPreferenceKey.self,
-                value: proxy.frame(in: .named(fileTabBarCoordinateSpaceName)).minX
-            )
-        }
     }
 
     @ViewBuilder
     private var fileTabBarScrollMask: some View {
-        if usesSubtleTOCTransition || usesTrailingTabTransition {
+        if usesTrailingTabTransition {
             LinearGradient(
                 stops: [
-                    .init(color: usesSubtleTOCTransition ? .clear : .black, location: 0),
+                    .init(color: .black, location: 0),
                     .init(color: .black, location: 0.035),
                     .init(color: .black, location: 0.965),
                     .init(color: usesTrailingTabTransition ? .clear : .black, location: 1)
@@ -1104,24 +990,21 @@ extension ContentView {
         }
     }
 
-#if os(macOS)
-    @ViewBuilder
-    private var tabBarBottomDivider: some View {
-        if usesAnySidebarTabTransition {
-            Divider()
-                .opacity(0.22)
-                .padding(.leading, 18)
-                .padding(.trailing, usesTrailingTabTransition ? 18 : 0)
-        } else {
-            Divider()
-                .opacity(0.45)
-        }
-    }
-#endif
 
     private var fileTabBarContainerShape: RoundedRectangle {
         RoundedRectangle(cornerRadius: 14, style: .continuous)
     }
+#endif
+
+#if os(macOS)
+    @ViewBuilder
+    private var tabBarBottomDivider: some View {
+        Divider()
+            .opacity(isMarkdownPreviewSplitVisible ? 0.22 : 0.32)
+            .padding(.leading, isMarkdownPreviewSplitVisible ? 18 : 0)
+            .padding(.trailing, isMarkdownPreviewSplitVisible ? 18 : 0)
+    }
+#endif
 
     private var vimStatusSuffix: String {
 #if os(macOS)

--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -753,10 +753,6 @@ struct ContentView: View {
     @State var projectRefreshStatusIsPending: Bool = false
     @State var projectFolderMonitorSource: DispatchSourceFileSystemObject? = nil
     @State var pendingProjectFolderRefreshWorkItem: DispatchWorkItem? = nil
-    @State var fileTabBarIsScrolledUnderTOCEdge: Bool = false
-    @State var tabDropInsertionTabID: UUID? = nil
-    @State var tabDropInsertionBefore: Bool = true
-    @State var previousSelectedTabID: UUID? = nil
     @State var quickSwitcherRecentItemIDs: [String] = []
     @State var recentFilesRefreshToken: UUID = UUID()
     @State var sharedImportsRefreshToken: UUID = UUID()
@@ -1149,6 +1145,12 @@ struct ContentView: View {
             guard let titlebarView else { return false }
             let point = titlebarView.convert(event.locationInWindow, from: nil)
             guard titlebarView.bounds.contains(point) else { return false }
+            // The transparent titlebar can extend over the editor content. Only
+            // the upper chrome band is a drag surface; otherwise a click that
+            // begins on selected text would be promoted to a window drag and
+            // leave the editor selection visibly marked during the move.
+            let dragBandHeight = min(88, max(44, titlebarView.bounds.height * 0.35))
+            guard point.y >= titlebarView.bounds.maxY - dragBandHeight else { return false }
             guard let hitView = titlebarView.hitTest(point) else { return true }
             var candidate: NSView? = hitView
             while let view = candidate, view !== titlebarView {
@@ -1186,13 +1188,13 @@ struct ContentView: View {
             switch modeRaw {
             case "subtle":
                 whiteLevel = isDarkMode ? 0.18 : 0.90
-                translucentAlpha = 0.92
+                translucentAlpha = 0.96
             case "vibrant":
                 whiteLevel = isDarkMode ? 0.12 : 0.82
-                translucentAlpha = 0.84
+                translucentAlpha = 0.90
             default:
                 whiteLevel = isDarkMode ? 0.15 : 0.86
-                translucentAlpha = 0.88
+                translucentAlpha = 0.93
             }
             return NSColor(calibratedWhite: whiteLevel, alpha: translucent ? translucentAlpha : 1)
         }
@@ -1217,7 +1219,11 @@ struct ContentView: View {
         )
     }
     private var macOpaqueEditorCanvasColor: Color {
-        currentEditorTheme(colorScheme: colorScheme).background
+        // Keep opaque-canvas mode readable while allowing a small amount of
+        // the native window surface to blend through. This is intentionally
+        // subtle; the editor remains visually solid without the hard slab
+        // produced by a fully opaque theme color.
+        currentEditorTheme(colorScheme: colorScheme).background.opacity(0.94)
     }
     private var macEditorSurfaceBackgroundStyle: AnyShapeStyle {
         if enableTranslucentWindow {
@@ -1235,11 +1241,29 @@ struct ContentView: View {
         return AnyShapeStyle(macSolidSurfaceColor)
     }
 
-    private var macToolbarBackgroundStyle: AnyShapeStyle {
+    var macToolbarBackgroundStyle: AnyShapeStyle {
         if enableTranslucentWindow {
+            // The NSWindow owns the translucent chrome surface. Keep SwiftUI
+            // clear here so the toolbar and tab strip reveal that same window
+            // material instead of stacking an opaque bar material over it.
             return macUnifiedTranslucentMaterialStyle
         }
+        if opaqueEditorSurfaceMac {
+            // Opaque editor mode uses the editor theme for the side columns as
+            // well. Continue that surface through the toolbar and tab strip so
+            // the upper chrome does not become a separate window-colored band.
+            return macEditorSurfaceBackgroundStyle
+        }
         return AnyShapeStyle(macSolidSurfaceColor)
+    }
+
+    var macSidebarColumnBackground: some View {
+        ZStack(alignment: .top) {
+            Rectangle().fill(editorSurfaceBackgroundStyle)
+            Rectangle()
+                .fill(macToolbarBackgroundStyle)
+                .frame(height: 42)
+        }
     }
 
     private var macInterPaneBackgroundStyle: AnyShapeStyle {
@@ -1352,10 +1376,6 @@ struct ContentView: View {
         if UIDevice.current.userInterfaceIdiom == .pad {
             // Keep tabs clear of iPad window controls in narrow/multitasking layouts.
             return horizontalSizeClass == .compact ? 112 : 10
-        }
-#else
-        if shouldUseSplitView {
-            return 4
         }
 #endif
         return 10
@@ -2471,6 +2491,7 @@ struct ContentView: View {
                     VStack(spacing: 0) {
                         if usesAppOwnedIOSSplitChromeLayout {
                             iOSUnifiedToolbarHost
+                            iOSUnifiedDocumentChromeHost
                         }
                         NavigationSplitView {
 #if os(iOS)
@@ -2490,6 +2511,7 @@ struct ContentView: View {
                         .toolbar(.hidden, for: .navigationBar)
                         .background(editorSurfaceBackgroundStyle)
                     }
+                    .background(editorSurfaceBackgroundStyle)
                 } else {
                     editorView
                 }
@@ -2782,7 +2804,6 @@ struct ContentView: View {
             }
             .onChange(of: viewModel.selectedTabID) { previousTabID, selectedTabID in
                 guard previousTabID != selectedTabID else { return }
-                previousSelectedTabID = previousTabID
                 if activeSplitSecondaryTabID == nil {
                     splitSecondaryTabID = nil
                 }
@@ -3562,6 +3583,7 @@ struct ContentView: View {
                     DetachedPreviewWindowPresenter(
                         isPresented: contentView.$showDetachedPreviewWindow,
                         title: contentView.previewTitle,
+                        metadata: contentView.previewFileSizeText(for: contentView.viewModel.selectedTab?.fileURL),
                         html: contentView.detachedPreviewHTML,
                         baseURL: contentView.detachedPreviewBaseURL
                     )
@@ -3997,7 +4019,11 @@ struct ContentView: View {
                 }
             )
                 .frame(minWidth: 200, idealWidth: 250, maxWidth: 600)
+#if os(macOS)
+                .background(Color.clear)
+#else
                 .background(editorSurfaceBackgroundStyle)
+#endif
         } else {
             EmptyView()
         }
@@ -4733,7 +4759,7 @@ struct ContentView: View {
             if shouldUseSplitView {
                 sidebarView
                     .frame(width: clampedTOCSidebarWidth)
-                    .background(editorSurfaceBackgroundStyle)
+                    .background(macSidebarColumnBackground)
                 tocSidebarResizeHandle
             }
             editorView
@@ -4769,6 +4795,7 @@ struct ContentView: View {
             // window. A solid theme color creates a white strip in translucent
             // mode even though both adjacent panes use the window material.
             surfaceStyle: macInterPaneBackgroundStyle,
+            topSurfaceStyle: macToolbarBackgroundStyle,
             isActive: isTOCSidebarResizeHandleHovered || tocSidebarResizeStartWidth != nil,
             isDragging: tocSidebarResizeStartWidth != nil,
             isHovered: $isTOCSidebarResizeHandleHovered,
@@ -5169,7 +5196,7 @@ struct ContentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
 #if os(iOS) || os(visionOS)
-        let contentWithTopChrome = useIOSUnifiedTopHost
+        let contentWithTopChrome = useIOSUnifiedTopHost && !usesAppOwnedIOSSplitChromeLayout
             ? AnyView(
                 content.safeAreaInset(edge: .top, spacing: 0) {
                     if usesAppOwnedIOSSplitChromeLayout {

--- a/Neon Vision Editor/UI/EditorTextView+iOS.swift
+++ b/Neon Vision Editor/UI/EditorTextView+iOS.swift
@@ -1699,13 +1699,14 @@ final class LineNumberedTextViewContainer: UIView {
 
     func applyLineNumberColors(editorBackground: UIColor, textColor: UIColor, translucentBackgroundEnabled: Bool) {
         backgroundColor = translucentBackgroundEnabled ? .clear : editorBackground
-        #if os(visionOS)
+        // The gutter is part of the editor surface, not a system sidebar.
+        // Painting secondarySystemBackground here made it remain opaque white
+        // in iPad translucent mode while the text canvas correctly showed the
+        // window material.
         lineNumberView.backgroundColor = translucentBackgroundEnabled ? .clear : editorBackground
-        divider.backgroundColor = textColor.withAlphaComponent(0.16)
-        #else
-        lineNumberView.backgroundColor = UIColor.secondarySystemBackground.withAlphaComponent(0.65)
-        divider.backgroundColor = UIColor.separator.withAlphaComponent(0.6)
-        #endif
+        divider.backgroundColor = translucentBackgroundEnabled
+            ? textColor.withAlphaComponent(0.16)
+            : UIColor.separator.withAlphaComponent(0.6)
         lineNumberView.textColor = textColor.withAlphaComponent(0.70)
     }
 

--- a/Neon Vision Editor/UI/MacNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MacNativeFileTabBar.swift
@@ -1,0 +1,649 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+struct MacNativeFileTabSnapshot: Equatable, Identifiable {
+    let id: UUID
+    let title: String
+    let isDirty: Bool
+    let isRemote: Bool
+    let isReadOnly: Bool
+}
+
+struct MacNativeFileTabBar: NSViewRepresentable {
+    let tabs: [MacNativeFileTabSnapshot]
+    let selectedTabID: UUID?
+    let usesOpaqueEditorCanvas: Bool
+    let onSelect: (UUID) -> Void
+    let onClose: (UUID) -> Void
+    let onMove: (UUID, UUID, Bool) -> Void
+    let onAdd: () -> Void
+
+    func makeNSView(context: Context) -> MacNativeFileTabBarView {
+        let view = MacNativeFileTabBarView()
+        configure(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: MacNativeFileTabBarView, context: Context) {
+        configure(nsView)
+    }
+
+    private func configure(_ view: MacNativeFileTabBarView) {
+        view.onSelect = onSelect
+        view.onClose = onClose
+        view.onMove = onMove
+        view.onAdd = onAdd
+        view.usesOpaqueEditorCanvas = usesOpaqueEditorCanvas
+        view.apply(tabs: tabs, selectedTabID: selectedTabID)
+    }
+}
+
+@MainActor
+final class MacNativeFileTabBarView: NSView {
+    var onSelect: ((UUID) -> Void)?
+    var onClose: ((UUID) -> Void)?
+    var onMove: ((UUID, UUID, Bool) -> Void)?
+    var onAdd: (() -> Void)?
+
+    private let scrollView = NSScrollView()
+    private let tabsView = MacNativeFileTabDocumentView()
+    private let addButton = NSButton()
+    private let scrollEdgeMask = CAGradientLayer()
+    private var tabViewsByID: [UUID: MacNativeFileTabItemView] = [:]
+    private(set) var orderedTabIDs: [UUID] = []
+    private(set) var selectedTabID: UUID?
+    private(set) var scrollEdgeFadeState = (left: false, right: false)
+    var usesOpaqueEditorCanvas = false
+
+    var managedTabViewCount: Int { tabViewsByID.count }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.clear.cgColor
+
+        scrollView.drawsBackground = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.hasVerticalScroller = false
+        scrollView.horizontalScrollElasticity = .automatic
+        scrollView.verticalScrollElasticity = .none
+        scrollView.scrollerStyle = .overlay
+        scrollView.documentView = tabsView
+        scrollView.wantsLayer = true
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        scrollEdgeMask.startPoint = CGPoint(x: 0, y: 0.5)
+        scrollEdgeMask.endPoint = CGPoint(x: 1, y: 0.5)
+        scrollView.layer?.mask = scrollEdgeMask
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(scrollBoundsDidChange),
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView
+        )
+        addSubview(scrollView)
+
+        addButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "New Tab")
+        addButton.imagePosition = .imageOnly
+        addButton.bezelStyle = .accessoryBarAction
+        addButton.controlSize = .small
+        addButton.target = self
+        addButton.action = #selector(addTab)
+        addButton.toolTip = "New Tab"
+        addButton.setAccessibilityLabel("New Tab")
+        addButton.setAccessibilityHelp("Creates a new untitled tab")
+        addSubview(addButton)
+
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var isFlipped: Bool { true }
+
+    override func layout() {
+        super.layout()
+        let leadingInset: CGFloat = 8
+        let tabToButtonSpacing: CGFloat = 8
+        let buttonWidth: CGFloat = 36
+        let trailingInset: CGFloat = 10
+        let buttonX = bounds.width - trailingInset - buttonWidth
+        addButton.frame = NSRect(x: buttonX, y: 6, width: buttonWidth, height: max(24, bounds.height - 12))
+        scrollView.frame = NSRect(
+            x: leadingInset,
+            y: 0,
+            width: max(0, buttonX - tabToButtonSpacing - leadingInset),
+            height: max(0, bounds.height)
+        )
+        // The document view must fill the clip viewport. Deriving its height
+        // from contentSize can reuse a stale/short document height during a
+        // relayout, making the scroll view clip the rounded tab layers at the
+        // bottom (most visible against dark chrome).
+        tabsView.frame.size.height = scrollView.contentView.bounds.height
+        tabsView.layoutTabs(viewportWidth: scrollView.contentSize.width)
+        updateScrollEdgeMask()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        // The representable can retain its NSView while SwiftUI replaces the
+        // toolbar/editor surface. Refresh the item layers from the container
+        // so their semantic colors are resolved against the new appearance.
+        for tabView in tabViewsByID.values {
+            tabView.refreshForContainerAppearanceChange()
+        }
+    }
+
+    func apply(tabs: [MacNativeFileTabSnapshot], selectedTabID: UUID?) {
+        let incomingIDs = Set(tabs.map(\.id))
+        let staleIDs = tabViewsByID.keys.filter { !incomingIDs.contains($0) }
+        for staleID in staleIDs {
+            tabViewsByID.removeValue(forKey: staleID)?.removeFromSuperview()
+        }
+
+        orderedTabIDs = tabs.map(\.id)
+        self.selectedTabID = selectedTabID
+        var orderedViews: [MacNativeFileTabItemView] = []
+        orderedViews.reserveCapacity(tabs.count)
+
+        for snapshot in tabs {
+            let tabView: MacNativeFileTabItemView
+            if let existing = tabViewsByID[snapshot.id] {
+                tabView = existing
+            } else {
+                tabView = MacNativeFileTabItemView(tabID: snapshot.id)
+                tabView.onSelect = { [weak self] id in self?.onSelect?(id) }
+                tabView.onClose = { [weak self] id in self?.onClose?(id) }
+                tabViewsByID[snapshot.id] = tabView
+            }
+            tabView.apply(
+                snapshot: snapshot,
+                isSelected: snapshot.id == selectedTabID,
+                usesOpaqueEditorCanvas: usesOpaqueEditorCanvas
+            )
+            orderedViews.append(tabView)
+        }
+
+        tabsView.setTabViews(orderedViews)
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+        if let selectedTabID, let selectedView = tabViewsByID[selectedTabID] {
+            selectedView.scrollToVisible(selectedView.bounds)
+        }
+    }
+
+    func selectTabForTesting(_ id: UUID) {
+        onSelect?(id)
+    }
+
+    func closeTabForTesting(_ id: UUID) {
+        onClose?(id)
+    }
+
+    func moveTabForTesting(_ source: UUID, destination: UUID, before: Bool) {
+        onMove?(source, destination, before)
+    }
+
+    func selectionIndicatorFrameForTesting(_ id: UUID) -> NSRect? {
+        tabViewsByID[id]?.selectionIndicatorFrameForTesting
+    }
+
+    func visualStateForTesting(_ id: UUID) -> (backgroundAlpha: CGFloat, borderWidth: CGFloat, borderAlpha: CGFloat)? {
+        tabViewsByID[id]?.visualStateForTesting
+    }
+
+    func outlineGeometryForTesting(_ id: UUID) -> (pathBounds: CGRect, viewBounds: CGRect)? {
+        tabViewsByID[id]?.outlineGeometryForTesting
+    }
+
+    func outlineZPositionForTesting(_ id: UUID) -> CGFloat? {
+        tabViewsByID[id]?.outlineZPositionForTesting
+    }
+
+    func setHoveredForTesting(_ id: UUID, hovered: Bool) {
+        tabViewsByID[id]?.setHoveredForTesting(hovered)
+    }
+
+    func titleLayoutForTesting(_ id: UUID) -> (titleFrame: NSRect, tabBounds: NSRect)? {
+        tabViewsByID[id]?.titleLayoutForTesting
+    }
+
+    var addButtonLayoutForTesting: (buttonFrame: NSRect, tabsFrame: NSRect) {
+        (addButton.frame, scrollView.frame)
+    }
+
+    var horizontalScrollLayoutForTesting: (documentWidth: CGFloat, viewportWidth: CGFloat) {
+        (tabsView.frame.width, scrollView.contentSize.width)
+    }
+
+    func scrollToEndForTesting() {
+        let destination = max(0, tabsView.frame.width - scrollView.contentSize.width)
+        scrollView.contentView.scroll(to: NSPoint(x: destination, y: 0))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        updateScrollEdgeMask()
+    }
+
+    func selectAdjacentTab(from id: UUID, offset: Int) {
+        guard let index = orderedTabIDs.firstIndex(of: id) else { return }
+        let destinationIndex = index + offset
+        guard orderedTabIDs.indices.contains(destinationIndex) else { return }
+        let destinationID = orderedTabIDs[destinationIndex]
+        onSelect?(destinationID)
+        window?.makeFirstResponder(tabViewsByID[destinationID])
+    }
+
+    @objc private func addTab() {
+        onAdd?()
+    }
+
+    @objc private func scrollBoundsDidChange() {
+        updateScrollEdgeMask()
+    }
+
+    private func updateScrollEdgeMask() {
+        let viewportWidth = scrollView.contentSize.width
+        let maximumOffset = max(0, tabsView.frame.width - viewportWidth)
+        let offset = min(max(0, scrollView.contentView.bounds.minX), maximumOffset)
+        let showsLeftFade = offset > 0.5
+        let showsRightFade = maximumOffset - offset > 0.5
+        scrollEdgeFadeState = (showsLeftFade, showsRightFade)
+
+        let opaque = NSColor.black.cgColor
+        let clear = NSColor.clear.cgColor
+        scrollEdgeMask.frame = scrollView.bounds
+        scrollEdgeMask.colors = [
+            showsLeftFade ? clear : opaque,
+            opaque,
+            opaque,
+            showsRightFade ? clear : opaque
+        ]
+        scrollEdgeMask.locations = [0, 0.035, 0.965, 1]
+    }
+}
+
+@MainActor
+private final class MacNativeFileTabDocumentView: NSView {
+    private var tabViews: [MacNativeFileTabItemView] = []
+
+    override var isFlipped: Bool { true }
+
+    func setTabViews(_ views: [MacNativeFileTabItemView]) {
+        guard tabViews.map(\.tabID) != views.map(\.tabID) else { return }
+        tabViews = views
+        subviews = views
+        needsLayout = true
+    }
+
+    func layoutTabs(viewportWidth: CGFloat) {
+        let count = tabViews.count
+        guard count > 0 else {
+            frame.size.width = viewportWidth
+            return
+        }
+
+        let spacing: CGFloat = 5
+        let totalSpacing = spacing * CGFloat(max(0, count - 1))
+        let contentWidth = tabViews.reduce(0) { $0 + $1.preferredWidth } + totalSpacing
+        frame.size.width = max(viewportWidth, contentWidth)
+        var x: CGFloat = 0
+        for tabView in tabViews {
+            let width = tabView.preferredWidth
+            // Keep a full-pixel breathing room around the rounded layer. The
+            // previous 5-point inset put the lower border on the scroll view's
+            // clipping boundary in dark appearance, making inactive tabs look
+            // cut off at the bottom.
+            tabView.frame = NSRect(x: x, y: 6, width: width, height: max(24, bounds.height - 12))
+            x += width + spacing
+        }
+    }
+}
+
+@MainActor
+private final class MacNativeFileTabItemView: NSView, NSDraggingSource {
+    let tabID: UUID
+    var onSelect: ((UUID) -> Void)?
+    var onClose: ((UUID) -> Void)?
+
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let remoteLabel = NSTextField(labelWithString: "Remote")
+    private let lockImage = NSImageView()
+    private let closeButton = NSButton()
+    private let divider = NSBox()
+    private let selectionIndicator = NSBox()
+    private let outlineLayer = CAShapeLayer()
+    private var trackingAreaReference: NSTrackingArea?
+    private var snapshot: MacNativeFileTabSnapshot?
+    private var isSelected = false
+    private var isHovered = false
+    private var isDragging = false
+    private var insertionBefore: Bool?
+    private var usesOpaqueEditorCanvas = false
+
+    var selectionIndicatorFrameForTesting: NSRect { selectionIndicator.frame }
+    var visualStateForTesting: (backgroundAlpha: CGFloat, borderWidth: CGFloat, borderAlpha: CGFloat) {
+        (layer?.backgroundColor?.alpha ?? 0, outlineLayer.lineWidth, outlineLayer.strokeColor?.alpha ?? 0)
+    }
+    var outlineGeometryForTesting: (pathBounds: CGRect, viewBounds: CGRect)? {
+        guard let path = outlineLayer.path else { return nil }
+        return (path.boundingBox, bounds)
+    }
+    var outlineZPositionForTesting: CGFloat { outlineLayer.zPosition }
+
+    func setHoveredForTesting(_ hovered: Bool) {
+        isHovered = hovered
+        updateAppearance()
+    }
+    var titleLayoutForTesting: (titleFrame: NSRect, tabBounds: NSRect) { (titleLabel.frame, bounds) }
+    var preferredWidth: CGFloat {
+        let titleWidth = ceil(titleLabel.intrinsicContentSize.width)
+        let remoteContribution: CGFloat = snapshot?.isRemote == true ? 51 : 0
+        let lockContribution: CGFloat = snapshot?.isReadOnly == true ? 19 : 0
+        let chromeWidth: CGFloat = 41
+        return min(256, max(128, titleWidth + remoteContribution + lockContribution + chromeWidth))
+    }
+
+    init(tabID: UUID) {
+        self.tabID = tabID
+        super.init(frame: .zero)
+        wantsLayer = true
+        outlineLayer.fillColor = NSColor.clear.cgColor
+        outlineLayer.lineJoin = .round
+        // Keep the complete outline above labels and AppKit control layers.
+        // During an appearance/material relayout those child layers can be
+        // composited after the default-z sublayer and cover its lower edge.
+        outlineLayer.zPosition = 10
+        outlineLayer.needsDisplayOnBoundsChange = true
+        layer?.addSublayer(outlineLayer)
+        registerForDraggedTypes([.string])
+
+        titleLabel.lineBreakMode = .byTruncatingMiddle
+        titleLabel.maximumNumberOfLines = 1
+        titleLabel.font = .systemFont(ofSize: 12)
+        addSubview(titleLabel)
+
+        remoteLabel.font = .systemFont(ofSize: 9, weight: .semibold)
+        remoteLabel.textColor = .secondaryLabelColor
+        remoteLabel.alignment = .center
+        remoteLabel.wantsLayer = true
+        remoteLabel.layer?.cornerRadius = 5
+        remoteLabel.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(0.12).cgColor
+        addSubview(remoteLabel)
+
+        lockImage.image = NSImage(systemSymbolName: "lock.fill", accessibilityDescription: "Read Only")
+        lockImage.contentTintColor = .secondaryLabelColor
+        lockImage.imageScaling = .scaleProportionallyDown
+        addSubview(lockImage)
+
+        closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Close Tab")
+        closeButton.imagePosition = .imageOnly
+        closeButton.bezelStyle = .inline
+        closeButton.isBordered = false
+        closeButton.controlSize = .small
+        closeButton.image = closeButton.image?.withSymbolConfiguration(.init(pointSize: 9, weight: .medium))
+        closeButton.target = self
+        closeButton.action = #selector(closeTab)
+        addSubview(closeButton)
+
+        divider.boxType = .separator
+        addSubview(divider)
+
+        selectionIndicator.boxType = .custom
+        selectionIndicator.borderWidth = 0
+        selectionIndicator.fillColor = .controlAccentColor
+        selectionIndicator.cornerRadius = 1
+        addSubview(selectionIndicator)
+
+        setAccessibilityElement(true)
+        setAccessibilityRole(.radioButton)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 36, 49: // Return or Space
+            onSelect?(tabID)
+        case 123: // Left Arrow
+            enclosingBar?.selectAdjacentTab(from: tabID, offset: -1)
+        case 124: // Right Arrow
+            enclosingBar?.selectAdjacentTab(from: tabID, offset: 1)
+        default:
+            super.keyDown(with: event)
+        }
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        onSelect?(tabID)
+        return true
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAppearance()
+    }
+
+    func refreshForContainerAppearanceChange() {
+        updateAppearance()
+        needsLayout = true
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingAreaReference {
+            removeTrackingArea(trackingAreaReference)
+        }
+        let tracking = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(tracking)
+        trackingAreaReference = tracking
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+        updateAppearance()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+        insertionBefore = nil
+        updateAppearance()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        onSelect?(tabID)
+        if event.clickCount == 2 {
+            onClose?(tabID)
+        }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard !isDragging else { return }
+        isDragging = true
+        let pasteboardItem = NSPasteboardItem()
+        pasteboardItem.setString(tabID.uuidString, forType: .string)
+        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+        draggingItem.setDraggingFrame(bounds, contents: bitmapImageRepForCachingDisplay(in: bounds))
+        beginDraggingSession(with: [draggingItem], event: event, source: self)
+    }
+
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        .move
+    }
+
+    func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
+        isDragging = false
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        updateInsertion(for: sender)
+        return .move
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        updateInsertion(for: sender)
+        return .move
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        insertionBefore = nil
+        updateAppearance()
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        defer {
+            insertionBefore = nil
+            updateAppearance()
+        }
+        guard let value = sender.draggingPasteboard.string(forType: .string),
+              let sourceID = UUID(uuidString: value),
+              sourceID != tabID else { return false }
+        let before = insertionBefore ?? true
+        guard let bar = enclosingBar else { return false }
+        bar.onMove?(sourceID, tabID, before)
+        return true
+    }
+
+    override func draggingEnded(_ sender: NSDraggingInfo) {
+        insertionBefore = nil
+        updateAppearance()
+    }
+
+    override func layout() {
+        super.layout()
+        let borderWidth: CGFloat = 0.5
+        let borderInset = borderWidth / 2
+        outlineLayer.frame = bounds
+        outlineLayer.contentsScale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
+        outlineLayer.lineWidth = borderWidth
+        outlineLayer.path = CGPath(
+            roundedRect: bounds.insetBy(dx: borderInset, dy: borderInset),
+            cornerWidth: 7 - borderInset,
+            cornerHeight: 7 - borderInset,
+            transform: nil
+        )
+        let closeWidth: CGFloat = 22
+        let sidePadding: CGFloat = 10
+        let remoteWidth: CGFloat = snapshot?.isRemote == true ? 45 : 0
+        let lockWidth: CGFloat = snapshot?.isReadOnly == true ? 14 : 0
+        let remoteGap: CGFloat = remoteWidth > 0 ? 6 : 0
+        let lockGap: CGFloat = lockWidth > 0 ? 5 : 0
+
+        closeButton.frame = NSRect(x: bounds.width - closeWidth - 4, y: 2, width: closeWidth, height: bounds.height - 4)
+        remoteLabel.frame = NSRect(x: sidePadding, y: max(7, bounds.height - 20), width: remoteWidth, height: 15)
+        let titleX = sidePadding + remoteWidth + remoteGap
+        let titleWidth = max(12, bounds.width - titleX - closeWidth - lockWidth - lockGap - 5)
+        titleLabel.frame = NSRect(x: titleX, y: max(7, bounds.height - 22), width: titleWidth, height: 18)
+        lockImage.frame = NSRect(x: titleLabel.frame.maxX + lockGap, y: max(9, bounds.height - 18), width: lockWidth, height: 12)
+        divider.frame = NSRect(x: bounds.width + 2, y: 7, width: 1, height: max(0, bounds.height - 14))
+        selectionIndicator.frame = NSRect(
+            x: insertionBefore == nil ? 8 : (insertionBefore == true ? -3 : bounds.width + 1),
+            y: insertionBefore == nil ? bounds.height - 2 : 3,
+            width: insertionBefore == nil ? max(0, bounds.width - 16) : 2,
+            height: insertionBefore == nil ? 2 : bounds.height - 6
+        )
+    }
+
+    func apply(
+        snapshot: MacNativeFileTabSnapshot,
+        isSelected: Bool,
+        usesOpaqueEditorCanvas: Bool
+    ) {
+        self.snapshot = snapshot
+        self.isSelected = isSelected
+        self.usesOpaqueEditorCanvas = usesOpaqueEditorCanvas
+        titleLabel.stringValue = snapshot.title + (snapshot.isDirty ? " •" : "")
+        titleLabel.font = .systemFont(ofSize: 12, weight: isSelected ? .semibold : .regular)
+        titleLabel.textColor = isSelected ? .labelColor : .secondaryLabelColor
+        remoteLabel.isHidden = !snapshot.isRemote
+        lockImage.isHidden = !snapshot.isReadOnly
+        closeButton.toolTip = "Close \(snapshot.title)"
+        closeButton.setAccessibilityLabel("Close \(snapshot.title)")
+        setAccessibilityLabel(accessibilityLabel(for: snapshot))
+        setAccessibilityValue(isSelected ? "Selected" : "Not selected")
+        setAccessibilityHelp("Press to select this tab. Use the left and right arrow keys to move between tabs.")
+        updateAppearance()
+        needsLayout = true
+    }
+
+    private var enclosingBar: MacNativeFileTabBarView? {
+        var candidate = superview
+        while let view = candidate {
+            if let bar = view as? MacNativeFileTabBarView { return bar }
+            candidate = view.superview
+        }
+        return nil
+    }
+
+    private func updateInsertion(for sender: NSDraggingInfo) {
+        let point = convert(sender.draggingLocation, from: nil)
+        insertionBefore = point.x < bounds.midX
+        updateAppearance()
+    }
+
+    private func updateAppearance() {
+        let isDarkAppearance = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let stateColor: NSColor? = if snapshot?.isDirty == true {
+            .systemOrange
+        } else if isSelected {
+            .controlAccentColor
+        } else {
+            nil
+        }
+        let fillColor: NSColor
+        if let stateColor {
+            fillColor = stateColor.withAlphaComponent(snapshot?.isDirty == true ? 0.13 : 0.105)
+        } else if isHovered {
+            fillColor = .labelColor.withAlphaComponent(0.075)
+        } else {
+            // Opaque light editor chrome is close to white, so the very low
+            // contrast used by translucent/dark surfaces makes inactive tabs
+            // visually disappear. Keep them quiet, but give each tab a clear
+            // surface boundary in light mode.
+            fillColor = .labelColor.withAlphaComponent(isDarkAppearance ? 0.025 : 0.055)
+        }
+        layer?.backgroundColor = fillColor.cgColor
+        layer?.cornerRadius = 7
+        layer?.borderWidth = 0
+        // Resolve the inactive outline to a concrete color before handing it
+        // to Core Animation. Retaining separatorColor's dynamic CGColor lets
+        // AppKit's material/hover recomposition replace the resolved contrast,
+        // which is why the border could flash once and then disappear.
+        let inactiveOutlineColor = NSColor(
+            calibratedWhite: isDarkAppearance ? 1 : 0,
+            alpha: !isDarkAppearance && usesOpaqueEditorCanvas ? 0.32 : (isDarkAppearance ? 0.34 : 0.28)
+        )
+        outlineLayer.strokeColor = stateColor != nil
+            ? stateColor?.withAlphaComponent(0.24).cgColor
+            : inactiveOutlineColor.cgColor
+        closeButton.isHidden = !(isSelected || isHovered || snapshot?.isDirty == true)
+        selectionIndicator.isHidden = insertionBefore == nil && stateColor == nil
+        selectionIndicator.fillColor = insertionBefore == nil ? (stateColor ?? .controlAccentColor) : .keyboardFocusIndicatorColor
+        divider.isHidden = true
+        needsLayout = true
+    }
+
+    private func accessibilityLabel(for snapshot: MacNativeFileTabSnapshot) -> String {
+        var parts = [snapshot.title, snapshot.isRemote ? "remote document" : "local document"]
+        if snapshot.isReadOnly { parts.append("read only") }
+        if snapshot.isDirty { parts.append("unsaved changes") }
+        return parts.joined(separator: ", ")
+    }
+
+    @objc private func closeTab() {
+        onClose?(tabID)
+    }
+}
+#endif

--- a/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
@@ -1,0 +1,479 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+struct MobileNativeFileTabSnapshot: Equatable, Identifiable {
+    let id: UUID
+    let title: String
+    let isDirty: Bool
+    let isRemote: Bool
+    let isReadOnly: Bool
+}
+
+struct MobileNativeFileTabBar: UIViewRepresentable {
+    let tabs: [MobileNativeFileTabSnapshot]
+    let selectedTabID: UUID?
+    let onSelect: (UUID) -> Void
+    let onClose: (UUID) -> Void
+    let onMove: (UUID, UUID, Bool) -> Void
+    let onAdd: () -> Void
+
+    func makeUIView(context: Context) -> MobileNativeFileTabBarView {
+        let view = MobileNativeFileTabBarView()
+        configure(view)
+        return view
+    }
+
+    func updateUIView(_ uiView: MobileNativeFileTabBarView, context: Context) {
+        configure(uiView)
+    }
+
+    private func configure(_ view: MobileNativeFileTabBarView) {
+        view.onSelect = onSelect
+        view.onClose = onClose
+        view.onMove = onMove
+        view.onAdd = onAdd
+        view.apply(tabs: tabs, selectedTabID: selectedTabID)
+    }
+}
+
+@MainActor
+final class MobileNativeFileTabBarView: UIView {
+    var onSelect: ((UUID) -> Void)?
+    var onClose: ((UUID) -> Void)?
+    var onMove: ((UUID, UUID, Bool) -> Void)?
+    var onAdd: (() -> Void)?
+
+    private let scrollView = UIScrollView()
+    private let tabsView = UIView()
+    private let addButton = UIButton(type: .system)
+    private let separator = UIView()
+    private var tabViewsByID: [UUID: MobileNativeFileTabItemView] = [:]
+    private(set) var orderedTabIDs: [UUID] = []
+    private(set) var selectedTabID: UUID?
+
+    var managedTabViewCount: Int { tabViewsByID.count }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .clear
+
+        scrollView.backgroundColor = .clear
+        scrollView.alwaysBounceHorizontal = false
+        scrollView.alwaysBounceVertical = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.isDirectionalLockEnabled = true
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.addSubview(tabsView)
+        addSubview(scrollView)
+
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: "plus")
+        configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
+        configuration.contentInsets = .zero
+        addButton.configuration = configuration
+        addButton.accessibilityLabel = "New Tab"
+        addButton.accessibilityHint = "Creates a new untitled tab"
+        addButton.addTarget(self, action: #selector(addTab), for: .touchUpInside)
+        addSubview(addButton)
+
+        separator.backgroundColor = .separator.withAlphaComponent(0.45)
+        separator.isAccessibilityElement = false
+        addSubview(separator)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let scale = max(1, traitCollection.displayScale)
+        let separatorHeight = 1 / scale
+        let leadingInset: CGFloat = 8
+        let buttonWidth: CGFloat = 44
+        let trailingInset: CGFloat = 4
+        let spacing: CGFloat = 4
+        let buttonX = max(leadingInset, bounds.width - trailingInset - buttonWidth)
+
+        separator.frame = CGRect(x: 0, y: bounds.height - separatorHeight, width: bounds.width, height: separatorHeight)
+        addButton.frame = CGRect(x: buttonX, y: 0, width: buttonWidth, height: max(0, bounds.height - separatorHeight))
+        scrollView.frame = CGRect(
+            x: leadingInset,
+            y: 0,
+            width: max(0, buttonX - spacing - leadingInset),
+            height: max(0, bounds.height - separatorHeight)
+        )
+        layoutTabs(viewportWidth: scrollView.bounds.width)
+    }
+
+    func apply(
+        tabs: [MobileNativeFileTabSnapshot],
+        selectedTabID: UUID?,
+    ) {
+        let incomingIDs = Set(tabs.map(\.id))
+        for staleID in tabViewsByID.keys.filter({ !incomingIDs.contains($0) }) {
+            tabViewsByID.removeValue(forKey: staleID)?.removeFromSuperview()
+        }
+
+        orderedTabIDs = tabs.map(\.id)
+        self.selectedTabID = selectedTabID
+
+        for snapshot in tabs {
+            let tabView: MobileNativeFileTabItemView
+            if let existing = tabViewsByID[snapshot.id] {
+                tabView = existing
+            } else {
+                tabView = MobileNativeFileTabItemView(tabID: snapshot.id)
+                tabView.onSelect = { [weak self] id in self?.onSelect?(id) }
+                tabView.onClose = { [weak self] id in self?.onClose?(id) }
+                tabView.onMove = { [weak self] source, destination, before in
+                    self?.onMove?(source, destination, before)
+                }
+                tabViewsByID[snapshot.id] = tabView
+                tabsView.addSubview(tabView)
+            }
+            tabView.apply(
+                snapshot: snapshot,
+                isSelected: snapshot.id == selectedTabID,
+                allowsReordering: traitCollection.userInterfaceIdiom == .pad
+            )
+        }
+
+        for (index, id) in orderedTabIDs.enumerated() {
+            guard let tabView = tabViewsByID[id] else { continue }
+            tabsView.insertSubview(tabView, at: index)
+        }
+
+        setNeedsLayout()
+        layoutIfNeeded()
+        scrollSelectedTabToVisible(animated: window != nil)
+    }
+
+    private func layoutTabs(viewportWidth: CGFloat) {
+        let count = orderedTabIDs.count
+        guard count > 0 else {
+            tabsView.frame = CGRect(x: 0, y: 0, width: viewportWidth, height: scrollView.bounds.height)
+            scrollView.contentSize = tabsView.bounds.size
+            return
+        }
+
+        let spacing: CGFloat = 5
+        let totalSpacing = spacing * CGFloat(max(0, count - 1))
+        let maximumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 220 : 188
+        let minimumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 136 : 128
+        let fittedWidth = (viewportWidth - totalSpacing) / CGFloat(count)
+        let tabWidth = min(maximumWidth, max(minimumWidth, fittedWidth))
+        let contentWidth = max(viewportWidth, tabWidth * CGFloat(count) + totalSpacing)
+        tabsView.frame = CGRect(x: 0, y: 0, width: contentWidth, height: scrollView.bounds.height)
+        scrollView.contentSize = tabsView.bounds.size
+
+        var x: CGFloat = 0
+        for id in orderedTabIDs {
+            tabViewsByID[id]?.frame = CGRect(x: x, y: 5, width: tabWidth, height: max(28, tabsView.bounds.height - 10))
+            x += tabWidth + spacing
+        }
+    }
+
+    private func scrollSelectedTabToVisible(animated: Bool) {
+        guard let selectedTabID, let selectedView = tabViewsByID[selectedTabID] else { return }
+        let visibleRect = selectedView.frame.insetBy(dx: -6, dy: 0)
+        guard !scrollView.bounds.contains(visibleRect) else { return }
+        scrollView.scrollRectToVisible(visibleRect, animated: animated)
+    }
+
+    func selectTabForTesting(_ id: UUID) { onSelect?(id) }
+    func closeTabForTesting(_ id: UUID) { onClose?(id) }
+    func moveTabForTesting(_ source: UUID, destination: UUID, before: Bool) {
+        onMove?(source, destination, before)
+    }
+    func addTabForTesting() { onAdd?() }
+
+    func visualStateForTesting(_ id: UUID) -> (selected: Bool, previous: Bool, dirty: Bool)? {
+        tabViewsByID[id]?.visualStateForTesting
+    }
+
+    func accessibilityStateForTesting(_ id: UUID) -> (label: String?, traits: UIAccessibilityTraits)? {
+        guard let view = tabViewsByID[id] else { return nil }
+        return (view.accessibilityLabel, view.accessibilityTraits)
+    }
+
+    func accessibilityActionsForTesting(_ id: UUID) -> [String]? {
+        tabViewsByID[id]?.accessibilityCustomActions?.map(\.name)
+    }
+
+    func tabFrameForTesting(_ id: UUID) -> CGRect? { tabViewsByID[id]?.frame }
+
+    var addButtonFrameForTesting: CGRect { addButton.frame }
+    var scrollViewFrameForTesting: CGRect { scrollView.frame }
+    var horizontalContentOffsetForTesting: CGFloat { scrollView.contentOffset.x }
+    var horizontalContentWidthForTesting: CGFloat { scrollView.contentSize.width }
+
+    @objc private func addTab() {
+        onAdd?()
+    }
+}
+
+@MainActor
+private final class MobileNativeFileTabItemView: UIControl, UIDragInteractionDelegate, UIDropInteractionDelegate {
+    let tabID: UUID
+    var onSelect: ((UUID) -> Void)?
+    var onClose: ((UUID) -> Void)?
+    var onMove: ((UUID, UUID, Bool) -> Void)?
+    var allowsReordering = false {
+        didSet {
+            dragInteraction.isEnabled = allowsReordering
+            updateAccessibilityActions()
+        }
+    }
+
+    private let remoteLabel = UILabel()
+    private let titleLabel = UILabel()
+    private let lockImage = UIImageView()
+    private let dirtyIndicator = UIView()
+    private let closeButton = UIButton(type: .system)
+    private let selectionIndicator = UIView()
+    private lazy var dragInteraction = UIDragInteraction(delegate: self)
+    private lazy var dropInteraction = UIDropInteraction(delegate: self)
+    private var snapshot: MobileNativeFileTabSnapshot?
+    private var isCurrentSelection = false
+    private var insertionBefore: Bool?
+
+    var visualStateForTesting: (selected: Bool, previous: Bool, dirty: Bool) {
+        (isCurrentSelection, false, snapshot?.isDirty == true)
+    }
+
+    init(tabID: UUID) {
+        self.tabID = tabID
+        super.init(frame: .zero)
+        layer.cornerCurve = .continuous
+        layer.cornerRadius = 8
+        layer.borderWidth = 0.5
+        clipsToBounds = false
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        addTarget(self, action: #selector(selectTab), for: .touchUpInside)
+
+        remoteLabel.text = "Remote"
+        remoteLabel.font = .systemFont(ofSize: 9, weight: .semibold)
+        remoteLabel.textColor = .secondaryLabel
+        remoteLabel.textAlignment = .center
+        remoteLabel.layer.cornerRadius = 5
+        remoteLabel.layer.backgroundColor = UIColor.tintColor.withAlphaComponent(0.12).cgColor
+        remoteLabel.clipsToBounds = true
+        remoteLabel.isAccessibilityElement = false
+        addSubview(remoteLabel)
+
+        titleLabel.font = .systemFont(ofSize: 12)
+        titleLabel.textColor = .secondaryLabel
+        titleLabel.lineBreakMode = .byTruncatingMiddle
+        titleLabel.numberOfLines = 1
+        titleLabel.isAccessibilityElement = false
+        addSubview(titleLabel)
+
+        lockImage.image = UIImage(systemName: "lock.fill")
+        lockImage.tintColor = .secondaryLabel
+        lockImage.contentMode = .scaleAspectFit
+        lockImage.isAccessibilityElement = false
+        addSubview(lockImage)
+
+        dirtyIndicator.backgroundColor = .systemOrange
+        dirtyIndicator.layer.cornerRadius = 3
+        dirtyIndicator.isAccessibilityElement = false
+        addSubview(dirtyIndicator)
+
+        var closeConfiguration = UIButton.Configuration.plain()
+        closeConfiguration.image = UIImage(systemName: "xmark")
+        closeConfiguration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 10, weight: .semibold)
+        closeConfiguration.contentInsets = .zero
+        closeButton.configuration = closeConfiguration
+        closeButton.accessibilityHint = "Closes this editor tab"
+        closeButton.addTarget(self, action: #selector(closeTab), for: .touchUpInside)
+        addSubview(closeButton)
+
+        selectionIndicator.backgroundColor = .tintColor
+        selectionIndicator.layer.cornerRadius = 1
+        selectionIndicator.isAccessibilityElement = false
+        addSubview(selectionIndicator)
+
+        addInteraction(dragInteraction)
+        addInteraction(dropInteraction)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let closeWidth: CGFloat = 36
+        let sidePadding: CGFloat = 10
+        let remoteWidth: CGFloat = snapshot?.isRemote == true ? 43 : 0
+        let lockWidth: CGFloat = snapshot?.isReadOnly == true ? 13 : 0
+        let dirtyWidth: CGFloat = snapshot?.isDirty == true ? 6 : 0
+        let remoteGap: CGFloat = remoteWidth > 0 ? 6 : 0
+        let lockGap: CGFloat = lockWidth > 0 ? 4 : 0
+        let dirtyGap: CGFloat = dirtyWidth > 0 ? 5 : 0
+
+        closeButton.frame = CGRect(x: bounds.width - closeWidth, y: 0, width: closeWidth, height: bounds.height)
+        remoteLabel.frame = CGRect(x: sidePadding, y: max(7, bounds.height - 22), width: remoteWidth, height: 15)
+        let titleX = sidePadding + remoteWidth + remoteGap
+        let reservedWidth = closeWidth + lockWidth + lockGap + dirtyWidth + dirtyGap + 4
+        titleLabel.frame = CGRect(
+            x: titleX,
+            y: max(6, bounds.height - 23),
+            width: max(12, bounds.width - titleX - reservedWidth),
+            height: 18
+        )
+        lockImage.frame = CGRect(x: titleLabel.frame.maxX + lockGap, y: max(8, bounds.height - 20), width: lockWidth, height: 13)
+        dirtyIndicator.frame = CGRect(x: lockImage.frame.maxX + dirtyGap, y: bounds.midY - 3, width: dirtyWidth, height: dirtyWidth)
+        selectionIndicator.frame = CGRect(x: 8, y: bounds.height - 2, width: max(0, bounds.width - 16), height: 2)
+
+        if let insertionBefore {
+            selectionIndicator.frame = CGRect(
+                x: insertionBefore ? -2 : bounds.width,
+                y: 3,
+                width: 2,
+                height: max(0, bounds.height - 6)
+            )
+        }
+    }
+
+    func apply(
+        snapshot: MobileNativeFileTabSnapshot,
+        isSelected: Bool,
+        allowsReordering: Bool
+    ) {
+        self.snapshot = snapshot
+        isCurrentSelection = isSelected
+        titleLabel.text = snapshot.title
+        titleLabel.font = .systemFont(ofSize: 12, weight: isSelected ? .semibold : .regular)
+        titleLabel.textColor = isSelected ? .label : .secondaryLabel
+        remoteLabel.isHidden = !snapshot.isRemote
+        lockImage.isHidden = !snapshot.isReadOnly
+        dirtyIndicator.isHidden = !snapshot.isDirty
+        closeButton.accessibilityLabel = "Close \(snapshot.title)"
+        accessibilityLabel = accessibilityLabel(for: snapshot)
+        accessibilityValue = isSelected ? "Selected" : nil
+        accessibilityHint = allowsReordering
+            ? "Double tap to select. Drag to reorder tabs."
+            : "Double tap to select this editor tab."
+        accessibilityTraits = isSelected ? [.button, .selected] : .button
+        self.allowsReordering = allowsReordering
+        updateAppearance()
+        setNeedsLayout()
+    }
+
+    override var isHighlighted: Bool {
+        didSet { updateAppearance() }
+    }
+
+    private func updateAppearance() {
+        let fillColor: UIColor
+        if isCurrentSelection {
+            fillColor = tintColor.withAlphaComponent(0.14)
+        } else if isHighlighted {
+            fillColor = UIColor.label.withAlphaComponent(0.10)
+        } else {
+            // Keep inactive tabs legible against both light and dark toolbar
+            // materials without introducing the heavy gray slab seen in the
+            // system secondary fill on translucent surfaces.
+            fillColor = UIColor.label.withAlphaComponent(0.055)
+        }
+        backgroundColor = fillColor
+        layer.borderColor = isCurrentSelection
+            ? tintColor.withAlphaComponent(0.28).cgColor
+            : UIColor.separator.withAlphaComponent(0.18).cgColor
+        selectionIndicator.isHidden = insertionBefore == nil && !isCurrentSelection
+        selectionIndicator.backgroundColor = insertionBefore == nil ? tintColor : .systemBlue
+    }
+
+    private func updateAccessibilityActions() {
+        var actions = [
+            UIAccessibilityCustomAction(name: "Close Tab", target: self, selector: #selector(closeForAccessibility))
+        ]
+        guard allowsReordering else {
+            accessibilityCustomActions = actions
+            return
+        }
+        actions.append(contentsOf: [
+            UIAccessibilityCustomAction(name: "Move Tab Left", target: self, selector: #selector(moveLeftForAccessibility)),
+            UIAccessibilityCustomAction(name: "Move Tab Right", target: self, selector: #selector(moveRightForAccessibility))
+        ])
+        accessibilityCustomActions = actions
+    }
+
+    private func accessibilityLabel(for snapshot: MobileNativeFileTabSnapshot) -> String {
+        var parts = [snapshot.title, snapshot.isRemote ? "remote document" : "local document"]
+        if snapshot.isReadOnly { parts.append("read only") }
+        if snapshot.isDirty { parts.append("unsaved changes") }
+        return parts.joined(separator: ", ")
+    }
+
+    @objc private func selectTab() { onSelect?(tabID) }
+    @objc private func closeTab() { onClose?(tabID) }
+
+    @objc private func closeForAccessibility() -> Bool {
+        onClose?(tabID)
+        return true
+    }
+
+    @objc private func moveLeftForAccessibility() -> Bool {
+        moveForAccessibility(offset: -1)
+    }
+
+    @objc private func moveRightForAccessibility() -> Bool {
+        moveForAccessibility(offset: 1)
+    }
+
+    private func moveForAccessibility(offset: Int) -> Bool {
+        guard let bar = superview?.superview?.superview as? MobileNativeFileTabBarView,
+              let index = bar.orderedTabIDs.firstIndex(of: tabID) else { return false }
+        let destinationIndex = index + offset
+        guard bar.orderedTabIDs.indices.contains(destinationIndex) else { return false }
+        onMove?(tabID, bar.orderedTabIDs[destinationIndex], offset < 0)
+        return true
+    }
+
+    func dragInteraction(_ interaction: UIDragInteraction, itemsForBeginning session: UIDragSession) -> [UIDragItem] {
+        guard allowsReordering else { return [] }
+        let provider = NSItemProvider(object: tabID.uuidString as NSString)
+        let item = UIDragItem(itemProvider: provider)
+        item.localObject = tabID
+        return [item]
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
+        guard allowsReordering,
+              let sourceID = session.items.first?.localObject as? UUID,
+              sourceID != tabID else {
+            insertionBefore = nil
+            updateAppearance()
+            return UIDropProposal(operation: .forbidden)
+        }
+        insertionBefore = session.location(in: self).x < bounds.midX
+        updateAppearance()
+        setNeedsLayout()
+        return UIDropProposal(operation: .move)
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidExit session: UIDropSession) {
+        insertionBefore = nil
+        updateAppearance()
+        setNeedsLayout()
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, performDrop session: UIDropSession) {
+        defer {
+            insertionBefore = nil
+            updateAppearance()
+            setNeedsLayout()
+        }
+        guard let sourceID = session.items.first?.localObject as? UUID,
+              sourceID != tabID else { return }
+        onMove?(sourceID, tabID, insertionBefore ?? true)
+    }
+}
+#endif

--- a/Neon Vision Editor/UI/NeonSettingsSyncModifier.swift
+++ b/Neon Vision Editor/UI/NeonSettingsSyncModifier.swift
@@ -11,9 +11,6 @@ struct AppearanceThemeSettingsSyncModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onAppear {
-                applyResult(AppearanceThemeCloudSync.syncIfEnabled())
-            }
             .onReceive(NotificationCenter.default.publisher(for: NSUbiquitousKeyValueStore.didChangeExternallyNotification)) { _ in
                 applyResult(AppearanceThemeCloudSync.syncIfEnabled())
             }

--- a/Neon Vision Editor/UI/NeonSettingsView.swift
+++ b/Neon Vision Editor/UI/NeonSettingsView.swift
@@ -941,6 +941,15 @@ struct NeonSettingsView: View {
             }
 #endif
         }
+#if os(macOS)
+        // Native macOS preferences should switch panes without the implicit
+        // TabView transition. That transition keeps the old pane in the view
+        // graph while the new pane is measured, which makes the window appear
+        // to rearrange before its final height is applied.
+        .transaction { transaction in
+            transaction.animation = nil
+        }
+#endif
 #if os(iOS) || os(visionOS)
         .animation(.easeOut(duration: 0.22), value: settingsActiveTab)
 #endif
@@ -1230,9 +1239,18 @@ struct NeonSettingsView: View {
             SettingsWindowConfigurator(
                 minSize: macSettingsWindowSize.min,
                 idealSize: macSettingsWindowSize.ideal,
-                preferredContentHeight: macSettingsContentHeights[settingsActiveTab].map {
-                    $0 + UI.macSettingsToolbarContentMargin
-                },
+                editorWindowNumber: WindowViewModelRegistry.shared.windowNumber(for: editorViewModel),
+                themeBackgroundRaw: colorToHex(
+                    currentEditorTheme(colorScheme: effectiveSettingsColorScheme).background
+                ),
+                opaqueEditorCanvasEnabled: opaqueEditorSurfaceMac,
+                // Keep a target available in the same update as the tab
+                // selection. The measured value replaces this estimate as
+                // soon as the selected pane reports its natural height.
+                preferredContentHeight: (
+                    macSettingsContentHeights[settingsActiveTab]
+                        ?? Self.macSettingsEstimatedContentHeight(for: settingsActiveTab)
+                ) + UI.macSettingsToolbarContentMargin,
                 translucentEnabled: usesTranslucentSettingsSurface,
                 translucencyModeRaw: macTranslucencyModeRaw,
                 appearanceRaw: appearance,
@@ -1452,19 +1470,8 @@ struct NeonSettingsView: View {
 
 #if os(macOS)
     private func applyAppearanceImmediately() {
-        let target: NSAppearance?
-        switch appearance {
-        case "light":
-            target = NSAppearance(named: .aqua)
-        case "dark":
-            target = NSAppearance(named: .darkAqua)
-        default:
-            target = nil
-        }
-        NSApp.appearance = target
+        ReleaseRuntimePolicy.applyMacApplicationAppearance(appearance)
         for window in NSApp.windows {
-            window.appearance = target
-            window.contentView?.appearance = target
             window.contentView?.needsDisplay = true
         }
     }
@@ -6426,7 +6433,9 @@ struct NeonSettingsView: View {
                   let height = heights[tabID],
                   height > 0,
                   abs((macSettingsContentHeights[tabID] ?? 0) - height) > 0.5 else { return }
-            macSettingsContentHeights[tabID] = height
+            withTransaction(Transaction(animation: nil)) {
+                macSettingsContentHeights[tabID] = height
+            }
             Self.storeMacSettingsContentHeights(macSettingsContentHeights)
         }
 #else
@@ -6528,17 +6537,26 @@ struct NeonSettingsView: View {
     }
 
     private var settingsWindowBackground: AnyShapeStyle {
-        guard usesTranslucentSettingsSurface else {
-            return AnyShapeStyle(Color(nsColor: .windowBackgroundColor))
+        let themeBackground = currentEditorTheme(colorScheme: effectiveSettingsColorScheme).background
+        if usesTranslucentSettingsSurface {
+            let nativeSurface = SettingsWindowConfigurator.settingsWindowBackgroundColor(
+                translucentEnabled: true,
+                translucencyModeRaw: macTranslucencyModeRaw,
+                appearanceRaw: appearance,
+                effectiveColorScheme: effectiveSettingsColorScheme
+            )
+            return AnyShapeStyle(Color(nsColor: nativeSurface))
         }
-        // Use the exact same calibrated color as the native window bridge. This
-        // keeps the header, tab strip, divider area, and content at one alpha.
-        return AnyShapeStyle(Color(nsColor: SettingsWindowConfigurator.settingsWindowBackgroundColor(
-            translucentEnabled: true,
-            translucencyModeRaw: macTranslucencyModeRaw,
-            appearanceRaw: appearance,
-            effectiveColorScheme: effectiveSettingsColorScheme
-        )))
+        guard opaqueEditorSurfaceMac else {
+            let nativeSurface = SettingsWindowConfigurator.settingsWindowBackgroundColor(
+                translucentEnabled: false,
+                translucencyModeRaw: macTranslucencyModeRaw,
+                appearanceRaw: appearance,
+                effectiveColorScheme: effectiveSettingsColorScheme
+            )
+            return AnyShapeStyle(Color(nsColor: nativeSurface))
+        }
+        return AnyShapeStyle(themeBackground)
     }
 #endif
 
@@ -6785,7 +6803,8 @@ struct NeonSettingsView: View {
     }
 
     private var macSettingsWindowSize: (min: NSSize, ideal: NSSize) {
-        // Keep a stable window envelope across tabs to avoid toolbar-tab jump/overflow relayout.
+        // Keep width and safety bounds stable; the configurator applies each
+        // pane's measured natural height to the native window.
         Self.macSettingsWindowSizePolicy()
     }
 
@@ -6794,6 +6813,23 @@ struct NeonSettingsView: View {
         // safe single-column layout before either form card can overlap, while
         // Toolbar retains enough room for two readable preset cards.
         (NSSize(width: 600, height: 320), NSSize(width: 900, height: 1120))
+    }
+
+    /// Supplies a deterministic target while a newly selected pane is being
+    /// mounted. SwiftUI only publishes the pane's measured height after that
+    /// mount, so waiting for the preference leaves AppKit displaying the old
+    /// window frame during the tab transition.
+    nonisolated static func macSettingsEstimatedContentHeight(for tabID: String) -> CGFloat {
+        switch tabID {
+        case "ai":
+            800
+        case "editor", "toolbar", "themes", "support", "remote", "shortcuts":
+            700
+        case "templates":
+            560
+        default:
+            760
+        }
     }
 
     nonisolated static func macSettingsInitialWindowSize() -> NSSize {
@@ -6805,12 +6841,7 @@ struct NeonSettingsView: View {
         // Bootstrap from the active pane, then replace this estimate with its
         // measured height. This matches native dynamic Preferences windows:
         // each pane gets its own natural height without a fixed global frame.
-        let fallbackContentHeight: CGFloat = switch activeTab {
-        case "ai": 800
-        case "editor", "toolbar", "themes", "support", "remote", "shortcuts": 700
-        case "templates": 560
-        default: 760
-        }
+        let fallbackContentHeight = macSettingsEstimatedContentHeight(for: activeTab)
         let contentHeight = measuredContentHeight ?? fallbackContentHeight
         let windowHeight = min(
             max(contentHeight + 20, policy.min.height),
@@ -7197,6 +7228,9 @@ private enum DefaultFileAssociation {
 struct SettingsWindowConfigurator: NSViewRepresentable {
     let minSize: NSSize
     let idealSize: NSSize
+    let editorWindowNumber: Int?
+    let themeBackgroundRaw: String
+    let opaqueEditorCanvasEnabled: Bool
     let preferredContentHeight: CGFloat?
     let translucentEnabled: Bool
     let translucencyModeRaw: String
@@ -7208,6 +7242,10 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
         var pendingApply: DispatchWorkItem?
         var lastTranslucentEnabled: Bool?
         var lastTranslucencyModeRaw: String?
+        var lastAppearanceRaw: String?
+        var lastEffectiveColorScheme: ColorScheme?
+        var lastThemeBackgroundRaw: String?
+        var lastOpaqueEditorCanvasEnabled: Bool?
         var didConfigureWindowChrome = false
         var lastPreferredContentHeight: CGFloat?
         var stableTopEdge: CGFloat?
@@ -7238,6 +7276,29 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
+        let coordinator = context.coordinator
+        let preferredHeightChanged: Bool = {
+            guard let preferredContentHeight else {
+                return coordinator.lastPreferredContentHeight != nil
+            }
+            guard let lastPreferredContentHeight = coordinator.lastPreferredContentHeight else {
+                return true
+            }
+            return abs(lastPreferredContentHeight - preferredContentHeight) > 1
+        }()
+        if coordinator.didInitialApply,
+           coordinator.lastTranslucentEnabled == translucentEnabled,
+           coordinator.lastTranslucencyModeRaw == translucencyModeRaw,
+           coordinator.lastAppearanceRaw == appearanceRaw,
+           coordinator.lastEffectiveColorScheme == effectiveColorScheme,
+           coordinator.lastThemeBackgroundRaw == themeBackgroundRaw,
+           coordinator.lastOpaqueEditorCanvasEnabled == opaqueEditorCanvasEnabled,
+           !preferredHeightChanged {
+            // Settings controls can invalidate the parent view frequently. Do
+            // not re-enter AppKit window layout for changes that do not affect
+            // the Settings window's actual chrome or surface.
+            return
+        }
         scheduleApply(to: nsView.window, coordinator: context.coordinator)
     }
 
@@ -7251,15 +7312,10 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
             apply(to: window, coordinator: coordinator)
             return
         }
-        let work = DispatchWorkItem { [weak window, weak coordinator] in
-            guard let window, let coordinator else { return }
-            apply(to: window, coordinator: coordinator)
-        }
-        coordinator.pendingApply = work
-        // The Settings scene applies its default/restored frame after the first view update.
-        // Apply a measured content height only after that layout pass has completed.
-        let delay: DispatchTimeInterval = coordinator.didInitialApply ? .milliseconds(150) : .milliseconds(0)
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        // The target height is already part of this representable update. A
+        // main-queue hop lets SwiftUI paint the old pane first and exposes the
+        // window-frame correction as visible movement, so apply synchronously.
+        apply(to: window, coordinator: coordinator)
     }
 
     private func apply(to window: NSWindow?, coordinator: Coordinator) {
@@ -7267,10 +7323,15 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
         ensureObservers(for: window, coordinator: coordinator)
         coordinator.lastTranslucentEnabled = translucentEnabled
         coordinator.lastTranslucencyModeRaw = translucencyModeRaw
+        coordinator.lastAppearanceRaw = appearanceRaw
+        coordinator.lastEffectiveColorScheme = effectiveColorScheme
+        coordinator.lastThemeBackgroundRaw = themeBackgroundRaw
+        coordinator.lastOpaqueEditorCanvasEnabled = opaqueEditorCanvasEnabled
         let isInitialLayout = !coordinator.didInitialApply
 
         if isInitialLayout {
             enforceResizableSettingsWindowBounds(on: window)
+            centerOverEditorWindow(window)
         }
 
         if !coordinator.didConfigureWindowChrome {
@@ -7295,6 +7356,9 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
             coordinator.stableTopEdge = window.frame.maxY
         }
         if let preferredContentHeight,
+           (isInitialLayout || coordinator.lastPreferredContentHeight.map {
+               abs($0 - preferredContentHeight) > 1
+           } ?? true),
            coordinator.lastPreferredContentHeight != preferredContentHeight {
             resizeHeight(
                 on: window,
@@ -7304,19 +7368,9 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
             coordinator.lastPreferredContentHeight = preferredContentHeight
         }
         window.isOpaque = !translucentEnabled
-        let windowAppearance: NSAppearance?
-        switch appearanceRaw {
-        case "light":
-            windowAppearance = NSAppearance(named: .aqua)
-        case "dark":
-            windowAppearance = NSAppearance(named: .darkAqua)
-        default:
-            // Inherit the current macOS appearance instead of retaining a
-            // previously forced Dark/Light appearance on this window.
-            windowAppearance = nil
-        }
-        window.appearance = windowAppearance
-        window.contentView?.appearance = windowAppearance
+        // The application owns the explicit Light/Dark override. The Settings
+        // window must inherit it so System mode cannot retain the prior mode.
+        ReleaseRuntimePolicy.clearMacWindowAppearanceOverrides([window])
         // Use one native surface for the titlebar and content. Without this
         // explicit titlebar background, AppKit can retain its default white
         // titlebar even while the Settings content is translucent.
@@ -7336,6 +7390,19 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
         window.contentMinSize = minSize
         window.contentMaxSize = maximumSize
         window.standardWindowButton(.zoomButton)?.isEnabled = true
+    }
+
+    private func centerOverEditorWindow(_ settingsWindow: NSWindow) {
+        guard let editorWindowNumber,
+              let editorWindow = NSApp.window(withWindowNumber: editorWindowNumber),
+              editorWindow !== settingsWindow,
+              editorWindow.isVisible else { return }
+        let editorFrame = editorWindow.frame
+        let origin = NSPoint(
+            x: editorFrame.midX - settingsWindow.frame.width / 2,
+            y: editorFrame.midY - settingsWindow.frame.height / 2
+        )
+        settingsWindow.setFrameOrigin(origin)
     }
 
     private func maximumWindowSize(for window: NSWindow) -> NSSize {
@@ -7412,24 +7479,30 @@ struct SettingsWindowConfigurator: NSViewRepresentable {
         switch translucencyModeRaw {
         case "subtle":
             whiteLevel = isDark ? 0.18 : 0.90
-            alpha = 0.92
+            alpha = 0.96
         case "vibrant":
             whiteLevel = isDark ? 0.12 : 0.82
-            alpha = 0.84
+            alpha = 0.90
         default:
             whiteLevel = isDark ? 0.15 : 0.86
-            alpha = 0.88
+            alpha = 0.93
         }
         return NSColor(calibratedWhite: whiteLevel, alpha: alpha)
     }
 
     private func translucencyEnabledColor(enabled: Bool) -> NSColor {
-        Self.settingsWindowBackgroundColor(
+        let nativeSurface = Self.settingsWindowBackgroundColor(
             translucentEnabled: enabled,
             translucencyModeRaw: translucencyModeRaw,
             appearanceRaw: appearanceRaw,
             effectiveColorScheme: effectiveColorScheme
         )
+        if enabled || opaqueEditorCanvasEnabled {
+            let fallback = Color(nsColor: nativeSurface.withAlphaComponent(1))
+            let themeColor = NSColor(colorFromHex(themeBackgroundRaw, fallback: fallback))
+            return enabled ? nativeSurface : themeColor.withAlphaComponent(1)
+        }
+        return nativeSurface.withAlphaComponent(1)
     }
 
     private func ensureObservers(for window: NSWindow, coordinator: Coordinator) {

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -2758,15 +2758,15 @@ struct WelcomeTourView: View {
 
     private let pages: [TourPage] = [
         TourPage(
-            title: "What’s New in v1.6.4",
-            subtitle: "Release highlights for v1.6.4.",
+            title: "What’s New in v1.7.0",
+            subtitle: "Release highlights for v1.7.0.",
             bullets: [
-                "Editor Improvements: Type continuously on macOS without editor flicker.",
-                "Accessible Controls: Move the window from unused titlebar and toolbar space while keeping toolbar controls usable.",
-                "Performance Updates: Switch between open documents while the editor preserves the current frame and loads previews in the background.",
-                "Usability Updates: Keep long, unwrapped iPhone lines visible and stable while typing and scrolling.",
-                "Editor Improvements: Improve hardware-keyboard word and logical-line selection on iPhone and iPad.",
-                "Workflow Refinements: Match current-line highlighting to the selected editor theme."
+                "Editor Improvements: Keeps native document tabs, sidebars, editor surfaces, and Settings visually consistent across macOS, iOS, and iPadOS…",
+                "Workflow Refinements: Applies appearance and layout changes immediately when switching Light, Dark, or System mode.",
+                "Editor Navigation: Makes tab switching and Settings navigation feel immediate while preserving the native platform controls.",
+                "Usability Updates: Replaces the remaining legacy tab-bar paths with native platform tab implementations.",
+                "Editor Improvements: Preserves complete tab borders, spacing, and translucent surfaces across hover, selection, and appearance changes.",
+                "iPhone TOC: Aligns tab, TOC sidebar, project sidebar, line-number, and editor backgrounds in opaque and translucent modes."
             ],
             iconName: "sparkles.rectangle.stack",
             colors: [Color(red: 0.40, green: 0.28, blue: 0.90), Color(red: 0.96, green: 0.46, blue: 0.55)],
@@ -3236,16 +3236,6 @@ struct WelcomeTourView: View {
 
             if isWhatsNewPage(page) {
                 whatsNewRows(bullets: displayBullets, compactLayout: compactLayout)
-                Button {
-                    guard let url = URL(string: "https://h3pdesign.github.io/Neon-Vision-Editor/changelog.html") else { return }
-                    openURL(url)
-                } label: {
-                    Label("Read the full changelog", systemImage: "arrow.up.right.square")
-                        .font(.system(size: compactLayout ? 13 : 14, weight: .semibold))
-                }
-                .buttonStyle(.link)
-                .padding(.top, 2)
-                .accessibilityHint("Opens the complete release history in your browser")
             } else if page.title == "Editor Essentials" {
                 recommendedEditorSettings(compactLayout: compactLayout)
             } else {

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -1202,6 +1202,7 @@ struct FindReplaceWindowPresenter: NSViewRepresentable {
 struct DetachedPreviewWindowPresenter: NSViewRepresentable {
     @Binding var isPresented: Bool
     let title: String
+    let metadata: String?
     let html: String
     let baseURL: URL?
     @Environment(\.colorScheme) private var colorScheme
@@ -1246,6 +1247,7 @@ struct DetachedPreviewWindowPresenter: NSViewRepresentable {
         func content() -> DetachedPreviewWindowView {
             DetachedPreviewWindowView(
                 title: self.parent.title,
+                metadata: self.parent.metadata,
                 html: self.parent.html,
                 baseURL: self.parent.baseURL,
                 editorBackground: self.parent.editorBackground,
@@ -1335,8 +1337,10 @@ struct DetachedPreviewWindowPresenter: NSViewRepresentable {
 @MainActor
 struct DetachedPreviewWindowView: View {
     static let quickLookGlassTintOpacity = 0.08
+    private static let windowCornerRadius: CGFloat = 14
 
     let title: String
+    let metadata: String?
     let html: String
     let baseURL: URL?
     let editorBackground: Color
@@ -1374,6 +1378,13 @@ struct DetachedPreviewWindowView: View {
                 Text(title)
                     .font(.headline)
                 Spacer()
+                if let metadata {
+                    Text(metadata)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                }
                 Button(action: onClose) {
                     Image(systemName: "xmark")
                 }
@@ -1389,14 +1400,15 @@ struct DetachedPreviewWindowView: View {
         }
         .background {
             if usesQuickLookTransparency {
-                Rectangle()
+                RoundedRectangle(cornerRadius: Self.windowCornerRadius, style: .continuous)
                     .fill(.thinMaterial)
                     .overlay(quickLookGlassTint)
             } else {
-                Rectangle()
+                RoundedRectangle(cornerRadius: Self.windowCornerRadius, style: .continuous)
                     .fill(surfaceBackground)
             }
         }
+        .clipShape(RoundedRectangle(cornerRadius: Self.windowCornerRadius, style: .continuous))
     }
 
     private var quickLookGlassTint: Color {

--- a/Neon Vision Editor/UI/SidebarViews.swift
+++ b/Neon Vision Editor/UI/SidebarViews.swift
@@ -93,7 +93,14 @@ struct SidebarView: View {
             #if os(macOS)
             return AnyShapeStyle(Color.clear)
             #else
-            return AnyShapeStyle(.ultraThinMaterial)
+            // Both iPad sidebars must resolve to the same surface color. Two
+            // independent materials sample different content behind each
+            // card, producing visibly different colors in translucent mode.
+            return AnyShapeStyle(
+                currentEditorTheme(colorScheme: colorScheme)
+                    .background
+                    .opacity(colorScheme == .dark ? 0.82 : 0.90)
+            )
             #endif
         }
 #if os(macOS)
@@ -319,7 +326,11 @@ struct SidebarView: View {
 
     private var sidebarOuterPaddingInsets: EdgeInsets {
 #if os(iOS)
-        EdgeInsets(top: 0, leading: 10, bottom: 10, trailing: 10)
+        // Match the project sidebar's iPad card inset on every edge so the
+        // TOC surface shares its height and boundary with the adjacent bar.
+        UIDevice.current.userInterfaceIdiom == .pad
+            ? EdgeInsets(top: 0, leading: 6, bottom: 0, trailing: 6)
+            : EdgeInsets(top: 0, leading: 10, bottom: 10, trailing: 10)
 #else
         EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 4)
 #endif
@@ -1558,7 +1569,13 @@ struct ProjectStructureSidebarView: View {
             #if os(macOS)
             return AnyShapeStyle(Color.clear)
             #else
-            return AnyShapeStyle(.ultraThinMaterial)
+            // Keep the project sidebar and TOC sidebar on one resolved color
+            // instead of compositing separate materials over different panes.
+            return AnyShapeStyle(
+                currentEditorTheme(colorScheme: colorScheme)
+                    .background
+                    .opacity(colorScheme == .dark ? 0.82 : 0.90)
+            )
             #endif
         }
 #if os(macOS)
@@ -1702,9 +1719,9 @@ struct ProjectStructureSidebarView: View {
     private var sidebarContainerBorderOverlay: some View {
 #if os(macOS)
         if translucentBackgroundEnabled {
-            // Continue the editor/window material through the boundary instead
-            // of painting a bright outline or exposing a clear hole.
-            sidebarContainerShape.stroke(sidebarSurfaceFill, lineWidth: 1.2)
+            // Keep the window material transparent while retaining a subtle
+            // edge so the sidebar remains legible against the desktop.
+            sidebarContainerShape.stroke(sidebarSurfaceStroke, lineWidth: 1.2)
         } else {
             sidebarContainerShape.stroke(sidebarSurfaceStroke, lineWidth: 1.2)
         }

--- a/Neon Vision EditorTests/ContentViewLayoutTests.swift
+++ b/Neon Vision EditorTests/ContentViewLayoutTests.swift
@@ -153,23 +153,26 @@ final class ContentViewLayoutTests: XCTestCase {
         )
     }
 
-    func testCollapsedFormattingControlUsesOpaqueSurfaceWhileExpandedControlMayUseGlass() {
-        XCTAssertFalse(
+    func testFormattingControlUsesGlassWhenEitherWindowOrToolbarTranslucencyIsEnabled() {
+        XCTAssertTrue(
             MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
                 isCollapsed: true,
-                liquidGlassEnabled: true
+                liquidGlassEnabled: false,
+                windowTranslucent: true
             )
         )
         XCTAssertTrue(
             MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
                 isCollapsed: false,
-                liquidGlassEnabled: true
+                liquidGlassEnabled: true,
+                windowTranslucent: false
             )
         )
         XCTAssertFalse(
             MarkdownFormattingChromePolicy.usesTranslucentControlSurface(
                 isCollapsed: false,
-                liquidGlassEnabled: false
+                liquidGlassEnabled: false,
+                windowTranslucent: false
             )
         )
     }

--- a/Neon Vision EditorTests/MacNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MacNativeFileTabBarTests.swift
@@ -1,0 +1,247 @@
+#if os(macOS)
+import XCTest
+@testable import Neon_Vision_Editor
+
+@MainActor
+final class MacNativeFileTabBarTests: XCTestCase {
+    func testApplyingTabSnapshotsKeepsStableViewsAndSelection() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MacNativeFileTabBarView()
+        let initial = [
+            snapshot(id: firstID, title: "First.swift"),
+            snapshot(id: secondID, title: "Second.md")
+        ]
+
+        view.apply(tabs: initial, selectedTabID: firstID)
+        XCTAssertEqual(view.orderedTabIDs, [firstID, secondID])
+        XCTAssertEqual(view.selectedTabID, firstID)
+        XCTAssertEqual(view.managedTabViewCount, 2)
+
+        view.apply(
+            tabs: [
+                snapshot(id: secondID, title: "Renamed.md", isDirty: true),
+                snapshot(id: firstID, title: "First.swift")
+            ],
+            selectedTabID: secondID
+        )
+
+        XCTAssertEqual(view.orderedTabIDs, [secondID, firstID])
+        XCTAssertEqual(view.selectedTabID, secondID)
+        XCTAssertEqual(view.managedTabViewCount, 2)
+    }
+
+    func testRemovingTabDropsItsManagedView() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MacNativeFileTabBarView()
+        view.apply(
+            tabs: [snapshot(id: firstID, title: "One"), snapshot(id: secondID, title: "Two")],
+            selectedTabID: firstID
+        )
+
+        view.apply(tabs: [snapshot(id: secondID, title: "Two")], selectedTabID: secondID)
+
+        XCTAssertEqual(view.orderedTabIDs, [secondID])
+        XCTAssertEqual(view.managedTabViewCount, 1)
+    }
+
+    func testNativeTabActionsRetainExistingViewModelRouting() {
+        let sourceID = UUID()
+        let destinationID = UUID()
+        let view = MacNativeFileTabBarView()
+        var selectedID: UUID?
+        var closedID: UUID?
+        var move: (UUID, UUID, Bool)?
+        view.onSelect = { selectedID = $0 }
+        view.onClose = { closedID = $0 }
+        view.onMove = { move = ($0, $1, $2) }
+
+        view.selectTabForTesting(sourceID)
+        view.closeTabForTesting(destinationID)
+        view.moveTabForTesting(sourceID, destination: destinationID, before: false)
+
+        XCTAssertEqual(selectedID, sourceID)
+        XCTAssertEqual(closedID, destinationID)
+        XCTAssertEqual(move?.0, sourceID)
+        XCTAssertEqual(move?.1, destinationID)
+        XCTAssertEqual(move?.2, false)
+    }
+
+    func testKeyboardAdjacentSelectionUsesOrderedTabsAndStopsAtEdges() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MacNativeFileTabBarView()
+        var selectedIDs: [UUID] = []
+        view.onSelect = { selectedIDs.append($0) }
+        view.apply(
+            tabs: [snapshot(id: firstID, title: "One"), snapshot(id: secondID, title: "Two")],
+            selectedTabID: firstID
+        )
+
+        view.selectAdjacentTab(from: firstID, offset: 1)
+        view.selectAdjacentTab(from: firstID, offset: -1)
+        view.selectAdjacentTab(from: secondID, offset: 1)
+
+        XCTAssertEqual(selectedIDs, [secondID])
+    }
+
+    func testSelectedIndicatorStartsAtTheSelectedTabsLeadingEdge() throws {
+        let selectedID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 32))
+        view.apply(
+            tabs: [snapshot(id: UUID(), title: "One"), snapshot(id: selectedID, title: "Two")],
+            selectedTabID: selectedID
+        )
+
+        let indicatorFrame = try XCTUnwrap(view.selectionIndicatorFrameForTesting(selectedID))
+        XCTAssertEqual(indicatorFrame.minX, 8)
+        XCTAssertGreaterThan(indicatorFrame.width, 100)
+    }
+
+    func testInactiveTabsKeepAVisibleTranslucentBoundary() throws {
+        let inactiveID = UUID()
+        let selectedID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 32))
+        view.apply(
+            tabs: [snapshot(id: inactiveID, title: "Inactive"), snapshot(id: selectedID, title: "Selected")],
+            selectedTabID: selectedID
+        )
+
+        let inactiveState = try XCTUnwrap(view.visualStateForTesting(inactiveID))
+        XCTAssertGreaterThan(inactiveState.backgroundAlpha, 0)
+        XCTAssertEqual(inactiveState.borderWidth, 0.5)
+
+        let outline = try XCTUnwrap(view.outlineGeometryForTesting(inactiveID))
+        XCTAssertEqual(outline.pathBounds.minX, 0.25, accuracy: 0.001)
+        XCTAssertEqual(outline.pathBounds.minY, 0.25, accuracy: 0.001)
+        XCTAssertEqual(outline.pathBounds.maxX, outline.viewBounds.maxX - 0.25, accuracy: 0.001)
+        XCTAssertEqual(outline.pathBounds.maxY, outline.viewBounds.maxY - 0.25, accuracy: 0.001)
+    }
+
+    func testInactiveOutlineIsCompositedAboveTabControls() throws {
+        let id = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.apply(tabs: [snapshot(id: id, title: "Document")], selectedTabID: nil)
+
+        let state = try XCTUnwrap(view.visualStateForTesting(id))
+        XCTAssertGreaterThan(state.borderWidth, 0)
+        XCTAssertEqual(view.outlineZPositionForTesting(id), 10)
+
+        let borderBeforeHover = state.borderAlpha
+        view.setHoveredForTesting(id, hovered: true)
+        let borderDuringHover = try XCTUnwrap(view.visualStateForTesting(id)).borderAlpha
+        XCTAssertEqual(borderDuringHover, borderBeforeHover, accuracy: 0.001)
+    }
+
+    func testOpaqueLightCanvasUsesAVisibleInactiveOutline() throws {
+        let inactiveID = UUID()
+        let selectedID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.appearance = NSAppearance(named: .aqua)
+        view.usesOpaqueEditorCanvas = true
+        view.apply(
+            tabs: [snapshot(id: inactiveID, title: "Inactive"), snapshot(id: selectedID, title: "Selected")],
+            selectedTabID: selectedID
+        )
+
+        let inactiveState = try XCTUnwrap(view.visualStateForTesting(inactiveID))
+        XCTAssertEqual(inactiveState.borderAlpha, 0.32, accuracy: 0.001)
+
+        view.apply(
+            tabs: [snapshot(id: inactiveID, title: "Inactive"), snapshot(id: selectedID, title: "Selected")],
+            selectedTabID: inactiveID
+        )
+
+        let previouslySelectedState = try XCTUnwrap(view.visualStateForTesting(selectedID))
+        XCTAssertEqual(previouslySelectedState.borderAlpha, 0.32, accuracy: 0.001)
+    }
+
+    func testTabTitleIsAlignedTowardTheBottomEdge() throws {
+        let id = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 300, height: 42))
+        view.apply(tabs: [snapshot(id: id, title: "Document")], selectedTabID: id)
+
+        let layout = try XCTUnwrap(view.titleLayoutForTesting(id))
+        XCTAssertLessThanOrEqual(layout.tabBounds.height - layout.titleFrame.maxY, 5)
+        XCTAssertGreaterThan(layout.titleFrame.midY, layout.tabBounds.midY)
+    }
+
+    func testNewTabButtonHasDeliberateSpacingFromTabsAndWindowEdge() {
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.layoutSubtreeIfNeeded()
+
+        let layout = view.addButtonLayoutForTesting
+        XCTAssertEqual(layout.buttonFrame.width, 36)
+        XCTAssertGreaterThanOrEqual(layout.buttonFrame.minX - layout.tabsFrame.maxX, 8)
+        XCTAssertGreaterThanOrEqual(view.bounds.maxX - layout.buttonFrame.maxX, 10)
+    }
+
+    func testFilenameWidthsAreBoundedAndOverflowScrollsWithEdgeFades() {
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 520, height: 42))
+        let tabs = (0..<6).map { index in
+            snapshot(id: UUID(), title: "A-very-long-professional-document-name-\(index).swift")
+        }
+        view.apply(tabs: tabs, selectedTabID: tabs.first?.id)
+
+        let initial = view.horizontalScrollLayoutForTesting
+        XCTAssertGreaterThan(initial.documentWidth, initial.viewportWidth)
+        XCTAssertFalse(view.scrollEdgeFadeState.left)
+        XCTAssertTrue(view.scrollEdgeFadeState.right)
+
+        view.scrollToEndForTesting()
+        XCTAssertTrue(view.scrollEdgeFadeState.left)
+        XCTAssertFalse(view.scrollEdgeFadeState.right)
+    }
+
+    func testTabWidthTracksFilenameWithinStandardAndDoubleWidthLimits() throws {
+        let shortID = UUID()
+        let longID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 700, height: 42))
+        view.apply(
+            tabs: [
+                snapshot(id: shortID, title: "a.swift"),
+                snapshot(id: longID, title: String(repeating: "long-file-name-", count: 8) + ".swift")
+            ],
+            selectedTabID: shortID
+        )
+
+        let shortWidth = try XCTUnwrap(view.titleLayoutForTesting(shortID)?.tabBounds.width)
+        let longWidth = try XCTUnwrap(view.titleLayoutForTesting(longID)?.tabBounds.width)
+        XCTAssertEqual(shortWidth, 128)
+        XCTAssertGreaterThan(longWidth, shortWidth)
+        XCTAssertEqual(longWidth, 256)
+    }
+
+    func testDirtyColorSupersedesSelectionColor() throws {
+        let dirtyID = UUID()
+        let previousID = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.apply(
+            tabs: [
+                snapshot(id: dirtyID, title: "Dirty", isDirty: true),
+                snapshot(id: previousID, title: "Previous")
+            ],
+            selectedTabID: dirtyID
+        )
+
+        let dirty = try XCTUnwrap(view.visualStateForTesting(dirtyID))
+        let previous = try XCTUnwrap(view.visualStateForTesting(previousID))
+        XCTAssertGreaterThan(dirty.backgroundAlpha, previous.backgroundAlpha)
+    }
+
+    private func snapshot(
+        id: UUID,
+        title: String,
+        isDirty: Bool = false
+    ) -> MacNativeFileTabSnapshot {
+        MacNativeFileTabSnapshot(
+            id: id,
+            title: title,
+            isDirty: isDirty,
+            isRemote: false,
+            isReadOnly: false
+        )
+    }
+}
+#endif

--- a/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
@@ -1,0 +1,158 @@
+#if os(iOS)
+import UIKit
+import XCTest
+@testable import Neon_Vision_Editor
+
+@MainActor
+final class MobileNativeFileTabBarTests: XCTestCase {
+    func testApplyingSnapshotsKeepsStableViewsAndSelectionHistory() throws {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MobileNativeFileTabBarView()
+
+        view.apply(
+            tabs: [snapshot(id: firstID, title: "First.swift"), snapshot(id: secondID, title: "Second.md")],
+            selectedTabID: firstID,
+        )
+        XCTAssertEqual(view.orderedTabIDs, [firstID, secondID])
+        XCTAssertEqual(view.managedTabViewCount, 2)
+
+        view.apply(
+            tabs: [snapshot(id: secondID, title: "Renamed.md", isDirty: true), snapshot(id: firstID, title: "First.swift")],
+            selectedTabID: secondID,
+        )
+
+        XCTAssertEqual(view.orderedTabIDs, [secondID, firstID])
+        XCTAssertEqual(view.selectedTabID, secondID)
+        XCTAssertEqual(view.managedTabViewCount, 2)
+        XCTAssertEqual(try XCTUnwrap(view.visualStateForTesting(secondID)).selected, true)
+        XCTAssertEqual(try XCTUnwrap(view.visualStateForTesting(secondID)).dirty, true)
+    }
+
+    func testRemovingTabDropsItsManagedView() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let view = MobileNativeFileTabBarView()
+        view.apply(
+            tabs: [snapshot(id: firstID, title: "One"), snapshot(id: secondID, title: "Two")],
+            selectedTabID: firstID,
+        )
+
+        view.apply(tabs: [snapshot(id: secondID, title: "Two")], selectedTabID: secondID)
+
+        XCTAssertEqual(view.orderedTabIDs, [secondID])
+        XCTAssertEqual(view.managedTabViewCount, 1)
+    }
+
+    func testNativeActionsRetainExistingViewModelRouting() {
+        let sourceID = UUID()
+        let destinationID = UUID()
+        let view = MobileNativeFileTabBarView()
+        var selectedID: UUID?
+        var closedID: UUID?
+        var move: (UUID, UUID, Bool)?
+        var addCount = 0
+        view.onSelect = { selectedID = $0 }
+        view.onClose = { closedID = $0 }
+        view.onMove = { move = ($0, $1, $2) }
+        view.onAdd = { addCount += 1 }
+
+        view.selectTabForTesting(sourceID)
+        view.closeTabForTesting(destinationID)
+        view.moveTabForTesting(sourceID, destination: destinationID, before: false)
+        view.addTabForTesting()
+
+        XCTAssertEqual(selectedID, sourceID)
+        XCTAssertEqual(closedID, destinationID)
+        XCTAssertEqual(move?.0, sourceID)
+        XCTAssertEqual(move?.1, destinationID)
+        XCTAssertEqual(move?.2, false)
+        XCTAssertEqual(addCount, 1)
+    }
+
+    func testSelectedTabAccessibilityIncludesStateAndMetadata() throws {
+        let id = UUID()
+        let view = MobileNativeFileTabBarView()
+        view.apply(
+            tabs: [MobileNativeFileTabSnapshot(
+                id: id,
+                title: "Notes.md",
+                isDirty: true,
+                isRemote: true,
+                isReadOnly: true
+            )],
+            selectedTabID: id,
+        )
+
+        let state = try XCTUnwrap(view.accessibilityStateForTesting(id))
+        XCTAssertEqual(state.label, "Notes.md, remote document, read only, unsaved changes")
+        XCTAssertTrue(state.traits.contains(.button))
+        XCTAssertTrue(state.traits.contains(.selected))
+        XCTAssertEqual(view.accessibilityActionsForTesting(id)?.first, "Close Tab")
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            XCTAssertEqual(view.accessibilityActionsForTesting(id), ["Close Tab", "Move Tab Left", "Move Tab Right"])
+        }
+    }
+
+    func testAddButtonStaysOutsideHorizontallyScrollingTabs() {
+        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 390, height: 42))
+        view.apply(
+            tabs: (0..<12).map { snapshot(id: UUID(), title: "Document \($0)") },
+            selectedTabID: nil,
+        )
+        view.layoutIfNeeded()
+
+        XCTAssertEqual(view.addButtonFrameForTesting.width, 44)
+        XCTAssertGreaterThanOrEqual(view.addButtonFrameForTesting.minX - view.scrollViewFrameForTesting.maxX, 4)
+        XCTAssertEqual(view.scrollViewFrameForTesting.minX, 8)
+    }
+
+    func testSelectingOverflowingLastTabScrollsItIntoView() throws {
+        let ids = (0..<12).map { _ in UUID() }
+        let lastID = try XCTUnwrap(ids.last)
+        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 390, height: 42))
+        view.apply(
+            tabs: ids.enumerated().map { snapshot(id: $0.element, title: "Document \($0.offset)") },
+            selectedTabID: lastID,
+        )
+        view.layoutIfNeeded()
+
+        XCTAssertGreaterThan(view.horizontalContentWidthForTesting, view.scrollViewFrameForTesting.width)
+        XCTAssertGreaterThan(view.horizontalContentOffsetForTesting, 0)
+        XCTAssertGreaterThan(try XCTUnwrap(view.tabFrameForTesting(lastID)).minX, view.scrollViewFrameForTesting.width)
+    }
+
+    func testLargeSnapshotUpdateReusesViewsWithinInteractiveBudget() {
+        let ids = (0..<250).map { _ in UUID() }
+        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 1_024, height: 42))
+        let initial = ids.enumerated().map { snapshot(id: $0.element, title: "Document \($0.offset)") }
+        view.apply(tabs: initial, selectedTabID: ids.first)
+
+        let start = ProcessInfo.processInfo.systemUptime
+        view.apply(
+            tabs: initial.reversed().enumerated().map {
+                snapshot(id: $0.element.id, title: $0.element.title, isDirty: $0.offset.isMultiple(of: 3))
+            },
+            selectedTabID: ids.last,
+        )
+        let elapsed = ProcessInfo.processInfo.systemUptime - start
+
+        XCTAssertEqual(view.managedTabViewCount, ids.count)
+        XCTAssertLessThan(elapsed, 1)
+    }
+
+    private func snapshot(
+        id: UUID,
+        title: String,
+        isDirty: Bool = false
+    ) -> MobileNativeFileTabSnapshot {
+        MobileNativeFileTabSnapshot(
+            id: id,
+            title: title,
+            isDirty: isDirty,
+            isRemote: false,
+            isReadOnly: false
+        )
+    }
+}
+#endif

--- a/Neon Vision EditorTests/ReleaseRuntimePolicyTests.swift
+++ b/Neon Vision EditorTests/ReleaseRuntimePolicyTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 @testable import Neon_Vision_Editor
 
 
@@ -21,6 +24,48 @@ final class ReleaseRuntimePolicyTests: XCTestCase {
         XCTAssertNil(ReleaseRuntimePolicy.preferredColorScheme(for: "system"))
         XCTAssertNil(ReleaseRuntimePolicy.preferredColorScheme(for: "unknown"))
     }
+
+#if os(macOS)
+    func testMacAppearanceMappingAndSystemInheritance() {
+        XCTAssertEqual(ReleaseRuntimePolicy.appKitAppearance(for: "light")?.name, .aqua)
+        XCTAssertEqual(ReleaseRuntimePolicy.appKitAppearance(for: "dark")?.name, .darkAqua)
+        XCTAssertNil(ReleaseRuntimePolicy.appKitAppearance(for: "system"))
+
+        let originalApplicationAppearance = NSApp.appearance
+        let originalWindowAppearances = NSApp.windows.map {
+            ($0, $0.appearance, $0.contentView?.appearance)
+        }
+        defer {
+            NSApp.appearance = originalApplicationAppearance
+            for (window, windowAppearance, contentAppearance) in originalWindowAppearances {
+                window.appearance = windowAppearance
+                window.contentView?.appearance = contentAppearance
+            }
+        }
+
+        ReleaseRuntimePolicy.applyMacApplicationAppearance("light")
+        XCTAssertEqual(NSApp.appearance?.name, .aqua)
+        ReleaseRuntimePolicy.applyMacApplicationAppearance("dark")
+        XCTAssertEqual(NSApp.appearance?.name, .darkAqua)
+        ReleaseRuntimePolicy.applyMacApplicationAppearance("system")
+        XCTAssertNil(NSApp.appearance)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = NSView(frame: window.contentLayoutRect)
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.contentView?.appearance = NSAppearance(named: .darkAqua)
+
+        ReleaseRuntimePolicy.clearMacWindowAppearanceOverrides([window])
+
+        XCTAssertNil(window.appearance)
+        XCTAssertNil(window.contentView?.appearance)
+    }
+#endif
 
     func testFindNextMovesCursorForwardAndWraps() {
         let text = "alpha beta alpha"

--- a/Neon Vision EditorTests/WindowTranslucencyTests.swift
+++ b/Neon Vision EditorTests/WindowTranslucencyTests.swift
@@ -124,9 +124,9 @@ final class WindowTranslucencyTests: XCTestCase {
             effectiveColorScheme: .dark
         )
 
-        XCTAssertEqual(subtle.alphaComponent, 0.92, accuracy: 0.001)
-        XCTAssertEqual(balanced.alphaComponent, 0.88, accuracy: 0.001)
-        XCTAssertEqual(vibrant.alphaComponent, 0.84, accuracy: 0.001)
+        XCTAssertEqual(subtle.alphaComponent, 0.96, accuracy: 0.001)
+        XCTAssertEqual(balanced.alphaComponent, 0.93, accuracy: 0.001)
+        XCTAssertEqual(vibrant.alphaComponent, 0.90, accuracy: 0.001)
         XCTAssertGreaterThan(subtle.alphaComponent, balanced.alphaComponent)
         XCTAssertLessThan(vibrant.alphaComponent, balanced.alphaComponent)
         XCTAssertEqual(disabled, NSColor.windowBackgroundColor)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 <p align="center"><a href="https://apps-h3p.com"><img alt="Docs on h3p apps" src="https://img.shields.io/badge/Docs-h3p%20apps-111827?style=for-the-badge"></a><a href="https://buymeacoffee.com/h3pdesign"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a-Coffee-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=111827"></a><a href="https://www.patreon.com/h3p"><img alt="Support on Patreon" src="https://img.shields.io/badge/Support%20on-Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white"></a><a href="https://www.paypal.com/paypalme/HilthartPedersen"><img alt="Support via PayPal" src="https://img.shields.io/badge/Support%20via-PayPal-0070BA?style=for-the-badge&logo=paypal&logoColor=white"></a></p>
 
+> Prepared release: **v1.7.0** — not published. See [candidate notes](CHANGELOG.md).
+
 <p align="center">
-  <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases"><img alt="Latest Release" src="https://img.shields.io/badge/release-v1.6.4-0A84FF"></a>
+  <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases"><img alt="Latest Release" src="https://img.shields.io/badge/release-v1.6.3-0A84FF"></a>
   <a href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965"><img alt="Platforms" src="https://img.shields.io/badge/platforms-macOS%20%7C%20iOS%20%7C%20iPadOS%20%7C%20visionOS-0A84FF"></a>
   <a href="https://github.com/h3pdesign/Neon-Vision-Editor/actions/workflows/release-github-only.yml"><img alt="Primary Release" src="https://img.shields.io/github/actions/workflow/status/h3pdesign/Neon-Vision-Editor/release-github-only.yml?branch=main&label=Primary%20Release"></a>
   <a href="https://github.com/h3pdesign/Neon-Vision-Editor/blob/main/SECURITY.md"><img alt="Security Policy" src="https://img.shields.io/badge/security-policy-22C55E"></a>
@@ -52,33 +54,16 @@
 </p>
 
 > Status: **active release**  
-> Latest release: **v1.6.4**
-> Next release target: **v1.6.5**
+> Latest release: **v1.6.3**
+> Next release target: **v1.6.4**
 > Platform target: **macOS 26 (Tahoe)** compatible with **macOS Sequoia**
 > Apple Silicon: tested / Intel: not tested
-> Direct GitHub release: **v1.6.4** / App Store and TestFlight availability varies by platform and review status
-> Last updated (README): **2026-09-08** for latest release **v1.6.4**
+> Direct GitHub release: **v1.6.3** / App Store and TestFlight availability varies by platform and review status
+> Last updated (README): **2026-09-08** for latest release **v1.6.3**
 
-## What's New in v1.6.3 and v1.6.4
+## What's New in v1.6.2 and v1.6.3
 
 ### Why Upgrade
-
-- v1.6.4: Keeps macOS typing visually stable while preserving the native editor viewport.
-- v1.6.4: Makes empty native titlebar space usable for window movement without sacrificing toolbar actions.
-- v1.6.4: Keeps the editor’s native tab and viewport lifecycle intact while these macOS chrome fixes are applied.
-
-### v1.6.4 Highlights
-
-- Type continuously on macOS without editor flicker.
-- Move the window from unused titlebar and toolbar space while keeping toolbar controls usable.
-- Switch between open documents while the editor preserves the current frame and loads previews in the background.
-- Keep long, unwrapped iPhone lines visible and stable while typing and scrolling.
-- Improve hardware-keyboard word and logical-line selection on iPhone and iPad.
-
-See the complete release history in the [public changelog](https://h3pdesign.github.io/Neon-Vision-Editor/changelog.html).
-- Adds native macOS window dragging from unused titlebar and toolbar space with no visible drag handle.
-
-### v1.6.3 Context
 
 - v1.6.3: Switch between open documents with less visible delay, including when changing between Markdown and source files.
 - v1.6.3: Keep local development builds usable without requiring a Developer ID certificate for Quick Look.
@@ -87,6 +72,19 @@ See the complete release history in the [public changelog](https://h3pdesign.git
 ### v1.6.3 Highlights
 
 - The selected editor publishes its first frame before deferred layout and preview work begins.
+
+### v1.6.2 Context
+
+- v1.6.2: Detects external edits on network volumes even when filesystem change notifications are missed.
+- v1.6.2: Lets you disable the automatic Welcome Tour and opens Finder documents without interrupting them with a tour.
+- v1.6.2: Keeps purchase feedback stable while Settings updates and product information refreshes.
+
+### v1.6.2 Highlights
+
+- Adds a background metadata polling fallback for open network-volume files, reusing the existing external-change conflict handling.
+- Adds an automatic Welcome Tour preference; Finder file launches suppress the tour, including after app updates.
+- Presents purchase alerts using local SwiftUI presentation state and preserves the latest queued purchase message.
+- Retains a complete local recovery copy of external-document save payloads on iOS/iPadOS and visionOS.
 
 ## Start Here
 
@@ -146,7 +144,7 @@ See the complete release history in the [public changelog](https://h3pdesign.git
         <td><img alt="Stable" src="https://img.shields.io/badge/Stable-22C55E?style=flat-square"></td>
         <td>Direct notarized builds and fastest stable updates</td>
         <td><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases">GitHub Releases</a></td>
-        <td>v1.6.4 release docs current; v1.6.4 direct download current</td>
+        <td>v1.6.3 release docs current; v1.6.3 direct download current</td>
       </tr>
       <tr>
         <td><img alt="Store" src="https://img.shields.io/badge/Store-0A84FF?style=flat-square"></td>
@@ -167,7 +165,7 @@ See the complete release history in the [public changelog](https://h3pdesign.git
 ## Download Metrics
 
 <p align="center">
-  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10558&color=0A84FF&style=for-the-badge">
+  <img alt="All Downloads" src="https://img.shields.io/static/v1?label=All+Downloads&message=10410&color=0A84FF&style=for-the-badge">
 </p>
 
 <p align="center"><strong>Release Download + Traffic Trend</strong></p>
@@ -182,8 +180,8 @@ See the complete release history in the [public changelog](https://h3pdesign.git
 
 <p align="center"><em>Styled line chart shows per-release totals with 14-day traffic counters for clones and views.</em></p>
 <p align="center">
-  <img alt="Unique cloners (14d)" src="https://img.shields.io/static/v1?label=Unique+cloners+%2814d%29&message=354&color=7C3AED&style=for-the-badge">
-  <img alt="Unique visitors (14d)" src="https://img.shields.io/static/v1?label=Unique+visitors+%2814d%29&message=224&color=0EA5E9&style=for-the-badge">
+  <img alt="Unique cloners (14d)" src="https://img.shields.io/static/v1?label=Unique+cloners+%2814d%29&message=277&color=7C3AED&style=for-the-badge">
+  <img alt="Unique visitors (14d)" src="https://img.shields.io/static/v1?label=Unique+visitors+%2814d%29&message=194&color=0EA5E9&style=for-the-badge">
 </p>
 <p align="center">
   <img alt="Clone snapshot (UTC)" src="https://img.shields.io/static/v1?label=Clone+snapshot+%28UTC%29&message=2026-09-08&color=334155&style=flat-square">
@@ -226,11 +224,11 @@ The direct GitHub release is currently ahead of the iOS/iPadOS App Store version
 
 | Channel | Platform | Best For | Download | Release Track | Notes |
 |---|---|---|---|---|---|
-| **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.6.4** | Current direct download |
+| **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.6.3** | Current direct download |
 | **Store** | iOS / iPadOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.6.2** | Current public App Store listing |
-| **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.6.4** | In Apple review |
+| **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.6.3** | In Apple review |
 | **Store** | visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.6.1** | Current recorded visionOS listing |
-| **Beta** | iOS / iPadOS / macOS | Testing upcoming changes before stable | [TestFlight Invite](https://testflight.apple.com/join/YWB2fGAP) | **v1.6.4** | Early access builds for feedback; availability may vary by review state |
+| **Beta** | iOS / iPadOS / macOS | Testing upcoming changes before stable | [TestFlight Invite](https://testflight.apple.com/join/YWB2fGAP) | **v1.6.3** | Early access builds for feedback; availability may vary by review state |
 
 ## Install
 
@@ -365,8 +363,7 @@ Platform-specific availability is tracked in the [Platform Matrix](#platform-mat
 - **Languages and structured documents:** Swift 6-ready highlighting includes TeX/LaTeX and Typst/CeTZ-aware editing; CSV/TSV, property lists, Apple crash reports, and recognized logs can switch between structured and raw-text views, and plain text can be transformed into validated JSON through an explicit AI-assisted action.
 - **Project and preview workflows:** project-level Markdown/PDF cards reuse the project index for bounded excerpts and thumbnails, while Markdown, HTML, SVG, PDF, and PNG previews remain integrated with the editor.
 - **macOS integration:** the embedded Quick Look extension previews supported Markdown and source files in Finder, and detached Markdown previews can use the same glass treatment without changing editor content.
-- **Latest stable additions (v1.6.4):** Type continuously on macOS without editor flicker; Move the window from unused titlebar and toolbar space while keeping toolbar controls usable; Switch between open documents while the editor preserves the current frame and loads previews in the background; Keep long, unwrapped iPhone lines visible and stable while typing and scrolling; Improve hardware-keyboard word and logical-line selection on iPhone and iPad; Match current-line highlighting to the selected editor theme.
-- **Latest stable additions (v1.6.4):** Adds native macOS window dragging from unused titlebar and toolbar space with no visible drag handle.
+- **Latest stable additions (v1.6.3):** The selected editor publishes its first frame before deferred layout and preview work begins.
 <!-- FEATURE_COVERAGE:END -->
 
 ### Editing Core
@@ -636,7 +633,7 @@ More release integrity details: [Release Integrity](#release-integrity)
 
 | Track | Current Focus | Status |
 |---|---|---|
-| Stable direct download | `v1.6.4` notarized GitHub release | Current |
+| Stable direct download | `v1.6.3` notarized GitHub release | Current |
 | App Store rollout | Platform releases are published independently after App Review | Check the relevant App Store listing |
 | Post-1.4 stabilization | Crash triage, docs freshness, platform polish, App Store/Xcode Cloud release checks | Next patch train |
 | Larger workflow work | Remote workflow hardening, minimap polish, project navigation refinements | Later `v1.5+` work |
@@ -644,19 +641,19 @@ More release integrity details: [Release Integrity](#release-integrity)
 ## Roadmap (Near Term)
 
 <p align="center">
-  <img alt="Now" src="https://img.shields.io/badge/NOW-v1.6.4-22C55E?style=for-the-badge">
-  <img alt="Next" src="https://img.shields.io/badge/NEXT-v1.6.5-F59E0B?style=for-the-badge">
+  <img alt="Now" src="https://img.shields.io/badge/NOW-v1.6.3-22C55E?style=for-the-badge">
+  <img alt="Next" src="https://img.shields.io/badge/NEXT-v1.6.4-F59E0B?style=for-the-badge">
   <img alt="Later" src="https://img.shields.io/badge/LATER-v1.5%2B-0A84FF?style=for-the-badge">
 </p>
 
-### Now (v1.6.4)
+### Now (v1.6.3)
 
 - ![v1.4.0](https://img.shields.io/badge/v1.4.0-22C55E?style=flat-square) delivers file-backed large-document editing, bounded live viewport virtualization, reliable ordinary-file installation, and the release workflow hardening shipped alongside the release.
-  Tracking: [Release v1.6.4](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.4)
+  Tracking: [Release v1.6.3](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.3)
 
-### Next (v1.6.5)
+### Next (v1.6.4)
 
-- ![v1.6.5](https://img.shields.io/badge/v1.6.5-F59E0B?style=flat-square) targets the reviewed changes listed under Unreleased in CHANGELOG.md; scope is not final until release preparation.
+- ![v1.6.4](https://img.shields.io/badge/v1.6.4-F59E0B?style=flat-square) targets the reviewed changes listed under Unreleased in CHANGELOG.md; scope is not final until release preparation.
   Tracking: [Milestones](https://github.com/h3pdesign/Neon-Vision-Editor/milestones)
 
 ### Later (v1.5+)
@@ -746,7 +743,7 @@ Vim navigation is also available on iPad with a hardware keyboard after enabling
 
 ## Changelog
 
-Latest stable: **v1.6.4** (2026-09-08)
+Latest stable: **v1.6.3** (2026-09-07)
 
 ### Editor Evolution
 
@@ -754,6 +751,8 @@ Latest stable: **v1.6.4** (2026-09-08)
 ```mermaid
 timeline
     title Neon Vision Editor — recent release story
+    29 August 2026 : v1.5.6 · A more deliberate workflow
+                : Makes the iPhone and iPad editor toolbar more compact and language-aware without hiding full menu names or accessibility context.
     3 September 2026 : v1.6.0 · A more deliberate workflow
                 : Opens and edits large Markdown and source files with less blocking work and bounded viewport rendering.
     4 September 2026 : v1.6.1 · A more deliberate workflow
@@ -762,8 +761,6 @@ timeline
                 : Detects external edits on network volumes even when filesystem change notifications are missed.
     7 September 2026 : v1.6.3 · A more deliberate workflow
                 : Switch between open documents with less visible delay, including when changing between Markdown and source files.
-    8 September 2026 : v1.6.4 · Release highlights
-                : Keeps macOS typing visually stable while preserving the native editor viewport.
 ```
 <!-- RELEASE_TIMELINE:END -->
 
@@ -773,13 +770,13 @@ The recent release arc is about continuity: files that change outside the app, w
 
 | Release | The editor change | What it protects or enables |
 |---|---|---|
-| [`v1.6.4`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.4) | **Release highlights** — Keeps macOS typing visually stable while preserving the native editor viewport. | Stops per-character document length and dirty-state changes from rebuilding the macOS editor configuration. |
 | [`v1.6.3`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.3) | **A more deliberate workflow** — Switch between open documents with less visible delay, including when changing between Markdown and source files. | Makes macOS tab switching responsive by publishing the selected editor before deferred Core Text layout and Markdown preview work runs. |
 | [`v1.6.2`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.2) | **Release highlights** — Detects external edits on network volumes even when filesystem change notifications are missed. | Avoids duplicate network-file checks and skips tabs that are still loading or already reviewing an external change. |
+| [`v1.6.1`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.1) | **A more deliberate workflow** — Brings official Emmet 2 abbreviation expansion to markup and stylesheet editing across the native editors. | Colors HTML tags, attributes, strings, embedded CSS properties, and numbers as separate syntax tokens instead of treating complete attribute or… |
 
 - Full release history: [`CHANGELOG.md`](CHANGELOG.md)
-- Latest release: **v1.6.4**
-- Compare recent changes: [v1.6.3...v1.6.4](https://github.com/h3pdesign/Neon-Vision-Editor/compare/v1.6.3...v1.6.4)
+- Latest release: **v1.6.3**
+- Compare recent changes: [v1.6.2...v1.6.3](https://github.com/h3pdesign/Neon-Vision-Editor/compare/v1.6.2...v1.6.3)
 
 ## Known Limitations
 
@@ -801,12 +798,12 @@ The recent release arc is about continuity: files that change outside the app, w
 
 ## Release Integrity
 
-- Tag: `v1.6.4`
+- Tag: `v1.6.3`
 - Tagged commit: release tag target
 - Verify local tag target:
 
 ```bash
-git rev-parse --verify v1.6.4
+git rev-parse --verify v1.6.3
 ```
 
 - Verify downloaded artifact checksum locally:

--- a/docs/images/neon-vision-release-history-0.1-to-0.5-light.svg
+++ b/docs/images/neon-vision-release-history-0.1-to-0.5-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="6856" height="1080" viewBox="0 0 6856 1080">
+<svg xmlns="http://www.w3.org/2000/svg" width="7208" height="1080" viewBox="0 0 7208 1080">
 <defs>
 <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
 <stop offset="0%" stop-color="#F6FBFF"/>
@@ -70,11 +70,14 @@
 <clipPath id="cardClip18">
 <rect x="6456.0" y="356" width="280" height="354" rx="20"/>
 </clipPath>
+<clipPath id="cardClip19">
+<rect x="6808.0" y="356" width="280" height="354" rx="20"/>
+</clipPath>
 </defs>
 <rect width="100%" height="100%" fill="url(#bg)"/>
 <text x="110" y="110" fill="#0F172A" font-size="62" font-weight="700" font-family="Arial, Helvetica, sans-serif">Neon Vision Editor</text>
-<text x="110" y="165" fill="#334155" font-size="30" font-family="Arial, Helvetica, sans-serif">Release History · Versions 0.1 – 1.6 + upcoming</text>
-<line x1="180" y1="800" x2="6756" y2="800" stroke="url(#lineGrad)" stroke-width="8" stroke-linecap="round"/>
+<text x="110" y="165" fill="#334155" font-size="30" font-family="Arial, Helvetica, sans-serif">Release History · Versions 0.1 – 1.7 + upcoming</text>
+<line x1="180" y1="800" x2="7108" y2="800" stroke="url(#lineGrad)" stroke-width="8" stroke-linecap="round"/>
 <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v0.1.0">
 <title>0.1 - Early Editor Foundation</title>
 <g filter="url(#shadow)">
@@ -382,7 +385,7 @@
 <circle cx="5188.0" cy="800" r="26" fill="#22C55E" fill-opacity="0.85"/>
 <text x="5188.0" y="870" text-anchor="middle" fill="#0F172A" font-size="28" font-family="Arial, Helvetica, sans-serif">1.5</text>
 </a>
-<a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.0">
+<a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.4">
 <title>1.6 - Why Upgrade</title>
 <g filter="url(#shadow)">
 <rect x="5390.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.78)" stroke="#F59E0B" stroke-width="3"/>
@@ -391,38 +394,38 @@
 <g clip-path="url(#cardClip15)">
 <text x="5414.0" y="390" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Why Upgrade</text>
 <line x1="5414.0" y1="436" x2="5666.0" y2="436" stroke="#94A3B8" stroke-opacity="0.4"/>
-<text x="5414.0" y="486" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Opens and edits large</text>
-<text x="5430.0" y="514" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">Markdown and sourc…</text>
-<text x="5414.0" y="556" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Keeps scrolling, rapid</text>
-<text x="5430.0" y="584" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">typing, Unicode edits…</text>
-<text x="5414.0" y="626" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Adds native macOS HEX</text>
-<text x="5430.0" y="654" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">color previews and …</text>
-<text x="5414.0" y="696" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Prepares large-file</text>
-<text x="5430.0" y="724" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">indexes in th…</text>
+<text x="5414.0" y="486" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Keeps macOS typing</text>
+<text x="5430.0" y="514" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">visually stable whil…</text>
+<text x="5414.0" y="556" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Makes empty native</text>
+<text x="5430.0" y="584" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">titlebar space usabl…</text>
+<text x="5414.0" y="626" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Keeps the editor’s</text>
+<text x="5430.0" y="654" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">native tab and viewpor…</text>
+<text x="5414.0" y="696" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Adds native macOS window</text>
+<text x="5430.0" y="724" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">dragging from unuse…</text>
 </g>
 <circle cx="5540.0" cy="800" r="26" fill="#F59E0B" fill-opacity="0.85"/>
 <text x="5540.0" y="870" text-anchor="middle" fill="#0F172A" font-size="28" font-family="Arial, Helvetica, sans-serif">1.6</text>
 </a>
-<a href="https://github.com/h3pdesign/Neon-Vision-Editor/issues/49">
-<title>1.7 - Upcoming Milestone</title>
+<a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.0">
+<title>1.7 - Why Upgrade</title>
 <g filter="url(#shadow)">
-<rect x="5742.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.78)" stroke="#06B6D4" stroke-width="3" stroke-dasharray="12 10"/>
+<rect x="5742.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.78)" stroke="#06B6D4" stroke-width="3"/>
 </g>
 <text x="5892.0" y="330" text-anchor="middle" fill="#0F172A" font-size="48" font-weight="700" font-family="Arial, Helvetica, sans-serif">1.7</text>
 <g clip-path="url(#cardClip16)">
-<text x="5766.0" y="390" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Upcoming</text>
-<text x="5766.0" y="426" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Milestone</text>
+<text x="5766.0" y="390" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Why Upgrade</text>
 <line x1="5766.0" y1="436" x2="6018.0" y2="436" stroke="#94A3B8" stroke-opacity="0.4"/>
-<text x="5766.0" y="486" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Planned roadmap</text>
-<text x="5782.0" y="514" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">milestone</text>
-<text x="5766.0" y="556" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• UX + reliability</text>
-<text x="5782.0" y="584" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">polishing</text>
-<text x="5766.0" y="626" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Scope refined via issue</text>
-<text x="5782.0" y="654" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">feedback</text>
+<text x="5766.0" y="486" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Keeps native document</text>
+<text x="5782.0" y="514" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">tabs, sidebars, edito…</text>
+<text x="5766.0" y="556" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Applies appearance and</text>
+<text x="5782.0" y="584" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">layout change…</text>
+<text x="5766.0" y="626" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Makes tab switching and</text>
+<text x="5782.0" y="654" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">Settings navigation fee…</text>
+<text x="5766.0" y="696" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Replaces the remaining</text>
+<text x="5782.0" y="724" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">legacy tab-bar path…</text>
 </g>
-<circle cx="5892.0" cy="800" r="26" fill="#06B6D4" fill-opacity="0.5" stroke-dasharray="6 6"/>
+<circle cx="5892.0" cy="800" r="26" fill="#06B6D4" fill-opacity="0.85"/>
 <text x="5892.0" y="870" text-anchor="middle" fill="#0F172A" font-size="28" font-family="Arial, Helvetica, sans-serif">1.7</text>
-<text x="5892.0" y="902" text-anchor="middle" fill="#334155" font-size="18" font-family="Arial, Helvetica, sans-serif">upcoming</text>
 </a>
 <a href="https://github.com/h3pdesign/Neon-Vision-Editor/issues/49">
 <title>1.8 - Upcoming Milestone</title>
@@ -446,23 +449,44 @@
 <text x="6244.0" y="902" text-anchor="middle" fill="#334155" font-size="18" font-family="Arial, Helvetica, sans-serif">upcoming</text>
 </a>
 <a href="https://github.com/h3pdesign/Neon-Vision-Editor/issues/49">
-<title>2.0 - Next Major Foundation</title>
+<title>1.9 - Upcoming Milestone</title>
 <g filter="url(#shadow)">
 <rect x="6446.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.78)" stroke="#49C6FF" stroke-width="3" stroke-dasharray="12 10"/>
 </g>
-<text x="6596.0" y="330" text-anchor="middle" fill="#0F172A" font-size="48" font-weight="700" font-family="Arial, Helvetica, sans-serif">2.0</text>
+<text x="6596.0" y="330" text-anchor="middle" fill="#0F172A" font-size="48" font-weight="700" font-family="Arial, Helvetica, sans-serif">1.9</text>
 <g clip-path="url(#cardClip18)">
-<text x="6470.0" y="390" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Next Major</text>
-<text x="6470.0" y="426" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Foundation</text>
+<text x="6470.0" y="390" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Upcoming</text>
+<text x="6470.0" y="426" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Milestone</text>
 <line x1="6470.0" y1="436" x2="6722.0" y2="436" stroke="#94A3B8" stroke-opacity="0.4"/>
-<text x="6470.0" y="486" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Platform + architecture</text>
-<text x="6486.0" y="514" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">step-up</text>
-<text x="6470.0" y="556" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Roadmap themes converge</text>
-<text x="6470.0" y="626" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Migration guidance in</text>
-<text x="6486.0" y="654" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">release notes</text>
+<text x="6470.0" y="486" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Planned roadmap</text>
+<text x="6486.0" y="514" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">milestone</text>
+<text x="6470.0" y="556" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• UX + reliability</text>
+<text x="6486.0" y="584" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">polishing</text>
+<text x="6470.0" y="626" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Scope refined via issue</text>
+<text x="6486.0" y="654" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">feedback</text>
 </g>
 <circle cx="6596.0" cy="800" r="26" fill="#49C6FF" fill-opacity="0.5" stroke-dasharray="6 6"/>
-<text x="6596.0" y="870" text-anchor="middle" fill="#0F172A" font-size="28" font-family="Arial, Helvetica, sans-serif">2.0</text>
+<text x="6596.0" y="870" text-anchor="middle" fill="#0F172A" font-size="28" font-family="Arial, Helvetica, sans-serif">1.9</text>
 <text x="6596.0" y="902" text-anchor="middle" fill="#334155" font-size="18" font-family="Arial, Helvetica, sans-serif">upcoming</text>
+</a>
+<a href="https://github.com/h3pdesign/Neon-Vision-Editor/issues/49">
+<title>2.0 - Next Major Foundation</title>
+<g filter="url(#shadow)">
+<rect x="6798.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.78)" stroke="#66E3FF" stroke-width="3" stroke-dasharray="12 10"/>
+</g>
+<text x="6948.0" y="330" text-anchor="middle" fill="#0F172A" font-size="48" font-weight="700" font-family="Arial, Helvetica, sans-serif">2.0</text>
+<g clip-path="url(#cardClip19)">
+<text x="6822.0" y="390" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Next Major</text>
+<text x="6822.0" y="426" fill="#0F172A" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Foundation</text>
+<line x1="6822.0" y1="436" x2="7074.0" y2="436" stroke="#94A3B8" stroke-opacity="0.4"/>
+<text x="6822.0" y="486" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Platform + architecture</text>
+<text x="6838.0" y="514" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">step-up</text>
+<text x="6822.0" y="556" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Roadmap themes converge</text>
+<text x="6822.0" y="626" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">• Migration guidance in</text>
+<text x="6838.0" y="654" fill="#1F2937" font-size="20" font-family="Arial, Helvetica, sans-serif">release notes</text>
+</g>
+<circle cx="6948.0" cy="800" r="26" fill="#66E3FF" fill-opacity="0.5" stroke-dasharray="6 6"/>
+<text x="6948.0" y="870" text-anchor="middle" fill="#0F172A" font-size="28" font-family="Arial, Helvetica, sans-serif">2.0</text>
+<text x="6948.0" y="902" text-anchor="middle" fill="#334155" font-size="18" font-family="Arial, Helvetica, sans-serif">upcoming</text>
 </a>
 </svg>

--- a/docs/images/neon-vision-release-history-0.1-to-0.5.svg
+++ b/docs/images/neon-vision-release-history-0.1-to-0.5.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="6856" height="1080" viewBox="0 0 6856 1080">
+<svg xmlns="http://www.w3.org/2000/svg" width="7208" height="1080" viewBox="0 0 7208 1080">
 <defs>
 <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
 <stop offset="0%" stop-color="#050A2A"/>
@@ -70,11 +70,14 @@
 <clipPath id="cardClip18">
 <rect x="6456.0" y="356" width="280" height="354" rx="20"/>
 </clipPath>
+<clipPath id="cardClip19">
+<rect x="6808.0" y="356" width="280" height="354" rx="20"/>
+</clipPath>
 </defs>
 <rect width="100%" height="100%" fill="url(#bg)"/>
 <text x="110" y="110" fill="#FFFFFF" font-size="62" font-weight="700" font-family="Arial, Helvetica, sans-serif">Neon Vision Editor</text>
-<text x="110" y="165" fill="#DFE8FF" font-size="30" font-family="Arial, Helvetica, sans-serif">Release History · Versions 0.1 – 1.6 + upcoming</text>
-<line x1="180" y1="800" x2="6756" y2="800" stroke="url(#lineGrad)" stroke-width="8" stroke-linecap="round"/>
+<text x="110" y="165" fill="#DFE8FF" font-size="30" font-family="Arial, Helvetica, sans-serif">Release History · Versions 0.1 – 1.7 + upcoming</text>
+<line x1="180" y1="800" x2="7108" y2="800" stroke="url(#lineGrad)" stroke-width="8" stroke-linecap="round"/>
 <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v0.1.0">
 <title>0.1 - Early Editor Foundation</title>
 <g filter="url(#shadow)">
@@ -382,7 +385,7 @@
 <circle cx="5188.0" cy="800" r="26" fill="#22C55E" fill-opacity="0.85"/>
 <text x="5188.0" y="870" text-anchor="middle" fill="#FFFFFF" font-size="28" font-family="Arial, Helvetica, sans-serif">1.5</text>
 </a>
-<a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.0">
+<a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.6.4">
 <title>1.6 - Why Upgrade</title>
 <g filter="url(#shadow)">
 <rect x="5390.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.06)" stroke="#F59E0B" stroke-width="3"/>
@@ -391,38 +394,38 @@
 <g clip-path="url(#cardClip15)">
 <text x="5414.0" y="390" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Why Upgrade</text>
 <line x1="5414.0" y1="436" x2="5666.0" y2="436" stroke="#DBE6FF" stroke-opacity="0.4"/>
-<text x="5414.0" y="486" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Opens and edits large</text>
-<text x="5430.0" y="514" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">Markdown and sourc…</text>
-<text x="5414.0" y="556" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Keeps scrolling, rapid</text>
-<text x="5430.0" y="584" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">typing, Unicode edits…</text>
-<text x="5414.0" y="626" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Adds native macOS HEX</text>
-<text x="5430.0" y="654" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">color previews and …</text>
-<text x="5414.0" y="696" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Prepares large-file</text>
-<text x="5430.0" y="724" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">indexes in th…</text>
+<text x="5414.0" y="486" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Keeps macOS typing</text>
+<text x="5430.0" y="514" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">visually stable whil…</text>
+<text x="5414.0" y="556" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Makes empty native</text>
+<text x="5430.0" y="584" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">titlebar space usabl…</text>
+<text x="5414.0" y="626" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Keeps the editor’s</text>
+<text x="5430.0" y="654" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">native tab and viewpor…</text>
+<text x="5414.0" y="696" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Adds native macOS window</text>
+<text x="5430.0" y="724" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">dragging from unuse…</text>
 </g>
 <circle cx="5540.0" cy="800" r="26" fill="#F59E0B" fill-opacity="0.85"/>
 <text x="5540.0" y="870" text-anchor="middle" fill="#FFFFFF" font-size="28" font-family="Arial, Helvetica, sans-serif">1.6</text>
 </a>
-<a href="https://github.com/h3pdesign/Neon-Vision-Editor/issues/49">
-<title>1.7 - Upcoming Milestone</title>
+<a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.0">
+<title>1.7 - Why Upgrade</title>
 <g filter="url(#shadow)">
-<rect x="5742.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.06)" stroke="#06B6D4" stroke-width="3" stroke-dasharray="12 10"/>
+<rect x="5742.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.06)" stroke="#06B6D4" stroke-width="3"/>
 </g>
 <text x="5892.0" y="330" text-anchor="middle" fill="#F3F7FF" font-size="48" font-weight="700" font-family="Arial, Helvetica, sans-serif">1.7</text>
 <g clip-path="url(#cardClip16)">
-<text x="5766.0" y="390" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Upcoming</text>
-<text x="5766.0" y="426" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Milestone</text>
+<text x="5766.0" y="390" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Why Upgrade</text>
 <line x1="5766.0" y1="436" x2="6018.0" y2="436" stroke="#DBE6FF" stroke-opacity="0.4"/>
-<text x="5766.0" y="486" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Planned roadmap</text>
-<text x="5782.0" y="514" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">milestone</text>
-<text x="5766.0" y="556" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• UX + reliability</text>
-<text x="5782.0" y="584" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">polishing</text>
-<text x="5766.0" y="626" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Scope refined via issue</text>
-<text x="5782.0" y="654" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">feedback</text>
+<text x="5766.0" y="486" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Keeps native document</text>
+<text x="5782.0" y="514" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">tabs, sidebars, edito…</text>
+<text x="5766.0" y="556" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Applies appearance and</text>
+<text x="5782.0" y="584" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">layout change…</text>
+<text x="5766.0" y="626" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Makes tab switching and</text>
+<text x="5782.0" y="654" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">Settings navigation fee…</text>
+<text x="5766.0" y="696" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Replaces the remaining</text>
+<text x="5782.0" y="724" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">legacy tab-bar path…</text>
 </g>
-<circle cx="5892.0" cy="800" r="26" fill="#06B6D4" fill-opacity="0.5" stroke-dasharray="6 6"/>
+<circle cx="5892.0" cy="800" r="26" fill="#06B6D4" fill-opacity="0.85"/>
 <text x="5892.0" y="870" text-anchor="middle" fill="#FFFFFF" font-size="28" font-family="Arial, Helvetica, sans-serif">1.7</text>
-<text x="5892.0" y="902" text-anchor="middle" fill="#DFE8FF" font-size="18" font-family="Arial, Helvetica, sans-serif">upcoming</text>
 </a>
 <a href="https://github.com/h3pdesign/Neon-Vision-Editor/issues/49">
 <title>1.8 - Upcoming Milestone</title>
@@ -446,23 +449,44 @@
 <text x="6244.0" y="902" text-anchor="middle" fill="#DFE8FF" font-size="18" font-family="Arial, Helvetica, sans-serif">upcoming</text>
 </a>
 <a href="https://github.com/h3pdesign/Neon-Vision-Editor/issues/49">
-<title>2.0 - Next Major Foundation</title>
+<title>1.9 - Upcoming Milestone</title>
 <g filter="url(#shadow)">
 <rect x="6446.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.06)" stroke="#49C6FF" stroke-width="3" stroke-dasharray="12 10"/>
 </g>
-<text x="6596.0" y="330" text-anchor="middle" fill="#F3F7FF" font-size="48" font-weight="700" font-family="Arial, Helvetica, sans-serif">2.0</text>
+<text x="6596.0" y="330" text-anchor="middle" fill="#F3F7FF" font-size="48" font-weight="700" font-family="Arial, Helvetica, sans-serif">1.9</text>
 <g clip-path="url(#cardClip18)">
-<text x="6470.0" y="390" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Next Major</text>
-<text x="6470.0" y="426" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Foundation</text>
+<text x="6470.0" y="390" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Upcoming</text>
+<text x="6470.0" y="426" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Milestone</text>
 <line x1="6470.0" y1="436" x2="6722.0" y2="436" stroke="#DBE6FF" stroke-opacity="0.4"/>
-<text x="6470.0" y="486" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Platform + architecture</text>
-<text x="6486.0" y="514" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">step-up</text>
-<text x="6470.0" y="556" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Roadmap themes converge</text>
-<text x="6470.0" y="626" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Migration guidance in</text>
-<text x="6486.0" y="654" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">release notes</text>
+<text x="6470.0" y="486" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Planned roadmap</text>
+<text x="6486.0" y="514" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">milestone</text>
+<text x="6470.0" y="556" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• UX + reliability</text>
+<text x="6486.0" y="584" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">polishing</text>
+<text x="6470.0" y="626" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Scope refined via issue</text>
+<text x="6486.0" y="654" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">feedback</text>
 </g>
 <circle cx="6596.0" cy="800" r="26" fill="#49C6FF" fill-opacity="0.5" stroke-dasharray="6 6"/>
-<text x="6596.0" y="870" text-anchor="middle" fill="#FFFFFF" font-size="28" font-family="Arial, Helvetica, sans-serif">2.0</text>
+<text x="6596.0" y="870" text-anchor="middle" fill="#FFFFFF" font-size="28" font-family="Arial, Helvetica, sans-serif">1.9</text>
 <text x="6596.0" y="902" text-anchor="middle" fill="#DFE8FF" font-size="18" font-family="Arial, Helvetica, sans-serif">upcoming</text>
+</a>
+<a href="https://github.com/h3pdesign/Neon-Vision-Editor/issues/49">
+<title>2.0 - Next Major Foundation</title>
+<g filter="url(#shadow)">
+<rect x="6798.0" y="260" width="300" height="470" rx="30" fill="rgba(255,255,255,0.06)" stroke="#66E3FF" stroke-width="3" stroke-dasharray="12 10"/>
+</g>
+<text x="6948.0" y="330" text-anchor="middle" fill="#F3F7FF" font-size="48" font-weight="700" font-family="Arial, Helvetica, sans-serif">2.0</text>
+<g clip-path="url(#cardClip19)">
+<text x="6822.0" y="390" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Next Major</text>
+<text x="6822.0" y="426" fill="#F3F7FF" font-size="30" font-weight="600" font-family="Arial, Helvetica, sans-serif">Foundation</text>
+<line x1="6822.0" y1="436" x2="7074.0" y2="436" stroke="#DBE6FF" stroke-opacity="0.4"/>
+<text x="6822.0" y="486" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Platform + architecture</text>
+<text x="6838.0" y="514" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">step-up</text>
+<text x="6822.0" y="556" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Roadmap themes converge</text>
+<text x="6822.0" y="626" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">• Migration guidance in</text>
+<text x="6838.0" y="654" fill="#E7EFFF" font-size="20" font-family="Arial, Helvetica, sans-serif">release notes</text>
+</g>
+<circle cx="6948.0" cy="800" r="26" fill="#66E3FF" fill-opacity="0.5" stroke-dasharray="6 6"/>
+<text x="6948.0" y="870" text-anchor="middle" fill="#FFFFFF" font-size="28" font-family="Arial, Helvetica, sans-serif">2.0</text>
+<text x="6948.0" y="902" text-anchor="middle" fill="#DFE8FF" font-size="18" font-family="Arial, Helvetica, sans-serif">upcoming</text>
 </a>
 </svg>

--- a/release/prepared-release.json
+++ b/release/prepared-release.json
@@ -1,13 +1,13 @@
 {
-  "tag": "v1.6.4",
-  "source": "aeafa90b34e883929aeac6133ee97c9803799285",
-  "date": "2026-09-08",
-  "build": 1032,
+  "tag": "v1.7.0",
+  "source": "5afa97c9eddd256cd125f1067bcf9ef183b53f51",
+  "date": "2026-09-09",
+  "build": 1033,
   "published_tag": "v1.6.3",
   "published_build": 1031,
-  "status": "published",
+  "status": "prepared",
   "cloud": {
     "product_id": "6BA578EC-8F26-47BC-81A9-94246EAF48E0",
-    "max_number": 1031
+    "max_number": 1032
   }
 }

--- a/scripts/prepare_release_docs.py
+++ b/scripts/prepare_release_docs.py
@@ -582,6 +582,7 @@ def rebuild_changelog_page(page: str, changelog: str, current_tag: str) -> str:
 
 LOCALIZED_TIMELINE_COPY = {
     "de": {
+        "v1.7.0": ("Native Tabs und konsistente Fensterdarstellung", "Hält Tabs, Seitenleisten, Editorflächen und Einstellungen über macOS, iOS und iPadOS hinweg konsistent und stabil.", ["Tabs", "Darstellung", "Seitenleisten"]),
         "v1.6.4": ("Stabiles Tippen und zuverlässiges Fensterziehen", "Hält den macOS-Editor beim Tippen stabil und macht leere Bereiche der nativen Symbolleiste verschiebbar, ohne ihre Aktionen zu blockieren.", ["Editor", "Fenster", "Symbolleiste"]),
         "v1.6.3": ("Sofortiger Tabwechsel und reibungsloser Editor", "Beschleunigt den Wechsel zwischen Markdown- und Quelldateien und verschiebt Vorschau- sowie Layoutarbeit aus dem ersten Anzeigeframe.", ["Editor", "Leistung", "Tabs"]),
         "v1.6.2": ("Sichereres Speichern und zuverlässigere App-Starts", "Verbessert das Speichern externer Dokumente und erkennt Änderungen auf Netzlaufwerken, öffnet Textdateien mit unbekannten Endungen und macht die automatische Willkommenstour abschaltbar.", ["Dateisicherheit", "Textdateien", "Start"]),
@@ -604,6 +605,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor und Snapshots werden verlässlicher", "Verbessert Auswahl, Tastaturnavigation und Themes im macOS-Editor und erweitert den Code-Snapshot-Export.", ["Editor", "Themes", "Snapshots"]),
     },
     "da": {
+        "v1.7.0": ("Native faner og ensartet vinduesvisning", "Holder faner, sidepaneler, editorflader og indstillinger ensartede og stabile på macOS, iOS og iPadOS.", ["Faner", "Visning", "Sidepaneler"]),
         "v1.6.4": ("Stabil indtastning og pålidelig vinduesflytning", "Holder macOS-editoren stabil under indtastning og gør tomme områder i den native værktøjslinje flytbare uden at blokere dens handlinger.", ["Editor", "Vindue", "Værktøjslinje"]),
         "v1.6.3": ("Øjeblikkeligt faneskift og mere flydende editor", "Gør skift mellem Markdown- og kildefiler hurtigere og flytter forhåndsvisnings- og layoutarbejde efter den første visning.", ["Editor", "Ydeevne", "Faner"]),
         "v1.6.2": ("Sikrere lagring og mere pålidelig opstart", "Forbedrer lagring af eksterne dokumenter og registrering af ændringer på netværksdrev, åbner tekstfiler med ukendte filendelser og gør den automatiske velkomst valgfri.", ["Filsikkerhed", "Tekstfiler", "Opstart"]),
@@ -626,6 +628,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor og snapshots bliver mere pålidelige", "Forbedrer markering, tastaturnavigation og temaer i macOS-editoren og udvider eksporten af kodesnapshots.", ["Editor", "Temaer", "Snapshots"]),
     },
     "fr": {
+        "v1.7.0": ("Onglets natifs et apparence cohérente", "Garde les onglets, barres latérales, surfaces d’édition et réglages cohérents et stables sur macOS, iOS et iPadOS.", ["Onglets", "Apparence", "Barres latérales"]),
         "v1.6.4": ("Saisie stable et déplacement fiable des fenêtres", "Stabilise l’éditeur macOS pendant la saisie et rend les espaces vides de la barre d’outils déplaçables sans bloquer ses actions.", ["Éditeur", "Fenêtre", "Barre d’outils"]),
         "v1.6.3": ("Changement d’onglet instantané et éditeur plus fluide", "Accélère le passage entre fichiers Markdown et source et reporte le travail d’aperçu et de mise en page après le premier affichage.", ["Éditeur", "Performances", "Onglets"]),
         "v1.6.2": ("Enregistrement plus sûr et démarrage plus fiable", "Améliore l’enregistrement des documents externes et la détection des modifications réseau, ouvre les fichiers texte aux extensions inconnues et rend l’accueil automatique facultatif.", ["Sécurité des fichiers", "Fichiers texte", "Démarrage"]),
@@ -648,6 +651,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Éditeur et instantanés plus fiables", "Améliore la sélection, la navigation au clavier et les thèmes dans l’éditeur macOS, tout en enrichissant l’export d’instantanés de code.", ["Éditeur", "Thèmes", "Instantanés"]),
     },
     "es": {
+        "v1.7.0": ("Pestañas nativas y apariencia coherente", "Mantiene coherentes y estables las pestañas, barras laterales, superficies del editor y Ajustes en macOS, iOS y iPadOS.", ["Pestañas", "Apariencia", "Barras laterales"]),
         "v1.6.4": ("Escritura estable y movimiento fiable de ventanas", "Estabiliza el editor de macOS al escribir y permite mover la ventana desde los espacios vacíos de la barra nativa sin bloquear sus acciones.", ["Editor", "Ventana", "Barra"]),
         "v1.6.3": ("Cambio de pestaña instantáneo y editor más fluido", "Acelera el cambio entre archivos Markdown y de código y pospone el trabajo de vista previa y diseño tras el primer dibujo.", ["Editor", "Rendimiento", "Pestañas"]),
         "v1.6.2": ("Guardado más seguro e inicio más fiable", "Mejora el guardado de documentos externos y la detección de cambios en red, abre archivos de texto con extensiones desconocidas y permite desactivar la bienvenida automática.", ["Seguridad de archivos", "Archivos de texto", "Inicio"]),
@@ -670,6 +674,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor y capturas más fiables", "Mejora la selección, la navegación por teclado y los temas del editor de macOS, y amplía la exportación de capturas de código.", ["Editor", "Temas", "Capturas"]),
     },
     "ja": {
+        "v1.7.0": ("ネイティブタブと一貫したウインドウ表示", "macOS、iOS、iPadOS でタブ、サイドバー、エディタ面、設定の表示を一貫させ、安定させます。", ["タブ", "表示", "サイドバー"]),
         "v1.6.4": ("安定した入力と確実なウインドウ移動", "macOS エディタの入力中のちらつきを抑え、ネイティブツールバーの空白部分から操作を妨げずにウインドウを移動できます。", ["エディタ", "ウインドウ", "ツールバー"]),
         "v1.6.3": ("瞬時のタブ切り替えとより滑らかなエディタ", "Markdown とソースファイルの切り替えを高速化し、プレビューとレイアウト処理を初回表示後に行います。", ["エディタ", "パフォーマンス", "タブ"]),
         "v1.6.2": ("より安全な保存と安定した起動", "外部ドキュメントの保存とネットワーク上の変更検出を改善し、未知の拡張子のテキストファイルを開けるようにしました。自動ウェルカム画面も無効にできます。", ["ファイルの安全性", "テキストファイル", "起動"]),
@@ -692,6 +697,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("エディタとスナップショットをさらに信頼性向上", "macOS エディタの選択、キーボード操作、テーマを改善し、コードスナップショットの書き出しを拡充します。", ["エディタ", "テーマ", "スナップショット"]),
     },
     "zh-Hans": {
+        "v1.7.0": ("原生标签页与一致的窗口外观", "在 macOS、iOS 和 iPadOS 上保持标签页、侧边栏、编辑器表面和设置的一致性与稳定性。", ["标签页", "外观", "侧边栏"]),
         "v1.6.4": ("稳定输入与可靠的窗口拖动", "让 macOS 编辑器输入时保持稳定，并可从原生工具栏的空白区域移动窗口，同时不影响工具栏操作。", ["编辑器", "窗口", "工具栏"]),
         "v1.6.3": ("即时标签页切换与更流畅的编辑器", "加快 Markdown 与源文件之间的切换，并将预览和布局工作延后到首帧显示之后。", ["编辑器", "性能", "标签页"]),
         "v1.6.2": ("更安全的保存与更可靠的启动", "改进外部文档保存和网络文件变更检测，支持打开未知扩展名的文本文件，并允许关闭自动欢迎界面。", ["文件安全", "文本文件", "启动"]),


### PR DESCRIPTION
Prepared from develop 5afa97c9eddd256cd125f1067bcf9ef183b53f51. Build 1033. Publication remains gated by signed archive and notarization checks.

## Summary by Sourcery

Prepare the v1.7.0 release with native cross-platform tabs and consistent editor chrome, surfaces, appearance handling, and Settings behavior.

New Features:
- Introduce native document tab implementations for macOS and iOS with selection, closing, reordering, overflow handling, and platform-appropriate accessibility support.
- Display file-size metadata in document previews and detached preview windows.

Bug Fixes:
- Fix appearance inheritance, translucent and opaque surface alignment, tab border rendering, and layout transitions across supported Apple platforms.
- Stabilize macOS Settings sizing, positioning, and navigation during pane and appearance changes.
- Restrict titlebar window dragging to the upper chrome area to avoid interfering with editor selection.

Enhancements:
- Unify editor, sidebar, tab, line-number, preview, and Settings surfaces across appearance modes and window configurations.
- Improve native tab visual states, scrolling, interaction feedback, and preview chrome.

Build:
- Prepare the v1.7.0 release metadata and project configuration.

Documentation:
- Update release-aligned architecture, changelog, README, localized release timeline content, and the welcome tour for v1.7.0.

Tests:
- Add coverage for native macOS and mobile tab behavior, appearance inheritance, window translucency, layout, accessibility, and Settings-related policies.

Chores:
- Mark v1.7.0 as prepared but unpublished pending signed archive and notarization checks.