### PR TITLE
Fix window drag selector and iOS App Store export

### DIFF
--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -1115,6 +1115,10 @@ struct ContentView: View {
         }
     }
 #if os(macOS)
+@objc private protocol MacWindowDragPerforming {
+    func performWindowDragWithEvent(_ event: NSEvent)
+}
+
     enum MacEditorSurfacePolicy {
         /// Allows empty areas of the native titlebar/toolbar to initiate a window drag.
         /// AppKit still routes clicks on toolbar controls to those controls.
@@ -1127,9 +1131,9 @@ struct ContentView: View {
                 guard let window,
                       event.window === window,
                       Self.isBlankTitlebarClick(event, in: window) else { return event }
-                // The Swift 6 SDK does not surface NSWindow's ObjC selector,
-                // but the AppKit entry point remains available at runtime.
-                window.perform(Selector(("performWindowDragWithEvent:")), with: event)
+                // The Swift 6 SDK does not expose this AppKit member on
+                // NSWindow, but its Objective-C entry point remains available.
+                window.perform(#selector(MacWindowDragPerforming.performWindowDragWithEvent(_:)), with: event)
                 return nil
             }
             dragMonitors[window.windowNumber] = monitor

--- a/release/ExportOptions-TestFlight.plist
+++ b/release/ExportOptions-TestFlight.plist
@@ -17,7 +17,7 @@
 	<key>stripSwiftSymbols</key>
 	<true/>
 	<key>uploadSymbols</key>
-	<true/>
+	<false/>
 	<key>compileBitcode</key>
 	<false/>
 </dict>

--- a/scripts/ci/xcode_cloud_release_preflight.sh
+++ b/scripts/ci/xcode_cloud_release_preflight.sh
@@ -40,7 +40,7 @@ if ! source scripts/ci/select_xcode17.sh; then
   fail "A compatible public Xcode 17+ installation that can open this project is not available."
 fi
 
-active_developer_dir="$DEVELOPER_DIR"
+active_developer_dir="${DEVELOPER_DIR:-$(xcode-select -p 2>/dev/null || true)}"
 if [[ "$active_developer_dir" == *Xcode-beta.app/* ]]; then
   echo "warning: allowing beta toolchain for local metadata checks only; do not upload this archive to App Store Connect." >&2
 fi


### PR DESCRIPTION
## Summary
- use #selector for macOS window dragging
- avoid Tahoe openrsync packaging failure by disabling symbol upload in TestFlight export options
- make Xcode Cloud preflight tolerate unset DEVELOPER_DIR

## Verification
- iOS archive succeeded
- export with symbol upload disabled produced an IPA
- Xcode Cloud release preflight passed with elevated Xcode access

## Summary by Sourcery

Fix macOS window dragging and improve the reliability of iOS TestFlight exports and Xcode Cloud release checks.

Bug Fixes:
- Fix macOS blank-titlebar window dragging with a selector-based AppKit invocation.
- Prevent TestFlight exports from failing during symbol packaging by disabling symbol uploads.
- Allow Xcode Cloud release preflight checks to work when DEVELOPER_DIR is unset.

CI:
- Make Xcode Cloud release preflight fall back to the selected system developer directory when DEVELOPER_DIR is unavailable.

Deployment:
- Disable dSYM symbol uploads in TestFlight export configuration to avoid App Store export packaging failures.