### PR TITLE
Fix mobile translucency and tab clipping

### DIFF
--- a/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
+++ b/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
@@ -43,7 +43,7 @@ extension ContentView {
                 .padding(.vertical, 6)
         } else {
             GlassSurface(
-                enabled: false,
+                enabled: enableTranslucentWindow,
                 material: primaryGlassMaterial,
                 fallbackColor: iOSNonTranslucentSurfaceColor,
                 shape: .capsule,
@@ -768,9 +768,8 @@ extension ContentView {
 #elseif os(iOS)
             GlassSurface(
                 // Keep the tab strip tied to the editor theme. Window
-                // translucency should not replace that theme surface with a
-                // separate material band.
-                enabled: false,
+                // translucency should apply to the tab strip as well.
+                enabled: enableTranslucentWindow,
                 material: primaryGlassMaterial,
                 fallbackColor: iOSNonTranslucentSurfaceColor,
                 shape: .rounded(18),
@@ -817,9 +816,11 @@ extension ContentView {
 #if os(macOS)
         .background(macToolbarBackgroundStyle)
 #elseif os(iOS)
-        // Keep the full-width strip on the same theme surface as the editor;
-        // this remains stable when window translucency is toggled.
-        .background(iOSNonTranslucentSurfaceColor)
+        .background(
+            enableTranslucentWindow
+                ? AnyShapeStyle(.ultraThinMaterial)
+                : AnyShapeStyle(iOSNonTranslucentSurfaceColor)
+        )
 #else
         .background(
             enableTranslucentWindow

--- a/Neon Vision Editor/UI/ContentView+Toolbar.swift
+++ b/Neon Vision Editor/UI/ContentView+Toolbar.swift
@@ -2123,7 +2123,7 @@ extension ContentView {
     @ViewBuilder
     var iPadUnifiedToolbarRow: some View {
         GlassSurface(
-            enabled: false,
+            enabled: enableTranslucentWindow,
             material: primaryGlassMaterial,
             fallbackColor: iOSNonTranslucentSurfaceColor,
             shape: .capsule,
@@ -2332,7 +2332,7 @@ extension ContentView {
             if #available(iOS 26.0, *) {
                 ToolbarItem(placement: .topBarTrailing) {
                     GlassSurface(
-                        enabled: false,
+                        enabled: enableTranslucentWindow,
                         material: primaryGlassMaterial,
                         fallbackColor: iOSNonTranslucentSurfaceColor,
                         shape: .capsule,
@@ -2350,7 +2350,7 @@ extension ContentView {
             } else {
                 ToolbarItem(placement: .topBarTrailing) {
                     GlassSurface(
-                        enabled: false,
+                        enabled: enableTranslucentWindow,
                         material: primaryGlassMaterial,
                         fallbackColor: iOSNonTranslucentSurfaceColor,
                         shape: .capsule,

--- a/Neon Vision Editor/UI/ContentView.swift
+++ b/Neon Vision Editor/UI/ContentView.swift
@@ -600,7 +600,7 @@ struct ContentView: View {
     @State var lastPersistedDraftSignature: String = ""
     @State private var largeFileEstimateCache: LargeFileEstimateCacheEntry?
 #if os(iOS) || os(visionOS)
-    @AppStorage("EnableTranslucentWindow") var enableTranslucentWindow: Bool = true
+    @AppStorage("EnableTranslucentWindow") var enableTranslucentWindow: Bool = false
 #else
     @AppStorage("EnableTranslucentWindow") var enableTranslucentWindow: Bool = false
 #endif
@@ -3359,7 +3359,7 @@ struct ContentView: View {
                             language: contentView.currentLanguage,
                             contentUTF16Length: contentView.currentDocumentUTF16Length,
                             documentID: contentView.viewModel.selectedTabID,
-                            translucentBackgroundEnabled: true,
+                            translucentBackgroundEnabled: contentView.enableTranslucentWindow,
                             onItemSelected: {
                                 contentView.showCompactSidebarSheet = false
                             },
@@ -3387,7 +3387,11 @@ struct ContentView: View {
                         }
                     }
                     .presentationDetents([.medium, .large])
-                    .presentationBackground(.ultraThinMaterial)
+                    .presentationBackground(
+                        contentView.enableTranslucentWindow
+                            ? AnyShapeStyle(.ultraThinMaterial)
+                            : AnyShapeStyle(contentView.iOSNonTranslucentSurfaceColor)
+                    )
                 }
                 .sheet(isPresented: contentView.$showCompactProjectSidebarSheet, onDismiss: {
                     contentView.projectSidebarFindInFilesRequestToken = 0
@@ -3408,7 +3412,7 @@ struct ContentView: View {
                                     showSupportedFilesOnly: contentView.showSupportedProjectFilesOnly,
                                     showHiddenFiles: contentView.showHiddenProjectFiles,
                                     ignoredFolderNamesRaw: contentView.$projectIgnoredFolderNamesRaw,
-                                    translucentBackgroundEnabled: true,
+                                    translucentBackgroundEnabled: contentView.enableTranslucentWindow,
                                     boundaryEdge: nil,
                                     onOpenFile: { contentView.openFileFromCompactProjectSidebar() },
                                     onOpenFolder: { contentView.openProjectFolderFromCompactProjectSidebar() },
@@ -3483,7 +3487,11 @@ struct ContentView: View {
                         }
                     }
                     .presentationDetents([.large])
-                    .presentationBackground(.ultraThinMaterial)
+                    .presentationBackground(
+                        contentView.enableTranslucentWindow
+                            ? AnyShapeStyle(.ultraThinMaterial)
+                            : AnyShapeStyle(contentView.iOSNonTranslucentSurfaceColor)
+                    )
                 }
                 .sheet(isPresented: contentView.previewSheetPresentationBinding) {
                     NavigationStack {

--- a/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
@@ -151,7 +151,9 @@ final class MobileNativeFileTabBarView: UIView {
             tabView.apply(
                 snapshot: snapshot,
                 isSelected: snapshot.id == selectedTabID,
-                allowsReordering: traitCollection.userInterfaceIdiom == .pad
+                // Keep tab interaction consistent across iPhone and iPad.
+                // The same drag/drop implementation supports both sizes.
+                allowsReordering: true
             )
         }
 
@@ -189,6 +191,13 @@ final class MobileNativeFileTabBarView: UIView {
         let contentWidth = max(viewportWidth, tabWidths.reduce(0, +) + totalSpacing)
         tabsView.frame = CGRect(x: 0, y: 0, width: contentWidth, height: scrollView.bounds.height)
         scrollView.contentSize = tabsView.bounds.size
+        let maximumOffset = max(0, contentWidth - viewportWidth)
+        if scrollView.contentOffset.x > maximumOffset {
+            scrollView.setContentOffset(
+                CGPoint(x: maximumOffset, y: scrollView.contentOffset.y),
+                animated: false
+            )
+        }
 
         var x: CGFloat = 0
         for (index, id) in orderedTabIDs.enumerated() {
@@ -200,9 +209,36 @@ final class MobileNativeFileTabBarView: UIView {
 
     private func scrollSelectedTabToVisible(animated: Bool) {
         guard let selectedTabID, let selectedView = tabViewsByID[selectedTabID] else { return }
-        let visibleRect = selectedView.frame.insetBy(dx: -6, dy: 0)
-        guard !scrollView.bounds.contains(visibleRect) else { return }
-        scrollView.scrollRectToVisible(visibleRect, animated: animated)
+        // `selectedView.frame` is in `tabsView` coordinates while the scroll
+        // view's bounds origin changes with contentOffset. Convert first so a
+        // tab selected beside the left edge is measured in the actual viewport
+        // rather than against stale content coordinates.
+        let tabRect = selectedView.convert(selectedView.bounds, to: scrollView)
+        let visibleBounds = scrollView.bounds.insetBy(dx: 6, dy: 0)
+        guard !visibleBounds.contains(tabRect) else { return }
+
+        let viewportWidth = scrollView.bounds.width
+        let maximumOffset = max(0, scrollView.contentSize.width - viewportWidth)
+        let leadingTarget = max(0, selectedView.frame.minX - 6)
+        let trailingTarget = min(maximumOffset, selectedView.frame.maxX + 6 - viewportWidth)
+        let targetOffset: CGFloat
+        if tabRect.minX < visibleBounds.minX {
+            targetOffset = leadingTarget
+        } else {
+            targetOffset = trailingTarget
+        }
+
+        // Use one explicit, clamped offset instead of scrollRectToVisible so
+        // a rapid right-to-left selection cancels the prior animation and
+        // cannot leave the first tab partially clipped.
+        let clampedTarget = min(max(0, targetOffset), maximumOffset)
+        scrollView.setContentOffset(
+            CGPoint(x: clampedTarget, y: scrollView.contentOffset.y),
+            // Never animate the leading edge. A pending right-to-left
+            // animation is what allowed the first tab to remain partially
+            // clipped after it was selected.
+            animated: animated && clampedTarget > 0.5
+        )
     }
 
     func selectTabForTesting(_ id: UUID) { onSelect?(id) }
@@ -226,6 +262,10 @@ final class MobileNativeFileTabBarView: UIView {
     }
 
     func tabFrameForTesting(_ id: UUID) -> CGRect? { tabViewsByID[id]?.frame }
+    func tabFrameInScrollViewForTesting(_ id: UUID) -> CGRect? {
+        guard let tabView = tabViewsByID[id] else { return nil }
+        return tabView.convert(tabView.bounds, to: scrollView)
+    }
 
     var addButtonFrameForTesting: CGRect { addButton.frame }
     var scrollViewFrameForTesting: CGRect { scrollView.frame }

--- a/Neon Vision Editor/UI/SidebarViews.swift
+++ b/Neon Vision Editor/UI/SidebarViews.swift
@@ -90,17 +90,10 @@ struct SidebarView: View {
 
     private var sidebarSurfaceFill: AnyShapeStyle {
         if translucentBackgroundEnabled {
-            #if os(macOS)
+#if os(macOS)
             return AnyShapeStyle(Color.clear)
             #else
-            // Both iPad sidebars must resolve to the same surface color. Two
-            // independent materials sample different content behind each
-            // card, producing visibly different colors in translucent mode.
-            return AnyShapeStyle(
-                currentEditorTheme(colorScheme: colorScheme)
-                    .background
-                    .opacity(colorScheme == .dark ? 0.82 : 0.90)
-            )
+            return AnyShapeStyle(.ultraThinMaterial)
             #endif
         }
 #if os(macOS)
@@ -1566,16 +1559,10 @@ struct ProjectStructureSidebarView: View {
 
     private var sidebarSurfaceFill: AnyShapeStyle {
         if translucentBackgroundEnabled {
-            #if os(macOS)
+#if os(macOS)
             return AnyShapeStyle(Color.clear)
             #else
-            // Keep the project sidebar and TOC sidebar on one resolved color
-            // instead of compositing separate materials over different panes.
-            return AnyShapeStyle(
-                currentEditorTheme(colorScheme: colorScheme)
-                    .background
-                    .opacity(colorScheme == .dark ? 0.82 : 0.90)
-            )
+            return AnyShapeStyle(.ultraThinMaterial)
             #endif
         }
 #if os(macOS)

--- a/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
@@ -89,9 +89,7 @@ final class MobileNativeFileTabBarTests: XCTestCase {
         XCTAssertTrue(state.traits.contains(.button))
         XCTAssertTrue(state.traits.contains(.selected))
         XCTAssertEqual(view.accessibilityActionsForTesting(id)?.first, "Close Tab")
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            XCTAssertEqual(view.accessibilityActionsForTesting(id), ["Close Tab", "Move Tab Left", "Move Tab Right"])
-        }
+        XCTAssertEqual(view.accessibilityActionsForTesting(id), ["Close Tab", "Move Tab Left", "Move Tab Right"])
     }
 
     func testAddButtonStaysOutsideHorizontallyScrollingTabs() {
@@ -120,6 +118,26 @@ final class MobileNativeFileTabBarTests: XCTestCase {
         XCTAssertGreaterThan(view.horizontalContentWidthForTesting, view.scrollViewFrameForTesting.width)
         XCTAssertGreaterThan(view.horizontalContentOffsetForTesting, 0)
         XCTAssertGreaterThan(try XCTUnwrap(view.tabFrameForTesting(lastID)).minX, view.scrollViewFrameForTesting.width)
+    }
+
+    func testSelectingFirstTabAfterScrollingRightReturnsItFullyIntoView() throws {
+        let ids = (0..<12).map { _ in UUID() }
+        let firstID = try XCTUnwrap(ids.first)
+        let lastID = try XCTUnwrap(ids.last)
+        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 390, height: 42))
+        let tabs = ids.enumerated().map { snapshot(id: $0.element, title: "Document \($0.offset)") }
+
+        view.apply(tabs: tabs, selectedTabID: lastID)
+        view.layoutIfNeeded()
+        XCTAssertGreaterThan(view.horizontalContentOffsetForTesting, 0)
+
+        view.apply(tabs: tabs, selectedTabID: firstID)
+        view.layoutIfNeeded()
+
+        XCTAssertEqual(view.horizontalContentOffsetForTesting, 0, accuracy: 0.5)
+        let visibleFrame = try XCTUnwrap(view.tabFrameInScrollViewForTesting(firstID))
+        XCTAssertGreaterThanOrEqual(visibleFrame.minX, -0.5)
+        XCTAssertLessThanOrEqual(visibleFrame.maxX, view.scrollViewFrameForTesting.width + 0.5)
     }
 
     func testPhoneTabsUseAReadableDefaultWidthForLongFilenames() throws {


### PR DESCRIPTION
## Summary
- fix the root cause of left-tab clipping after right-to-left selection
- enable iPhone tab drag reordering using the existing iPad interaction
- apply the translucency setting consistently to mobile toolbar, tab bar, project sidebar, TOC, and compact sheets
- keep mobile translucency disabled by default

## Verification
- Focused iOS simulator tests passed: MobileNativeFileTabBarTests and ContentViewLayoutTests
- git diff --check passed

## Summary by Sourcery

Fix mobile tab visibility and reordering while making translucent surfaces consistently follow the mobile display preference.

New Features:
- Enable tab drag reordering consistently on iPhone and iPad.

Bug Fixes:
- Prevent mobile tab clipping when selecting a tab after scrolling in the opposite direction.
- Keep the selected mobile tab within the visible viewport and correct stale scroll offsets.

Enhancements:
- Apply the translucency preference consistently across mobile toolbars, tab bars, sidebars, table of contents, and compact sheets.
- Keep mobile translucency disabled by default.

Tests:
- Add coverage for restoring the first tab fully into view after scrolling through a large tab set.
- Update tab accessibility tests to require reordering actions on all supported mobile devices.