### PR TITLE
Harden release workflow self-healing

### DIFF
--- a/.github/workflows/post-release-documentation-sync.yml
+++ b/.github/workflows/post-release-documentation-sync.yml
@@ -205,10 +205,29 @@ jobs:
             exit 1
           fi
 
-          # Do not merge immediately after opening the PR.  The pre-release
-          # workflow may still be queued; deleting the branch while that run
-          # is being created produces a failed, job-less check and leaves the
-          # documentation repair looking broken even when the patch is valid.
+          # Do not merge immediately after opening the PR. The pre-release
+          # workflow may still be queued, and gh pr checks reports an empty
+          # result during that short registration window. Treat that state as
+          # startup delay; only fail once checks exist and one actually fails.
+          checks_ready=false
+          checks_timeout_seconds=600
+          checks_interval_seconds=15
+          checks_elapsed=0
+          while (( checks_elapsed <= checks_timeout_seconds )); do
+            check_count="$(gh pr checks "${docs_pr}" --repo "${GITHUB_REPOSITORY}" \
+              --json name --jq 'length' 2>/dev/null || true)"
+            if [[ "$check_count" =~ ^[1-9][0-9]*$ ]]; then
+              checks_ready=true
+              break
+            fi
+            echo "No PR checks reported yet for ${docs_pr}; waiting ${checks_interval_seconds}s for registration..."
+            sleep "$checks_interval_seconds"
+            checks_elapsed=$((checks_elapsed + checks_interval_seconds))
+          done
+          if [[ "$checks_ready" != true ]]; then
+            echo "Timed out waiting for checks to register on documentation PR ${docs_pr}." >&2
+            exit 1
+          fi
           if ! gh pr checks "${docs_pr}" --repo "${GITHUB_REPOSITORY}" --watch --fail-fast --interval 15; then
             echo "Documentation PR checks failed; leaving ${docs_pr} open for inspection." >&2
             exit 1

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -169,16 +169,24 @@ class ReleaseWorkflowTests(unittest.TestCase):
 
     def test_dispatch_pins_sha_and_documentation_writers_queue(self):
         hosted = (ROOT / ".github/workflows/release-github-only.yml").read_text()
+        release_all = (ROOT / "scripts/release_all.sh").read_text()
         checkout = hosted.split("- name: Checkout release source", 1)[1].split("- name: Validate release docs", 1)[0]
         self.assertNotIn("--depth=1", checkout)
         self.assertIn('merge-base --is-ancestor "$SOURCE_SHA" "$MAIN_SHA"', checkout)
-        self.assertIn('-f ref="$RELEASE_SHA"', (ROOT / "scripts/release_all.sh").read_text())
-        self.assertNotIn('-f ref=main', (ROOT / "scripts/release_all.sh").read_text())
+        self.assertIn('-f ref="$RELEASE_SHA"', release_all)
+        self.assertNotIn('-f ref=main', release_all)
+        self.assertIn('--input - <<EOF', release_all)
+        self.assertNotIn('-F "environment_ids[]=', release_all)
+        self.assertIn("Reusing active ${WORKFLOW_NAME} run", release_all)
         for name in ("post-release-documentation-sync", "sync-readme-appstore-versions", "update-download-metrics"):
             workflow = (ROOT / f".github/workflows/{name}.yml").read_text()
             self.assertIn("group: public-documentation-writer", workflow)
             self.assertIn("queue: max", workflow)
             self.assertNotIn("run: sleep", workflow)
+        docs_sync = (ROOT / ".github/workflows/post-release-documentation-sync.yml").read_text()
+        self.assertIn("checks_ready=false", docs_sync)
+        self.assertIn("--json name --jq 'length'", docs_sync)
+        self.assertIn("Timed out waiting for checks to register", docs_sync)
 
     @unittest.skipUnless(shutil.which("ssh-keygen"), "SSH signing executable unavailable")
     def test_real_local_worktree_signing_resume_and_source_preservation(self):

--- a/scripts/release_all.sh
+++ b/scripts/release_all.sh
@@ -560,9 +560,9 @@ approve_pending_release_environment() {
     [[ -n "$environment_id" ]] || continue
     echo "Approving protected release environment ${environment_id} for workflow run ${run_id}..."
     gh_retry gh api -X POST "repos/${REPO_SLUG}/actions/runs/${run_id}/pending_deployments" \
-      -F "environment_ids[]=${environment_id}" \
-      -f state=approved \
-      -f comment="Release ${TAG} approved after local release validation."
+      --input - <<EOF
+{"environment_ids":[${environment_id}],"state":"approved","comment":"Release environment approved after local release validation."}
+EOF
   done <<< "$environment_ids"
 }
 
@@ -879,42 +879,55 @@ if [[ "$TRIGGER_NOTARIZED" -eq 1 ]] && step_enabled notarize; then
     WORKFLOW_DISPATCH_CMD=(gh workflow run "$WORKFLOW_NAME" --ref main -f tag="$TAG" -f ref="$RELEASE_SHA")
   fi
 
-  echo "Dispatching ${WORKFLOW_NAME} for ${TAG}..."
-  DISPATCHED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-  DISPATCH_UNCERTAIN=0
-  if ! "${WORKFLOW_DISPATCH_CMD[@]}"; then
-    DISPATCH_UNCERTAIN=1
-    echo "Workflow dispatch response failed; checking for a created run before retrying." >&2
+  # Reuse an active same-tag run instead of creating a duplicate that will sit
+  # behind the release concurrency group. This makes reruns idempotent when a
+  # terminal command is interrupted while GitHub continues the workflow.
+  RUN_ID="$(
+    gh_retry gh run list \
+      --workflow "$WORKFLOW_NAME" \
+      --limit 30 \
+      --json databaseId,displayTitle,status,createdAt \
+      --jq "[.[] | select((.displayTitle | contains(\"${TAG}\")) and .status != \"completed\")][0].databaseId // empty" || true
+  )"
+  if [[ -n "$RUN_ID" ]]; then
+    echo "Reusing active ${WORKFLOW_NAME} run ${RUN_ID} for ${TAG}."
   else
-    echo "Workflow dispatch request accepted."
-  fi
-
-  echo "Waiting for ${WORKFLOW_NAME} run..."
-  RUN_ID=""
-  for dispatch_attempt in 1 2; do
-    if [[ "$dispatch_attempt" -eq 2 ]]; then
-      if [[ "$DISPATCH_UNCERTAIN" -eq 0 ]]; then
-        break
-      fi
-      echo "No run appeared after the failed response; retrying the dispatch once."
-      "${WORKFLOW_DISPATCH_CMD[@]}"
+    echo "Dispatching ${WORKFLOW_NAME} for ${TAG}..."
+    DISPATCHED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    DISPATCH_UNCERTAIN=0
+    if ! "${WORKFLOW_DISPATCH_CMD[@]}"; then
+      DISPATCH_UNCERTAIN=1
+      echo "Workflow dispatch response failed; checking for a created run before retrying." >&2
+    else
+      echo "Workflow dispatch request accepted."
     fi
 
-    for _ in {1..20}; do
-      sleep 6
-      RUN_ID="$(
-        gh_retry gh run list \
-          --workflow "$WORKFLOW_NAME" \
-          --limit 30 \
-          --json databaseId,displayTitle,createdAt \
-          --jq "[.[] | select((.displayTitle | contains(\"${TAG}\")) and .createdAt >= \"${DISPATCHED_AT}\")][0].databaseId // empty" || true
-      )"
-      if [[ -n "$RUN_ID" ]]; then
-        break
+    echo "Waiting for ${WORKFLOW_NAME} run..."
+    for dispatch_attempt in 1 2; do
+      if [[ "$dispatch_attempt" -eq 2 ]]; then
+        if [[ "$DISPATCH_UNCERTAIN" -eq 0 ]]; then
+          break
+        fi
+        echo "No run appeared after the failed response; retrying the dispatch once."
+        "${WORKFLOW_DISPATCH_CMD[@]}"
       fi
+
+      for _ in {1..20}; do
+        sleep 6
+        RUN_ID="$(
+          gh_retry gh run list \
+            --workflow "$WORKFLOW_NAME" \
+            --limit 30 \
+            --json databaseId,displayTitle,createdAt \
+            --jq "[.[] | select((.displayTitle | contains(\"${TAG}\")) and .createdAt >= \"${DISPATCHED_AT}\")][0].databaseId // empty" || true
+        )"
+        if [[ -n "$RUN_ID" ]]; then
+          break
+        fi
+      done
+      [[ -n "$RUN_ID" ]] && break
     done
-    [[ -n "$RUN_ID" ]] && break
-  done
+  fi
   if [[ -z "$RUN_ID" ]]; then
     echo "Could not find workflow run for ${TAG}." >&2
     exit 1


### PR DESCRIPTION
Fixes the post-release documentation self-heal race that treated an empty check list as a failure immediately after creating the repair PR.

Also hardens release orchestration by using the documented pending-deployment JSON payload and reusing active same-tag runs.

Validation:
- bash -n scripts/release_all.sh
- python3 scripts/ci/test_release_workflow.py (31 tests)
- git diff --check

## Summary by Sourcery

Harden release workflow recovery and self-healing so transient GitHub Actions states do not create false failures or duplicate runs.

Bug Fixes:
- Prevent post-release documentation repair PRs from being marked failed while checks are still registering.
- Use the documented pending-deployment approval payload to improve release environment approvals.
- Reuse active same-tag workflow runs to avoid duplicate release executions after interrupted dispatches.

Tests:
- Extend release workflow validation to cover pending-deployment payloads, active run reuse, and delayed documentation check registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Improved release reliability by reusing an already active run for the same release instead of starting a duplicate.
  - Added a readiness window for documentation checks, allowing time for checks to appear before continuing.
  - Improved handling of environment approvals and dispatch retries to reduce failed or repeated release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->