### PR TITLE
Prepare v1.7.1 welcome tour and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 - Aligns tab, TOC sidebar, project sidebar, line-number, and editor backgrounds in opaque and translucent modes.
 - Prevents tab borders from clipping, flashing, or disappearing during hover and theme transitions.
 - Keeps Settings content sized to the selected tab and opens the Settings window in a stable editor-relative position.
+- Restores drag-to-move behavior across the macOS top bar without applying window-drag handling to the editor surface.
+- Keeps cursor-based text selection available on iPhone, iPad, and visionOS.
+- Makes the Welcome Tour follow the configured Light, Dark, or System appearance and carries the major release highlights forward.
+- Prevents iOS App Store packaging from failing when the export environment rejects Xcode's symbol-copy flag.
 
 ### Breaking changes
 

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -2775,15 +2775,15 @@ struct WelcomeTourView: View {
 
     private let pages: [TourPage] = [
         TourPage(
-            title: "What’s New in v1.7.0",
-            subtitle: "Major fixes and improvements in the current release.",
+            title: "What’s New in v1.7.1",
+            subtitle: "Major fixes and improvements from the 1.7.0 and 1.7.1 releases.",
             bullets: [
                 "Native Tabs: Replaces the remaining legacy tab-bar paths with native platform tab implementations.",
                 "Theme Consistency: Keeps tabs, sidebars, editor surfaces, and Settings consistent across Light, Dark, and System modes.",
                 "Responsive Workflows: Makes tab switching and Settings navigation feel immediate while preserving native controls.",
                 "Stable Window Surfaces: Aligns tab, TOC sidebar, project sidebar, line-number, and editor backgrounds in opaque and translucent modes.",
                 "Reliable Tab Chrome: Prevents tab borders from clipping, flashing, or disappearing during hover and theme transitions.",
-                "Settings Polish: Keeps Settings content sized to the selected tab and opens the window in a stable editor-relative position."
+                "1.7.1 Fixes: Restores top-bar window dragging on supported macOS versions, keeps iPhone/iPad/visionOS text selection working, applies the selected Welcome Tour theme, expands the release highlights, and fixes App Store export packaging."
             ],
             iconName: "sparkles.rectangle.stack",
             colors: [Color(red: 0.40, green: 0.28, blue: 0.90), Color(red: 0.96, green: 0.46, blue: 0.55)],

--- a/scripts/prepare_release_docs.py
+++ b/scripts/prepare_release_docs.py
@@ -588,6 +588,7 @@ def rebuild_changelog_page(page: str, changelog: str, current_tag: str) -> str:
 
 LOCALIZED_TIMELINE_COPY = {
     "de": {
+        "v1.7.1": ("Stabilere Fenster, Auswahl und App-Store-Builds", "Behebt das Verschieben von Fenstern, die Textauswahl auf iPhone und iPad, die Darstellung der Willkommenstour und die iOS-App-Store-Paketierung.", ["Fenster", "Auswahl", "App Store"]),
         "v1.7.0": ("Native Tabs und konsistente Fensterdarstellung", "Hält Tabs, Seitenleisten, Editorflächen und Einstellungen über macOS, iOS und iPadOS hinweg konsistent und stabil.", ["Tabs", "Darstellung", "Seitenleisten"]),
         "v1.6.4": ("Stabiles Tippen und zuverlässiges Fensterziehen", "Hält den macOS-Editor beim Tippen stabil und macht leere Bereiche der nativen Symbolleiste verschiebbar, ohne ihre Aktionen zu blockieren.", ["Editor", "Fenster", "Symbolleiste"]),
         "v1.6.3": ("Sofortiger Tabwechsel und reibungsloser Editor", "Beschleunigt den Wechsel zwischen Markdown- und Quelldateien und verschiebt Vorschau- sowie Layoutarbeit aus dem ersten Anzeigeframe.", ["Editor", "Leistung", "Tabs"]),
@@ -611,6 +612,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor und Snapshots werden verlässlicher", "Verbessert Auswahl, Tastaturnavigation und Themes im macOS-Editor und erweitert den Code-Snapshot-Export.", ["Editor", "Themes", "Snapshots"]),
     },
     "da": {
+        "v1.7.1": ("Mere stabile vinduer, markering og App Store-builds", "Retter flytning af vinduer, tekstmarkering på iPhone og iPad, velkomstturens udseende og iOS App Store-paketering.", ["Vinduer", "Markering", "App Store"]),
         "v1.7.0": ("Native faner og ensartet vinduesvisning", "Holder faner, sidepaneler, editorflader og indstillinger ensartede og stabile på macOS, iOS og iPadOS.", ["Faner", "Visning", "Sidepaneler"]),
         "v1.6.4": ("Stabil indtastning og pålidelig vinduesflytning", "Holder macOS-editoren stabil under indtastning og gør tomme områder i den native værktøjslinje flytbare uden at blokere dens handlinger.", ["Editor", "Vindue", "Værktøjslinje"]),
         "v1.6.3": ("Øjeblikkeligt faneskift og mere flydende editor", "Gør skift mellem Markdown- og kildefiler hurtigere og flytter forhåndsvisnings- og layoutarbejde efter den første visning.", ["Editor", "Ydeevne", "Faner"]),
@@ -634,6 +636,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor og snapshots bliver mere pålidelige", "Forbedrer markering, tastaturnavigation og temaer i macOS-editoren og udvider eksporten af kodesnapshots.", ["Editor", "Temaer", "Snapshots"]),
     },
     "fr": {
+        "v1.7.1": ("Fenêtres, sélection et builds App Store plus stables", "Corrige le déplacement des fenêtres, la sélection de texte sur iPhone et iPad, l’apparence de l’accueil et le paquet iOS pour l’App Store.", ["Fenêtres", "Sélection", "App Store"]),
         "v1.7.0": ("Onglets natifs et apparence cohérente", "Garde les onglets, barres latérales, surfaces d’édition et réglages cohérents et stables sur macOS, iOS et iPadOS.", ["Onglets", "Apparence", "Barres latérales"]),
         "v1.6.4": ("Saisie stable et déplacement fiable des fenêtres", "Stabilise l’éditeur macOS pendant la saisie et rend les espaces vides de la barre d’outils déplaçables sans bloquer ses actions.", ["Éditeur", "Fenêtre", "Barre d’outils"]),
         "v1.6.3": ("Changement d’onglet instantané et éditeur plus fluide", "Accélère le passage entre fichiers Markdown et source et reporte le travail d’aperçu et de mise en page après le premier affichage.", ["Éditeur", "Performances", "Onglets"]),
@@ -657,6 +660,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Éditeur et instantanés plus fiables", "Améliore la sélection, la navigation au clavier et les thèmes dans l’éditeur macOS, tout en enrichissant l’export d’instantanés de code.", ["Éditeur", "Thèmes", "Instantanés"]),
     },
     "es": {
+        "v1.7.1": ("Ventanas, selección y builds del App Store más estables", "Corrige el movimiento de ventanas, la selección de texto en iPhone y iPad, la apariencia de la bienvenida y el empaquetado iOS para el App Store.", ["Ventanas", "Selección", "App Store"]),
         "v1.7.0": ("Pestañas nativas y apariencia coherente", "Mantiene coherentes y estables las pestañas, barras laterales, superficies del editor y Ajustes en macOS, iOS y iPadOS.", ["Pestañas", "Apariencia", "Barras laterales"]),
         "v1.6.4": ("Escritura estable y movimiento fiable de ventanas", "Estabiliza el editor de macOS al escribir y permite mover la ventana desde los espacios vacíos de la barra nativa sin bloquear sus acciones.", ["Editor", "Ventana", "Barra"]),
         "v1.6.3": ("Cambio de pestaña instantáneo y editor más fluido", "Acelera el cambio entre archivos Markdown y de código y pospone el trabajo de vista previa y diseño tras el primer dibujo.", ["Editor", "Rendimiento", "Pestañas"]),
@@ -680,6 +684,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor y capturas más fiables", "Mejora la selección, la navegación por teclado y los temas del editor de macOS, y amplía la exportación de capturas de código.", ["Editor", "Temas", "Capturas"]),
     },
     "ja": {
+        "v1.7.1": ("ウインドウ、選択、App Store ビルドを安定化", "ウインドウ移動、iPhone と iPad のテキスト選択、ウェルカムツアーの外観、iOS App Store パッケージを修正します。", ["ウインドウ", "選択", "App Store"]),
         "v1.7.0": ("ネイティブタブと一貫したウインドウ表示", "macOS、iOS、iPadOS でタブ、サイドバー、エディタ面、設定の表示を一貫させ、安定させます。", ["タブ", "表示", "サイドバー"]),
         "v1.6.4": ("安定した入力と確実なウインドウ移動", "macOS エディタの入力中のちらつきを抑え、ネイティブツールバーの空白部分から操作を妨げずにウインドウを移動できます。", ["エディタ", "ウインドウ", "ツールバー"]),
         "v1.6.3": ("瞬時のタブ切り替えとより滑らかなエディタ", "Markdown とソースファイルの切り替えを高速化し、プレビューとレイアウト処理を初回表示後に行います。", ["エディタ", "パフォーマンス", "タブ"]),
@@ -703,6 +708,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("エディタとスナップショットをさらに信頼性向上", "macOS エディタの選択、キーボード操作、テーマを改善し、コードスナップショットの書き出しを拡充します。", ["エディタ", "テーマ", "スナップショット"]),
     },
     "zh-Hans": {
+        "v1.7.1": ("更稳定的窗口、文本选择与 App Store 构建", "修复窗口移动、iPhone 和 iPad 文本选择、欢迎导览外观以及 iOS App Store 打包问题。", ["窗口", "选择", "App Store"]),
         "v1.7.0": ("原生标签页与一致的窗口外观", "在 macOS、iOS 和 iPadOS 上保持标签页、侧边栏、编辑器表面和设置的一致性与稳定性。", ["标签页", "外观", "侧边栏"]),
         "v1.6.4": ("稳定输入与可靠的窗口拖动", "让 macOS 编辑器输入时保持稳定，并可从原生工具栏的空白区域移动窗口，同时不影响工具栏操作。", ["编辑器", "窗口", "工具栏"]),
         "v1.6.3": ("即时标签页切换与更流畅的编辑器", "加快 Markdown 与源文件之间的切换，并将预览和布局工作延后到首帧显示之后。", ["编辑器", "性能", "标签页"]),


### PR DESCRIPTION
## Summary
- carry five major v1.7.0 Welcome Tour cards into the v1.7.1 release page
- consolidate all v1.7.1 fixes into one sixth card
- add v1.7.1 changelog fixes and localized timeline entries

## Verification
- `bash scripts/release_all.sh v1.7.1 --dry-run` passed
- `python3 scripts/ci/test_release_workflow.py` passed (31 tests)
- release rehearsal confirms exactly six Welcome Tour cards

The authenticated App Store Connect Cloud build-number preflight remains required before publication.

## Summary by Sourcery

Prepare the v1.7.1 Welcome Tour and release documentation for publication.

New Features:
- Update the Welcome Tour for v1.7.1 with the major v1.7.0 highlights plus a consolidated card for the latest fixes.

Bug Fixes:
- Document fixes for macOS window dragging, cross-platform text selection, appearance-aware Welcome Tour styling, and iOS App Store packaging.

Documentation:
- Add v1.7.1 changelog content and localized release timeline entries across supported languages.