### PR TITLE
Fix mobile toolbar theme and right-edge clipping

### DIFF
--- a/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
+++ b/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
@@ -43,9 +43,9 @@ extension ContentView {
                 .padding(.vertical, 6)
         } else {
             GlassSurface(
-                enabled: shouldUseLiquidGlass,
+                enabled: false,
                 material: primaryGlassMaterial,
-                fallbackColor: toolbarFallbackColor,
+                fallbackColor: iOSNonTranslucentSurfaceColor,
                 shape: .capsule,
                 chromeStyle: .single
             ) {

--- a/Neon Vision Editor/UI/ContentView+Toolbar.swift
+++ b/Neon Vision Editor/UI/ContentView+Toolbar.swift
@@ -2061,9 +2061,11 @@ extension ContentView {
                     }
                 }
                 .padding(.leading, 12)
+                .padding(.trailing, 12)
                 .padding(.vertical, 8)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: true, vertical: false)
             }
+            .defaultScrollAnchor(.leading)
             if !iPhoneMoreActions.isEmpty {
                 moreActionsControl
                     .padding(.trailing, 12)
@@ -2103,7 +2105,9 @@ extension ContentView {
                 .padding(.leading, 24)
                 .padding(.trailing, 8)
                 .padding(.vertical, 8)
+                .fixedSize(horizontal: true, vertical: false)
             }
+            .defaultScrollAnchor(.leading)
             .frame(maxWidth: .infinity, alignment: .leading)
             if !iPadOverflowActions.isEmpty {
                 iPadOverflowMenuControl
@@ -2119,9 +2123,9 @@ extension ContentView {
     @ViewBuilder
     var iPadUnifiedToolbarRow: some View {
         GlassSurface(
-            enabled: shouldUseLiquidGlass,
+            enabled: false,
             material: primaryGlassMaterial,
-            fallbackColor: toolbarFallbackColor,
+            fallbackColor: iOSNonTranslucentSurfaceColor,
             shape: .capsule,
             chromeStyle: iOSToolbarChromeStyle
         ) {
@@ -2328,9 +2332,9 @@ extension ContentView {
             if #available(iOS 26.0, *) {
                 ToolbarItem(placement: .topBarTrailing) {
                     GlassSurface(
-                        enabled: shouldUseLiquidGlass,
+                        enabled: false,
                         material: primaryGlassMaterial,
-                        fallbackColor: toolbarFallbackColor,
+                        fallbackColor: iOSNonTranslucentSurfaceColor,
                         shape: .capsule,
                         chromeStyle: iOSToolbarChromeStyle
                     ) {
@@ -2346,9 +2350,9 @@ extension ContentView {
             } else {
                 ToolbarItem(placement: .topBarTrailing) {
                     GlassSurface(
-                        enabled: shouldUseLiquidGlass,
+                        enabled: false,
                         material: primaryGlassMaterial,
-                        fallbackColor: toolbarFallbackColor,
+                        fallbackColor: iOSNonTranslucentSurfaceColor,
                         shape: .capsule,
                         chromeStyle: iOSToolbarChromeStyle
                     ) {

--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -1283,7 +1283,10 @@ struct ContentView: View {
 #elseif os(iOS) || os(visionOS)
     var primaryGlassMaterial: Material { colorScheme == .dark ? .regularMaterial : .ultraThinMaterial }
     var toolbarFallbackColor: Color {
-        colorScheme == .dark ? Color.black.opacity(0.34) : Color.white.opacity(0.86)
+        // Keep mobile toolbar chrome on the active editor surface when the
+        // solid fallback is used. System black/white made the toolbar look
+        // detached from themed documents.
+        iOSNonTranslucentSurfaceColor
     }
     var iOSNonTranslucentSurfaceColor: Color {
 #if os(visionOS)

--- a/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
@@ -73,7 +73,6 @@ final class MobileNativeFileTabBarView: UIView {
             UIColor.white.cgColor,
             UIColor.clear.cgColor
         ]
-        rightEdgeFadeMask.locations = [0, 0.82, 1]
         rightEdgeFadeMask.startPoint = CGPoint(x: 0, y: 0.5)
         rightEdgeFadeMask.endPoint = CGPoint(x: 1, y: 0.5)
         scrollView.layer.mask = rightEdgeFadeMask
@@ -117,6 +116,9 @@ final class MobileNativeFileTabBarView: UIView {
             height: max(0, bounds.height - separatorHeight)
         )
         rightEdgeFadeMask.frame = scrollView.bounds
+        let fadeWidth = min(18, scrollView.bounds.width)
+        let fadeStart = max(0, 1 - fadeWidth / max(scrollView.bounds.width, 1))
+        rightEdgeFadeMask.locations = [0, NSNumber(value: Double(fadeStart)), 1]
         layoutTabs(viewportWidth: scrollView.bounds.width)
     }
 
@@ -173,16 +175,24 @@ final class MobileNativeFileTabBarView: UIView {
 
         let spacing: CGFloat = 5
         let totalSpacing = spacing * CGFloat(max(0, count - 1))
-        let maximumWidth: CGFloat = 220
-        let minimumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 136 : 148
-        let fittedWidth = (viewportWidth - totalSpacing) / CGFloat(count)
-        let tabWidth = min(maximumWidth, max(minimumWidth, fittedWidth))
-        let contentWidth = max(viewportWidth, tabWidth * CGFloat(count) + totalSpacing)
+        let maximumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 220 : 188
+        let minimumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 136 : 104
+        var tabWidths = orderedTabIDs.map { id in
+            guard let tabView = tabViewsByID[id] else { return minimumWidth }
+            return min(maximumWidth, max(minimumWidth, tabView.preferredTabWidth))
+        }
+        let preferredTotal = tabWidths.reduce(0, +) + totalSpacing
+        if preferredTotal < viewportWidth {
+            let extraPerTab = (viewportWidth - preferredTotal) / CGFloat(count)
+            tabWidths = tabWidths.map { min(maximumWidth, $0 + extraPerTab) }
+        }
+        let contentWidth = max(viewportWidth, tabWidths.reduce(0, +) + totalSpacing)
         tabsView.frame = CGRect(x: 0, y: 0, width: contentWidth, height: scrollView.bounds.height)
         scrollView.contentSize = tabsView.bounds.size
 
         var x: CGFloat = 0
-        for id in orderedTabIDs {
+        for (index, id) in orderedTabIDs.enumerated() {
+            let tabWidth = tabWidths[index]
             tabViewsByID[id]?.frame = CGRect(x: x, y: 5, width: tabWidth, height: max(28, tabsView.bounds.height - 10))
             x += tabWidth + spacing
         }
@@ -251,6 +261,14 @@ private final class MobileNativeFileTabItemView: UIControl, UIDragInteractionDel
     private var snapshot: MobileNativeFileTabSnapshot?
     private var isCurrentSelection = false
     private var insertionBefore: Bool?
+
+    var preferredTabWidth: CGFloat {
+        let titleWidth = titleLabel.intrinsicContentSize.width
+        let remoteWidth: CGFloat = snapshot?.isRemote == true ? 49 : 0
+        let lockWidth: CGFloat = snapshot?.isReadOnly == true ? 17 : 0
+        let dirtyWidth: CGFloat = snapshot?.isDirty == true ? 11 : 0
+        return titleWidth + 50 + remoteWidth + lockWidth + dirtyWidth
+    }
 
     var visualStateForTesting: (selected: Bool, previous: Bool, dirty: Bool) {
         (isCurrentSelection, false, snapshot?.isDirty == true)

--- a/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
@@ -131,7 +131,7 @@ final class MobileNativeFileTabBarTests: XCTestCase {
         )
         view.layoutIfNeeded()
 
-        let expectedMinimumWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 136 : 148
+        let expectedMinimumWidth: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 136 : 128
         XCTAssertGreaterThanOrEqual(try XCTUnwrap(view.tabFrameForTesting(ids[1])).width, expectedMinimumWidth)
     }
 


### PR DESCRIPTION
## Summary
- use the active editor theme for mobile toolbar surfaces
- prevent toolbar controls from clipping at the right edge on first render
- preserve filename-driven tab widths and narrow the tab fade

## Verification
- Focused iOS simulator tests passed: MobileNativeFileTabBarTests and ContentViewLayoutTests
- git diff --check passed

## Summary by Sourcery

Keep mobile toolbar and tab chrome visually aligned with themed content while improving first-render layout and tab sizing.

Bug Fixes:
- Align mobile toolbar surfaces with the active editor theme instead of detached system-colored backgrounds.
- Prevent mobile toolbar controls from clipping at the right edge during initial layout.

Enhancements:
- Preserve filename- and state-driven mobile tab widths while allowing tabs to expand within available space.
- Narrow the mobile tab bar’s right-edge fade effect.

Tests:
- Update mobile tab bar layout expectations for the revised minimum tab width.