### PR TITLE
Prevent titlebar drags from extending editor selection

### DIFF
--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -868,6 +868,10 @@ struct VirtualEditorAccessibilityContext: Equatable {
 
 @MainActor
 enum VirtualEditorSelectionPolicy {
+    static func shouldContinueDrag(at point: NSPoint, in bounds: NSRect) -> Bool {
+        bounds.contains(point)
+    }
+
     static func lineRange(in text: String, at utf16Offset: Int) -> NSRange {
         let source = text as NSString
         guard source.length > 0 else { return NSRange(location: 0, length: 0) }
@@ -2026,7 +2030,16 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
 
     override func mouseDragged(with event: NSEvent) {
         guard let selectionAnchor else { return }
-        let caret = documentOffset(at: convert(event.locationInWindow, from: nil))
+        let point = convert(event.locationInWindow, from: nil)
+        guard VirtualEditorSelectionPolicy.shouldContinueDrag(at: point, in: bounds) else {
+            absoluteCaret = selectionAnchor
+            selection = NSRange(location: selectionAnchor, length: 0)
+            self.selectionAnchor = nil
+            publishCaret()
+            needsDisplay = true
+            return
+        }
+        let caret = documentOffset(at: point)
         absoluteCaret = caret
         selection = NSRange(location: min(selectionAnchor, caret), length: abs(selectionAnchor - caret))
         scheduleDragPublication()

--- a/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
+++ b/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
@@ -25,6 +25,19 @@ final class VirtualEditorLayoutTests: XCTestCase {
         )
     }
 
+    func testSelectionDragStopsWhenPointerLeavesEditorCanvas() {
+        let bounds = NSRect(x: 0, y: 0, width: 800, height: 600)
+
+        XCTAssertTrue(VirtualEditorSelectionPolicy.shouldContinueDrag(
+            at: NSPoint(x: 400, y: 300),
+            in: bounds
+        ))
+        XCTAssertFalse(VirtualEditorSelectionPolicy.shouldContinueDrag(
+            at: NSPoint(x: 400, y: -1),
+            in: bounds
+        ))
+    }
+
     func testFindReplaceEscapePolicyDismissesOnlyEscape() {
         let escape = try! XCTUnwrap(NSEvent.keyEvent(
             with: .keyDown,


### PR DESCRIPTION
Fixes macOS editor text selection extending when a drag leaves the editor and enters the title bar. The editor now stops selection tracking outside its canvas and restores the caret at the original anchor.

Validation:
- Focused VirtualEditorLayoutTests passed
- git diff --check

## Summary by Sourcery

Prevent editor selection drags from extending into the title bar by ending tracking outside the canvas.

Bug Fixes:
- Stop macOS editor text selection from continuing when a drag leaves the editor canvas, restoring the caret to the original selection anchor.

Tests:
- Add coverage for stopping selection drags when the pointer leaves the editor canvas.