### PR TITLE
Fix editor interactions and release tour

### DIFF
--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -4554,6 +4554,7 @@ struct ContentView: View {
             indentWidth: effectiveIndentWidth,
             isSplitPaneResizeInProgress: previewPaneResizeStartWidth != nil,
             preferredLayoutWidth: brainDumpLayoutEnabled ? 920 : nil,
+            focusesEditorOnInitialWindowAttachment: startupBehavior == .forceBlankDocument,
             onFontSizeChange: { setEditorFontSize(Double($0)) },
             onTextMutation: { mutation in
                 if let viewport = mutation.viewport {

--- a/Neon Vision Editor/UI/EditorTextView+iOS.swift
+++ b/Neon Vision Editor/UI/EditorTextView+iOS.swift
@@ -12,6 +12,12 @@ nonisolated func iPadShiftScrollFontSizeDelta(contentOffsetDeltaY: CGFloat) -> C
 }
 
 #if os(iOS)
+enum EditorPointerSelectionPolicy {
+    static func shouldEnableTextDragInteraction(for idiom: UIUserInterfaceIdiom) -> Bool {
+        false
+    }
+}
+
 enum EditorPencilInputPolicy {
     static func selectionAnchorPoint(current: CGPoint, translation: CGPoint) -> CGPoint {
         CGPoint(x: current.x - translation.x, y: current.y - translation.y)
@@ -1917,12 +1923,19 @@ struct CustomTextEditor: UIViewRepresentable {
     }
 
     private func configurePointerSelectionBehavior(_ textView: UITextView) {
-        #if os(visionOS)
-        textView.textDragInteraction?.isEnabled = true
-        #else
+#if os(visionOS)
+        // Keep the system pointer selection interaction in control of drags.
+        // Text transfers otherwise take precedence over selecting editor text.
+        textView.textDragInteraction?.isEnabled = false
+#else
+        // Keep UIKit's native pointer/text-selection interaction in control of
+        // mouse drags on both iPad and iPhone. Text drag transfers otherwise
+        // claim the drag before the caret/selection interaction can update.
+        textView.textDragInteraction?.isEnabled = EditorPointerSelectionPolicy.shouldEnableTextDragInteraction(
+            for: UIDevice.current.userInterfaceIdiom
+        )
         if UIDevice.current.userInterfaceIdiom == .pad {
             textView.keyboardDismissMode = .none
-            textView.textDragInteraction?.isEnabled = true
         } else {
             // A phone editor should release the software keyboard as soon as
             // the document is scrolled. `.interactive` only follows a downward

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -2708,6 +2708,23 @@ struct WelcomeTourView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.purchase) private var purchase
     @EnvironmentObject private var supportPurchaseManager: SupportPurchaseManager
+    @AppStorage("SettingsAppearance") private var appearance: String = "system"
+
+    private var effectiveTourColorScheme: ColorScheme {
+        switch appearance {
+        case "light": return .light
+        case "dark": return .dark
+        default: return colorScheme
+        }
+    }
+
+    private var preferredTourColorScheme: ColorScheme? {
+        switch appearance {
+        case "light": return .light
+        case "dark": return .dark
+        default: return nil
+        }
+    }
 
     static var releaseID: String {
         let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
@@ -2758,15 +2775,15 @@ struct WelcomeTourView: View {
 
     private let pages: [TourPage] = [
         TourPage(
-            title: "What’s New in v1.6.4",
-            subtitle: "Release highlights for v1.6.4.",
+            title: "What’s New in v1.7.0",
+            subtitle: "Major fixes and improvements in the current release.",
             bullets: [
-                "Editor Improvements: Keeps macOS typing visually stable while preserving the native editor viewport.",
-                "Workflow Refinements: Makes empty native titlebar space usable for window movement without sacrificing toolbar actions.",
-                "Performance Updates: Keeps the editor’s native tab and viewport lifecycle intact while these macOS chrome fixes are applied.",
-                "Usability Updates: Adds native macOS window dragging from unused titlebar and toolbar space with no visible drag handle.",
-                "Editor Improvements: Stops per-character document length and dirty-state changes from rebuilding the macOS editor configuration.",
-                "Workflow Refinements: Preserves toolbar button hit-testing while supporting window dragging in the middle of the native toolbar."
+                "Native Tabs: Replaces the remaining legacy tab-bar paths with native platform tab implementations.",
+                "Theme Consistency: Keeps tabs, sidebars, editor surfaces, and Settings consistent across Light, Dark, and System modes.",
+                "Responsive Workflows: Makes tab switching and Settings navigation feel immediate while preserving native controls.",
+                "Stable Window Surfaces: Aligns tab, TOC sidebar, project sidebar, line-number, and editor backgrounds in opaque and translucent modes.",
+                "Reliable Tab Chrome: Prevents tab borders from clipping, flashing, or disappearing during hover and theme transitions.",
+                "Settings Polish: Keeps Settings content sized to the selected tab and opens the window in a stable editor-relative position."
             ],
             iconName: "sparkles.rectangle.stack",
             colors: [Color(red: 0.40, green: 0.28, blue: 0.90), Color(red: 0.96, green: 0.46, blue: 0.55)],
@@ -3015,9 +3032,10 @@ struct WelcomeTourView: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: containerCornerRadius, style: .continuous)
-                .stroke(colorScheme == .dark ? Color.white.opacity(0.10) : Color.black.opacity(0.08), lineWidth: 1)
+                .stroke(effectiveTourColorScheme == .dark ? Color.white.opacity(0.10) : Color.black.opacity(0.08), lineWidth: 1)
         )
         .frame(width: 980, height: 780)
+        .preferredColorScheme(preferredTourColorScheme)
 #else
         .presentationDetents([.height(preferredSheetHeight), .large])
 #endif
@@ -3093,19 +3111,19 @@ struct WelcomeTourView: View {
     private var welcomeTourBackground: some View {
         ZStack {
             Rectangle()
-                .fill(colorScheme == .dark ? AnyShapeStyle(.regularMaterial) : AnyShapeStyle(.ultraThinMaterial))
+                .fill(effectiveTourColorScheme == .dark ? AnyShapeStyle(.regularMaterial) : AnyShapeStyle(.ultraThinMaterial))
 
             LinearGradient(
                 colors: welcomeTourBackgroundColors,
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
-            .opacity(colorScheme == .dark ? 0.42 : 0.28)
+            .opacity(effectiveTourColorScheme == .dark ? 0.42 : 0.28)
         }
     }
 
     private var welcomeTourBackgroundColors: [Color] {
-        if colorScheme == .dark {
+        if effectiveTourColorScheme == .dark {
             return [
                 Color(red: 0.09, green: 0.10, blue: 0.14),
                 Color(red: 0.13, green: 0.16, blue: 0.22)
@@ -3158,30 +3176,22 @@ struct WelcomeTourView: View {
     ) -> some View {
         let displayBullets = page.bullets.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("![") }
 #if os(macOS)
-        if isWhatsNewPage(page), !compactLayout {
+        ScrollView(.vertical, showsIndicators: true) {
             tourCardContent(for: page, displayBullets: displayBullets, index: index, compactLayout: compactLayout)
-                .padding(.top, 8)
-                .padding(.horizontal, 2)
-                .frame(maxHeight: .infinity, alignment: .top)
-                .clipped()
-        } else {
-            ScrollView(.vertical, showsIndicators: true) {
-                tourCardContent(for: page, displayBullets: displayBullets, index: index, compactLayout: compactLayout)
-                    .padding(.bottom, compactLayout ? 24 : 0)
-            }
-            .padding(.top, 8)
-            .padding(.horizontal, 2)
-            .mask(alignment: .bottom) {
-                LinearGradient(
-                    stops: [
-                        .init(color: .black, location: 0),
-                        .init(color: .black, location: compactLayout ? 0.90 : 1),
-                        .init(color: .clear, location: 1)
-                    ],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            }
+                .padding(.bottom, compactLayout ? 24 : 0)
+        }
+        .padding(.top, 8)
+        .padding(.horizontal, 2)
+        .mask(alignment: .bottom) {
+            LinearGradient(
+                stops: [
+                    .init(color: .black, location: 0),
+                    .init(color: .black, location: compactLayout ? 0.90 : 1),
+                    .init(color: .clear, location: 1)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
         }
 #else
         ScrollView(.vertical, showsIndicators: true) {
@@ -3331,10 +3341,10 @@ struct WelcomeTourView: View {
             .padding(compactLayout ? 10 : 12)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(colorScheme == .dark ? Color.white.opacity(0.060) : Color.white.opacity(0.68))
+                    .fill(effectiveTourColorScheme == .dark ? Color.white.opacity(0.060) : Color.white.opacity(0.68))
                     .overlay(
                         RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .stroke(colorScheme == .dark ? Color.white.opacity(0.10) : Color.black.opacity(0.07), lineWidth: 1)
+                            .stroke(effectiveTourColorScheme == .dark ? Color.white.opacity(0.10) : Color.black.opacity(0.07), lineWidth: 1)
                     )
             )
         }
@@ -3375,21 +3385,17 @@ struct WelcomeTourView: View {
         .padding(compactLayout ? 10 : 12)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(colorScheme == .dark ? Color.white.opacity(0.060) : Color.white.opacity(0.68))
+                .fill(effectiveTourColorScheme == .dark ? Color.white.opacity(0.060) : Color.white.opacity(0.68))
                 .overlay(
                     RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(colorScheme == .dark ? Color.white.opacity(0.10) : Color.black.opacity(0.07), lineWidth: 1)
+                        .stroke(effectiveTourColorScheme == .dark ? Color.white.opacity(0.10) : Color.black.opacity(0.07), lineWidth: 1)
                 )
         )
     }
 
     @ViewBuilder
     private func whatsNewRows(bullets: [String], compactLayout: Bool) -> some View {
-        #if os(macOS)
-        let columns = 3
-        #else
         let columns = 2
-        #endif
 
         VStack(alignment: .leading, spacing: compactLayout ? 10 : 12) {
             ForEach(Array(stride(from: 0, to: bullets.count, by: columns)), id: \.self) { rowStart in
@@ -3424,7 +3430,7 @@ struct WelcomeTourView: View {
                                 endPoint: .bottomTrailing
                             )
                         )
-                        .shadow(color: Color.accentColor.opacity(colorScheme == .dark ? 0.28 : 0.20), radius: 6, y: 2)
+                        .shadow(color: Color.accentColor.opacity(effectiveTourColorScheme == .dark ? 0.28 : 0.20), radius: 6, y: 2)
                 )
                 .padding(.top, 1)
                 .accessibilityHidden(true)
@@ -3445,12 +3451,12 @@ struct WelcomeTourView: View {
         .frame(maxWidth: .infinity, minHeight: compactLayout ? 104 : 142, maxHeight: compactLayout ? 118 : 142, alignment: .topLeading)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(colorScheme == .dark ? Color.white.opacity(0.060) : Color.white.opacity(0.68))
+                .fill(effectiveTourColorScheme == .dark ? Color.white.opacity(0.060) : Color.white.opacity(0.68))
                 .overlay(
                     RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(colorScheme == .dark ? Color.white.opacity(0.10) : Color.black.opacity(0.07), lineWidth: 1)
+                        .stroke(effectiveTourColorScheme == .dark ? Color.white.opacity(0.10) : Color.black.opacity(0.07), lineWidth: 1)
                 )
-                .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.18 : 0.06), radius: 10, y: 4)
+                .shadow(color: Color.black.opacity(effectiveTourColorScheme == .dark ? 0.18 : 0.06), radius: 10, y: 4)
         )
         .clipped()
         .accessibilityElement(children: .combine)
@@ -4476,6 +4482,41 @@ struct InAppChangelogView: View {
     }
 
     private let releases: [Release] = [
+        Release(id: "1.7.0", version: "1.7.0", date: "2026-09-09", highlights: [
+            "Replaces remaining legacy tab-bar paths with native platform tabs and preserves borders, spacing, and translucent surfaces during appearance changes.",
+            "Keeps macOS, iOS, and iPadOS editor surfaces consistent in opaque and translucent window modes.",
+            "Improves Settings sizing and navigation while keeping tab switching responsive and preserving native controls."
+        ]),
+        Release(id: "1.6.4", version: "1.6.4", date: "2026-09-08", highlights: [
+            "Adds native macOS window dragging from unused titlebar and toolbar space without sacrificing toolbar actions.",
+            "Keeps macOS typing visually stable and avoids rebuilding editor configuration for every character edit.",
+            "Preserves toolbar hit-testing while native window chrome is updated."
+        ]),
+        Release(id: "1.6.3", version: "1.6.3", date: "2026-09-07", highlights: [
+            "Publishes the selected editor's first frame before deferred layout and preview work begins.",
+            "Improves Markdown and source-file tab switching, PDF export, Find in Files ignores, and mobile line-number behavior.",
+            "Adds mobile logical-line selection and preserves Markdown source emphasis."
+        ]),
+        Release(id: "1.6.2", version: "1.6.2", date: "2026-09-05", highlights: [
+            "Adds metadata polling for external edits on network volumes and safer conflict handling.",
+            "Adds an automatic Welcome Tour preference and suppresses the tour for Finder file launches.",
+            "Improves external-document saves, purchase feedback, encoding changes, and failed-open recovery."
+        ]),
+        Release(id: "1.6.1", version: "1.6.1", date: "2026-09-04", highlights: [
+            "Adds official Emmet expansion for markup and stylesheet editing.",
+            "Restores macOS virtual-editor commands including inline completion, Vim navigation, Markdown shortcuts, drag and drop, snapshots, and whitespace inspection.",
+            "Adds bounded viewport caching and performance budgets for large documents."
+        ]),
+        Release(id: "1.6.0", version: "1.6.0", date: "2026-09-03", highlights: [
+            "Adds bounded large-file rendering and background indexing for Markdown and source documents.",
+            "Adds HEX color swatches and a source-editor color picker with format preservation.",
+            "Improves UTF-8/UTF-16 editing, caret navigation, atomic saves, accessibility context, and editor-width changes."
+        ]),
+        Release(id: "1.5.6", version: "1.5.6", date: "2026-08-29", highlights: [
+            "Adds compact, language-aware mobile toolbar presets while preserving full menu and accessibility names.",
+            "Improves Markdown list continuation, text-selection commands, and mobile formatting controls.",
+            "Keeps Settings and Help toolbar visibility aligned with configured presets."
+        ]),
         Release(id: "1.0.2", version: "1.0.2", date: "2026-07-28", highlights: [
             "Adds persistent Markdown project card previews with grid or stacked layouts.",
             "Adds saved editor layout presets for Writing, Code, Markdown, and Review.",
@@ -4667,12 +4708,34 @@ final class MacWindowDragRegionView: NSView {
 struct WelcomeTourWindowPresenter: NSViewRepresentable {
     @Binding var isPresented: Bool
     let makeContent: () -> WelcomeTourView
+    @Environment(\.colorScheme) private var colorScheme
+    @AppStorage("SettingsAppearance") private var appearance: String = "system"
+    @AppStorage("EnableTranslucentWindow") private var enableTranslucentWindow: Bool = true
+    @AppStorage("SettingsMacTranslucencyMode") private var translucencyModeRaw: String = "balanced"
+
+    private var effectiveColorScheme: ColorScheme {
+        switch appearance {
+        case "light": return .light
+        case "dark": return .dark
+        default: return colorScheme
+        }
+    }
+
+    private var windowBackgroundColor: NSColor {
+        SettingsWindowConfigurator.settingsWindowBackgroundColor(
+            translucentEnabled: enableTranslucentWindow,
+            translucencyModeRaw: translucencyModeRaw,
+            appearanceRaw: appearance,
+            effectiveColorScheme: effectiveColorScheme
+        )
+    }
 
     @MainActor
     final class Coordinator: NSObject, NSWindowDelegate {
         var parent: WelcomeTourWindowPresenter
         weak var hostWindow: NSWindow?
         var window: NSWindow?
+        var hostingController: NSHostingController<WelcomeTourView>?
         private var hostWindowObservers: [NSObjectProtocol] = []
         private weak var observedHostWindow: NSWindow?
 
@@ -4773,7 +4836,9 @@ struct WelcomeTourWindowPresenter: NSViewRepresentable {
 
         func presentIfNeeded() {
             guard window == nil else {
-                if let window {
+                if let window, let hostingController {
+                    hostingController.rootView = parent.makeContent()
+                    configureAppearance(of: window)
                     centerTourWindow(window)
                 }
                 window?.makeKeyAndOrderFront(nil)
@@ -4790,20 +4855,40 @@ struct WelcomeTourWindowPresenter: NSViewRepresentable {
             window.delegate = self
             window.isMovableByWindowBackground = false
             window.titleVisibility = .hidden
-            window.titlebarAppearsTransparent = false
             window.setContentSize(NSSize(width: 980, height: 720))
+            configureAppearance(of: window)
 
             centerTourWindow(window)
 
             self.window = window
+            self.hostingController = controller
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
+        }
+
+        private func configureAppearance(of window: NSWindow) {
+            switch parent.appearance {
+            case "light": window.appearance = NSAppearance(named: .aqua)
+            case "dark": window.appearance = NSAppearance(named: .darkAqua)
+            default: window.appearance = nil
+            }
+            window.isOpaque = !parent.enableTranslucentWindow
+            window.backgroundColor = parent.windowBackgroundColor
+            window.contentView?.wantsLayer = true
+            window.contentView?.layer?.backgroundColor = NSColor.clear.cgColor
+            window.titlebarAppearsTransparent = true
+            window.toolbarStyle = .unified
+            window.styleMask.insert(.fullSizeContentView)
+            if #available(macOS 13.0, *) {
+                window.titlebarSeparatorStyle = .none
+            }
         }
 
         func dismissIfNeeded() {
             guard let window else { return }
             window.close()
             self.window = nil
+            self.hostingController = nil
         }
 
         func windowWillClose(_ notification: Notification) {

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -379,6 +379,7 @@ struct VirtualEditorView: NSViewRepresentable {
     let indentWidth: Int
     let isSplitPaneResizeInProgress: Bool
     let preferredLayoutWidth: CGFloat?
+    let focusesEditorOnInitialWindowAttachment: Bool
     let onFontSizeChange: ((CGFloat) -> Void)?
     let onTextMutation: ((EditorTextMutation) -> Bool)?
 
@@ -392,6 +393,7 @@ struct VirtualEditorView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> VirtualEditorScrollView {
         let view = VirtualEditorScrollView()
+        view.focusesEditorOnInitialWindowAttachment = focusesEditorOnInitialWindowAttachment
         view.configure(
             document: document,
             documentID: documentID,
@@ -605,6 +607,8 @@ final class VirtualEditorScrollView: NSScrollView {
     private var isSplitPaneResizeInProgress = false
     private var viewportGeometryRetryCount = 0
     private var isViewportGeometryRetryScheduled = false
+    var focusesEditorOnInitialWindowAttachment = false
+    private var didRequestInitialEditorFocus = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -734,7 +738,12 @@ final class VirtualEditorScrollView: NSScrollView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard window != nil else { return }
+        guard let window else { return }
+
+        if focusesEditorOnInitialWindowAttachment, !didRequestInitialEditorFocus {
+            didRequestInitialEditorFocus = true
+            window.makeFirstResponder(canvas)
+        }
 
         // SwiftUI can replace the surrounding hierarchy (for example when a
         // workspace mode hides every sidebar) before the scroll view receives
@@ -1108,6 +1117,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
 
     override var isFlipped: Bool { true }
     override var acceptsFirstResponder: Bool { true }
+    override var mouseDownCanMoveWindow: Bool { false }
     override var undoManager: UndoManager? { documentUndoManager }
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
     override func isAccessibilityElement() -> Bool { true }

--- a/Neon Vision EditorTests/MobileEditorInteractionTests.swift
+++ b/Neon Vision EditorTests/MobileEditorInteractionTests.swift
@@ -99,6 +99,11 @@ final class MobileEditorInteractionTests: XCTestCase {
         }
     }
 
+    func testIOSPointerSelectionDoesNotEnableTextDragInteraction() {
+        XCTAssertFalse(EditorPointerSelectionPolicy.shouldEnableTextDragInteraction(for: .pad))
+        XCTAssertFalse(EditorPointerSelectionPolicy.shouldEnableTextDragInteraction(for: .phone))
+    }
+
     func testLogicalLineSelectionPreservesUnicodeAndIncludesLineEnding() {
         let view = EditorInputTextView()
         view.text = "😀 first\r\nsecond\n"

--- a/Neon Vision EditorTests/WindowTranslucencyTests.swift
+++ b/Neon Vision EditorTests/WindowTranslucencyTests.swift
@@ -37,6 +37,32 @@ final class WindowTranslucencyTests: XCTestCase {
         XCTAssertTrue(dragRegion.acceptsFirstMouse(for: nil))
     }
 
+    func testVirtualEditorCanvasRejectsWindowBackgroundDragging() {
+        let canvas = VirtualEditorCanvas(frame: NSRect(x: 0, y: 0, width: 480, height: 320))
+
+        XCTAssertFalse(canvas.mouseDownCanMoveWindow)
+    }
+
+    func testNewWindowEditorBecomesInitialFirstResponder() {
+        let testWindow = NSWindow(
+            contentRect: NSRect(x: 40, y: 40, width: 480, height: 320),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        testWindow.isReleasedWhenClosed = false
+        defer {
+            testWindow.orderOut(nil)
+            testWindow.close()
+        }
+
+        let editor = VirtualEditorScrollView(frame: testWindow.contentView?.bounds ?? .zero)
+        editor.focusesEditorOnInitialWindowAttachment = true
+        testWindow.contentView = editor
+
+        XCTAssertTrue(testWindow.firstResponder === editor.documentView)
+    }
+
     // Verifies that the translucency toggle updates registered editor windows without touching unrelated panels.
     func testApplyWindowTranslucencyUpdatesMacWindowFlags() {
         let defaults = UserDefaults.standard


### PR DESCRIPTION
## Summary
- prevent macOS editor text selection from moving the window while preserving top-bar dragging
- focus new-window editors immediately and preserve native window movement regions
- make the Welcome Tour follow Light, Dark, and System appearance settings
- show the current release highlights in What's New and retain major historical entries in the in-app changelog
- restore pointer text selection on iPhone, iPad, and visionOS by disabling conflicting text-drag interaction

## Validation
- iPhone simulator: 14/14 MobileEditorInteractionTests passed
- iPad simulator: 14/14 MobileEditorInteractionTests passed
- visionOS simulator build succeeded
- macOS WindowTranslucencyTests: 15/15 passed
- git diff --check passed

## Target
- develop

## Summary by Sourcery

Improve editor interaction behavior across Apple platforms and refresh the release tour and changelog for the current release.

New Features:
- Update the Welcome Tour and in-app changelog with the current release highlights and retained historical release entries.

Bug Fixes:
- Restore reliable pointer text selection across iPhone, iPad, and visionOS by preventing text-drag interactions from taking over editor drags.
- Prevent macOS editor text interactions from moving the window while preserving native window dragging elsewhere.
- Focus editors automatically when attaching a new blank-document window.

Enhancements:
- Make the Welcome Tour honor Light, Dark, and System appearance settings across its content and macOS window.

Tests:
- Add mobile pointer-selection and macOS window/editor interaction coverage.