### PR TITLE
fix: refine iOS editor chrome

### DIFF
--- a/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
+++ b/Neon Vision Editor/UI/ContentView+MarkdownFormatting.swift
@@ -87,9 +87,10 @@ enum MarkdownFormattingChromePolicy {
     nonisolated static func shouldReserveMobileFormattingRow(
         isPhone: Bool,
         shouldShow: Bool,
-        isCollapsed: Bool
+        isCollapsed: Bool,
+        keepCollapsedBelowTabs: Bool = false
     ) -> Bool {
-        isPhone && shouldShow && !isCollapsed
+        isPhone && shouldShow && (!isCollapsed || keepCollapsedBelowTabs)
     }
 
     nonisolated static func shouldRenderInEditorStack(
@@ -141,6 +142,7 @@ extension ContentView {
         UIDevice.current.userInterfaceIdiom == .phone
             && shouldPinFloatingStatusToTop
             && shouldShowMarkdownFormattingControls
+            && !shouldPlaceMarkdownFormattingBelowTabs
     }
 
     var iPhoneMarkdownFormattingStatusControl: some View {
@@ -187,7 +189,8 @@ extension ContentView {
         MarkdownFormattingChromePolicy.shouldReserveMobileFormattingRow(
             isPhone: UIDevice.current.userInterfaceIdiom == .phone,
             shouldShow: shouldShowMarkdownFormattingControls,
-            isCollapsed: markdownFormattingToolbarCollapsed
+            isCollapsed: markdownFormattingToolbarCollapsed,
+            keepCollapsedBelowTabs: shouldPinFloatingStatusToTop
         )
         #elseif os(visionOS)
         return shouldShowMarkdownFormattingControls

--- a/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
+++ b/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
@@ -42,15 +42,24 @@ extension ContentView {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 6)
         } else {
-            iPhoneUnifiedToolbarRow
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
+            GlassSurface(
+                enabled: shouldUseLiquidGlass,
+                material: primaryGlassMaterial,
+                fallbackColor: toolbarFallbackColor,
+                shape: .capsule,
+                chromeStyle: .single
+            ) {
+                iPhoneUnifiedToolbarRow
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
         }
     }
 
     var iOSUnifiedDocumentChromeHost: some View {
         VStack(spacing: 0) {
             tabBarView
+                .padding(.bottom, 8)
             if shouldPlaceMarkdownFormattingBelowTabs {
                 iPhoneMarkdownFormattingTopChrome
             }
@@ -85,6 +94,7 @@ extension ContentView {
             // available width so its action row can scroll horizontally.
             .fixedSize(horizontal: markdownFormattingToolbarCollapsed, vertical: false)
             .frame(maxWidth: .infinity, alignment: .trailing)
+            .padding(.top, 12)
             .tint(iOSToolbarForegroundColor)
     }
 
@@ -757,12 +767,12 @@ extension ContentView {
             .frame(height: 41)
 #elseif os(iOS)
             GlassSurface(
-                // Window translucency must keep the tab strip on a material
-                // surface even when the optional Liquid Glass toolbar style is
-                // disabled; otherwise the fallback color paints an opaque band.
-                enabled: shouldUseLiquidGlass || enableTranslucentWindow,
+                // Keep the tab strip tied to the editor theme. Window
+                // translucency should not replace that theme surface with a
+                // separate material band.
+                enabled: false,
                 material: primaryGlassMaterial,
-                fallbackColor: toolbarFallbackColor,
+                fallbackColor: iOSNonTranslucentSurfaceColor,
                 shape: .rounded(18),
                 chromeStyle: .single
             ) {
@@ -807,10 +817,9 @@ extension ContentView {
 #if os(macOS)
         .background(macToolbarBackgroundStyle)
 #elseif os(iOS)
-        // Keep the full-width strip on the same surface as the project bar
-        // and editor. The inner GlassSurface supplies the rounded chrome;
-        // this outer surface prevents a mismatched band around it.
-        .background(editorSurfaceBackgroundStyle)
+        // Keep the full-width strip on the same theme surface as the editor;
+        // this remains stable when window translucency is toggled.
+        .background(iOSNonTranslucentSurfaceColor)
 #else
         .background(
             enableTranslucentWindow

--- a/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
@@ -49,6 +49,7 @@ final class MobileNativeFileTabBarView: UIView {
     private let tabsView = UIView()
     private let addButton = UIButton(type: .system)
     private let separator = UIView()
+    private let rightEdgeFadeMask = CAGradientLayer()
     private var tabViewsByID: [UUID: MobileNativeFileTabItemView] = [:]
     private(set) var orderedTabIDs: [UUID] = []
     private(set) var selectedTabID: UUID?
@@ -67,6 +68,15 @@ final class MobileNativeFileTabBarView: UIView {
         scrollView.isDirectionalLockEnabled = true
         scrollView.contentInsetAdjustmentBehavior = .never
         scrollView.addSubview(tabsView)
+        rightEdgeFadeMask.colors = [
+            UIColor.white.cgColor,
+            UIColor.white.cgColor,
+            UIColor.clear.cgColor
+        ]
+        rightEdgeFadeMask.locations = [0, 0.82, 1]
+        rightEdgeFadeMask.startPoint = CGPoint(x: 0, y: 0.5)
+        rightEdgeFadeMask.endPoint = CGPoint(x: 1, y: 0.5)
+        scrollView.layer.mask = rightEdgeFadeMask
         addSubview(scrollView)
 
         var configuration = UIButton.Configuration.plain()
@@ -106,6 +116,7 @@ final class MobileNativeFileTabBarView: UIView {
             width: max(0, buttonX - spacing - leadingInset),
             height: max(0, bounds.height - separatorHeight)
         )
+        rightEdgeFadeMask.frame = scrollView.bounds
         layoutTabs(viewportWidth: scrollView.bounds.width)
     }
 
@@ -162,8 +173,8 @@ final class MobileNativeFileTabBarView: UIView {
 
         let spacing: CGFloat = 5
         let totalSpacing = spacing * CGFloat(max(0, count - 1))
-        let maximumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 220 : 188
-        let minimumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 136 : 128
+        let maximumWidth: CGFloat = 220
+        let minimumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 136 : 148
         let fittedWidth = (viewportWidth - totalSpacing) / CGFloat(count)
         let tabWidth = min(maximumWidth, max(minimumWidth, fittedWidth))
         let contentWidth = max(viewportWidth, tabWidth * CGFloat(count) + totalSpacing)
@@ -350,7 +361,10 @@ private final class MobileNativeFileTabItemView: UIControl, UIDragInteractionDel
         isCurrentSelection = isSelected
         titleLabel.text = snapshot.title
         titleLabel.font = .systemFont(ofSize: 12, weight: isSelected ? .semibold : .regular)
-        titleLabel.textColor = isSelected ? .label : .secondaryLabel
+        // Secondary-label gray is too faint over the light editor surface.
+        // Keep inactive tabs subordinate without sacrificing filename
+        // readability in light mode.
+        titleLabel.textColor = isSelected ? .label : UIColor.label.withAlphaComponent(0.72)
         remoteLabel.isHidden = !snapshot.isRemote
         lockImage.isHidden = !snapshot.isReadOnly
         dirtyIndicator.isHidden = !snapshot.isDirty

--- a/Neon Vision EditorTests/ContentViewLayoutTests.swift
+++ b/Neon Vision EditorTests/ContentViewLayoutTests.swift
@@ -134,6 +134,14 @@ final class ContentViewLayoutTests: XCTestCase {
             MarkdownFormattingChromePolicy.shouldReserveMobileFormattingRow(
                 isPhone: true,
                 shouldShow: true,
+                isCollapsed: true,
+                keepCollapsedBelowTabs: true
+            )
+        )
+        XCTAssertTrue(
+            MarkdownFormattingChromePolicy.shouldReserveMobileFormattingRow(
+                isPhone: true,
+                shouldShow: true,
                 isCollapsed: false
             )
         )

--- a/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
@@ -122,6 +122,19 @@ final class MobileNativeFileTabBarTests: XCTestCase {
         XCTAssertGreaterThan(try XCTUnwrap(view.tabFrameForTesting(lastID)).minX, view.scrollViewFrameForTesting.width)
     }
 
+    func testPhoneTabsUseAReadableDefaultWidthForLongFilenames() throws {
+        let ids = (0..<3).map { _ in UUID() }
+        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 390, height: 42))
+        view.apply(
+            tabs: ids.map { snapshot(id: $0, title: "architecture.md") },
+            selectedTabID: ids.first,
+        )
+        view.layoutIfNeeded()
+
+        let expectedMinimumWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 136 : 148
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(view.tabFrameForTesting(ids[1])).width, expectedMinimumWidth)
+    }
+
     func testLargeSnapshotUpdateReusesViewsWithinInteractiveBudget() {
         let ids = (0..<250).map { _ in UUID() }
         let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 1_024, height: 42))


### PR DESCRIPTION
## Summary
- keep the iOS tab bar on the active editor theme surface
- restore liquid-glass toolbar treatment and add spacing around mobile chrome
- keep Markdown controls below the tab bar during keyboard presentation
- widen tabs, improve light-mode filename contrast, and fade the right edge into the add-tab button

## Verification
- focused iOS Simulator tests passed for ContentViewLayoutTests and MobileNativeFileTabBarTests
- git diff --check passed

This is the clean main-based equivalent of PR #409.

## Summary by Sourcery

Refine iOS editor chrome so tab, toolbar, and Markdown controls remain visually consistent and usable across themes and keyboard states.

New Features:
- Improve iOS mobile tab presentation with wider readable tabs and a subtle fade toward the add-tab action.

Bug Fixes:
- Keep iOS tab and editor chrome on the active theme surface instead of introducing mismatched translucent bands.
- Maintain the Markdown formatting row below the tab bar when the keyboard is presented.
- Improve inactive filename contrast in light mode.

Enhancements:
- Restore liquid-glass treatment for the mobile toolbar and add spacing around the tab and formatting chrome.

Tests:
- Extend layout and mobile tab bar coverage for collapsed formatting-row placement and phone tab sizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved mobile editor chrome with clearer spacing around tabs and formatting controls.
  * Added a subtle fade at the edge of scrollable tabs to indicate additional tabs.
  * Increased minimum tab widths on phones for improved readability of longer filenames.
  * Refined inactive tab contrast and updated toolbar and tab styling for a more consistent appearance.
  * Preserved formatting controls below the tab bar when the status area is pinned at the top.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->