### PR TITLE
Sync develop into main

### DIFF
--- a/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
+++ b/Neon Vision Editor/UI/ContentView+TabChromeStatus.swift
@@ -786,6 +786,8 @@ extension ContentView {
                         )
                     },
                     selectedTabID: viewModel.selectedTabID,
+                    transitionColor: UIColor(iOSNonTranslucentSurfaceColor),
+                    transitionOpacity: enableTranslucentWindow ? 0.35 : 1,
                     onSelect: { viewModel.selectTab(id: $0) },
                     onClose: { tabID in
                         guard let tab = viewModel.tabs.first(where: { $0.id == tabID }) else { return }

--- a/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MobileNativeFileTabBar.swift
@@ -14,6 +14,8 @@ struct MobileNativeFileTabSnapshot: Equatable, Identifiable {
 struct MobileNativeFileTabBar: UIViewRepresentable {
     let tabs: [MobileNativeFileTabSnapshot]
     let selectedTabID: UUID?
+    let transitionColor: UIColor
+    let transitionOpacity: CGFloat
     let onSelect: (UUID) -> Void
     let onClose: (UUID) -> Void
     let onMove: (UUID, UUID, Bool) -> Void
@@ -34,12 +36,13 @@ struct MobileNativeFileTabBar: UIViewRepresentable {
         view.onClose = onClose
         view.onMove = onMove
         view.onAdd = onAdd
+        view.setTrailingTransitionColor(transitionColor, opacity: transitionOpacity)
         view.apply(tabs: tabs, selectedTabID: selectedTabID)
     }
 }
 
 @MainActor
-final class MobileNativeFileTabBarView: UIView {
+final class MobileNativeFileTabBarView: UIView, UIScrollViewDelegate {
     var onSelect: ((UUID) -> Void)?
     var onClose: ((UUID) -> Void)?
     var onMove: ((UUID, UUID, Bool) -> Void)?
@@ -47,9 +50,10 @@ final class MobileNativeFileTabBarView: UIView {
 
     private let scrollView = UIScrollView()
     private let tabsView = UIView()
+    private let trailingTransitionView = UIView()
+    private let trailingTransitionGradient = CAGradientLayer()
     private let addButton = UIButton(type: .system)
     private let separator = UIView()
-    private let rightEdgeFadeMask = CAGradientLayer()
     private var tabViewsByID: [UUID: MobileNativeFileTabItemView] = [:]
     private(set) var orderedTabIDs: [UUID] = []
     private(set) var selectedTabID: UUID?
@@ -67,16 +71,17 @@ final class MobileNativeFileTabBarView: UIView {
         scrollView.showsVerticalScrollIndicator = false
         scrollView.isDirectionalLockEnabled = true
         scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.delegate = self
         scrollView.addSubview(tabsView)
-        rightEdgeFadeMask.colors = [
-            UIColor.white.cgColor,
-            UIColor.white.cgColor,
-            UIColor.clear.cgColor
-        ]
-        rightEdgeFadeMask.startPoint = CGPoint(x: 0, y: 0.5)
-        rightEdgeFadeMask.endPoint = CGPoint(x: 1, y: 0.5)
-        scrollView.layer.mask = rightEdgeFadeMask
         addSubview(scrollView)
+
+        trailingTransitionView.isUserInteractionEnabled = false
+        trailingTransitionView.isAccessibilityElement = false
+        trailingTransitionView.isHidden = true
+        trailingTransitionGradient.startPoint = CGPoint(x: 0, y: 0.5)
+        trailingTransitionGradient.endPoint = CGPoint(x: 1, y: 0.5)
+        trailingTransitionView.layer.addSublayer(trailingTransitionGradient)
+        addSubview(trailingTransitionView)
 
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(systemName: "plus")
@@ -102,9 +107,9 @@ final class MobileNativeFileTabBarView: UIView {
         let scale = max(1, traitCollection.displayScale)
         let separatorHeight = 1 / scale
         let leadingInset: CGFloat = 8
-        let buttonWidth: CGFloat = 44
-        let trailingInset: CGFloat = 4
-        let spacing: CGFloat = 4
+        let buttonWidth: CGFloat = 32
+        let trailingInset: CGFloat = 0
+        let transitionWidth: CGFloat = 2
         let buttonX = max(leadingInset, bounds.width - trailingInset - buttonWidth)
 
         separator.frame = CGRect(x: 0, y: bounds.height - separatorHeight, width: bounds.width, height: separatorHeight)
@@ -112,14 +117,29 @@ final class MobileNativeFileTabBarView: UIView {
         scrollView.frame = CGRect(
             x: leadingInset,
             y: 0,
-            width: max(0, buttonX - spacing - leadingInset),
+            width: max(0, buttonX - transitionWidth - leadingInset),
             height: max(0, bounds.height - separatorHeight)
         )
-        rightEdgeFadeMask.frame = scrollView.bounds
-        let fadeWidth = min(18, scrollView.bounds.width)
-        let fadeStart = max(0, 1 - fadeWidth / max(scrollView.bounds.width, 1))
-        rightEdgeFadeMask.locations = [0, NSNumber(value: Double(fadeStart)), 1]
+        trailingTransitionView.frame = CGRect(
+            x: scrollView.frame.maxX,
+            y: 0,
+            width: max(0, buttonX - scrollView.frame.maxX),
+            height: max(0, bounds.height - separatorHeight)
+        )
+        trailingTransitionGradient.frame = trailingTransitionView.bounds
         layoutTabs(viewportWidth: scrollView.bounds.width)
+        // Frame changes (rotation, split-view resizing, keyboard chrome) can
+        // preserve an old content offset. Re-apply the selected-tab invariant
+        // after the new viewport has been laid out.
+        scrollSelectedTabToVisible()
+    }
+
+    func setTrailingTransitionColor(_ color: UIColor, opacity: CGFloat) {
+        let resolvedOpacity = min(max(opacity, 0), 1)
+        trailingTransitionGradient.colors = [
+            color.withAlphaComponent(0).cgColor,
+            color.withAlphaComponent(resolvedOpacity).cgColor
+        ]
     }
 
     func apply(
@@ -164,7 +184,7 @@ final class MobileNativeFileTabBarView: UIView {
 
         setNeedsLayout()
         layoutIfNeeded()
-        scrollSelectedTabToVisible(animated: window != nil)
+        scrollSelectedTabToVisible()
     }
 
     private func layoutTabs(viewportWidth: CGFloat) {
@@ -172,21 +192,17 @@ final class MobileNativeFileTabBarView: UIView {
         guard count > 0 else {
             tabsView.frame = CGRect(x: 0, y: 0, width: viewportWidth, height: scrollView.bounds.height)
             scrollView.contentSize = tabsView.bounds.size
+            updateTrailingTransitionVisibility()
             return
         }
 
         let spacing: CGFloat = 5
         let totalSpacing = spacing * CGFloat(max(0, count - 1))
-        let maximumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 220 : 188
+        let maximumWidth: CGFloat = 188
         let minimumWidth: CGFloat = traitCollection.userInterfaceIdiom == .pad ? 136 : 104
-        var tabWidths = orderedTabIDs.map { id in
+        let tabWidths = orderedTabIDs.map { id in
             guard let tabView = tabViewsByID[id] else { return minimumWidth }
             return min(maximumWidth, max(minimumWidth, tabView.preferredTabWidth))
-        }
-        let preferredTotal = tabWidths.reduce(0, +) + totalSpacing
-        if preferredTotal < viewportWidth {
-            let extraPerTab = (viewportWidth - preferredTotal) / CGFloat(count)
-            tabWidths = tabWidths.map { min(maximumWidth, $0 + extraPerTab) }
         }
         let contentWidth = max(viewportWidth, tabWidths.reduce(0, +) + totalSpacing)
         tabsView.frame = CGRect(x: 0, y: 0, width: contentWidth, height: scrollView.bounds.height)
@@ -198,7 +214,7 @@ final class MobileNativeFileTabBarView: UIView {
                 animated: false
             )
         }
-
+        updateTrailingTransitionVisibility()
         var x: CGFloat = 0
         for (index, id) in orderedTabIDs.enumerated() {
             let tabWidth = tabWidths[index]
@@ -207,7 +223,7 @@ final class MobileNativeFileTabBarView: UIView {
         }
     }
 
-    private func scrollSelectedTabToVisible(animated: Bool) {
+    private func scrollSelectedTabToVisible() {
         guard let selectedTabID, let selectedView = tabViewsByID[selectedTabID] else { return }
         // `selectedView.frame` is in `tabsView` coordinates while the scroll
         // view's bounds origin changes with contentOffset. Convert first so a
@@ -228,17 +244,25 @@ final class MobileNativeFileTabBarView: UIView {
             targetOffset = trailingTarget
         }
 
-        // Use one explicit, clamped offset instead of scrollRectToVisible so
-        // a rapid right-to-left selection cancels the prior animation and
-        // cannot leave the first tab partially clipped.
+        // Set the final offset directly. There is no transition state that
+        // can keep a newly selected tab partially clipped.
         let clampedTarget = min(max(0, targetOffset), maximumOffset)
         scrollView.setContentOffset(
             CGPoint(x: clampedTarget, y: scrollView.contentOffset.y),
-            // Never animate the leading edge. A pending right-to-left
-            // animation is what allowed the first tab to remain partially
-            // clipped after it was selected.
-            animated: animated && clampedTarget > 0.5
+            animated: false
         )
+        updateTrailingTransitionVisibility()
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        updateTrailingTransitionVisibility()
+    }
+
+    private func updateTrailingTransitionVisibility() {
+        let maximumOffset = max(0, scrollView.contentSize.width - scrollView.bounds.width)
+        let hasHiddenTabsToRight = maximumOffset > 0.5
+            && scrollView.contentOffset.x < maximumOffset - 0.5
+        trailingTransitionView.isHidden = !hasHiddenTabsToRight
     }
 
     func selectTabForTesting(_ id: UUID) { onSelect?(id) }
@@ -269,8 +293,14 @@ final class MobileNativeFileTabBarView: UIView {
 
     var addButtonFrameForTesting: CGRect { addButton.frame }
     var scrollViewFrameForTesting: CGRect { scrollView.frame }
+    var trailingTransitionFrameForTesting: CGRect { trailingTransitionView.frame }
+    var trailingTransitionAcceptsTouchesForTesting: Bool { trailingTransitionView.isUserInteractionEnabled }
+    var trailingTransitionIsVisibleForTesting: Bool { !trailingTransitionView.isHidden }
     var horizontalContentOffsetForTesting: CGFloat { scrollView.contentOffset.x }
     var horizontalContentWidthForTesting: CGFloat { scrollView.contentSize.width }
+    func setContentOffsetForTesting(x: CGFloat) {
+        scrollView.setContentOffset(CGPoint(x: x, y: scrollView.contentOffset.y), animated: false)
+    }
 
     @objc private func addTab() {
         onAdd?()

--- a/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
@@ -100,8 +100,12 @@ final class MobileNativeFileTabBarTests: XCTestCase {
         )
         view.layoutIfNeeded()
 
-        XCTAssertEqual(view.addButtonFrameForTesting.width, 44)
-        XCTAssertGreaterThanOrEqual(view.addButtonFrameForTesting.minX - view.scrollViewFrameForTesting.maxX, 4)
+        XCTAssertEqual(view.addButtonFrameForTesting.width, 32)
+        XCTAssertEqual(view.trailingTransitionFrameForTesting.minX, view.scrollViewFrameForTesting.maxX, accuracy: 0.5)
+        XCTAssertEqual(view.trailingTransitionFrameForTesting.maxX, view.addButtonFrameForTesting.minX, accuracy: 0.5)
+        XCTAssertEqual(view.trailingTransitionFrameForTesting.width, 2, accuracy: 0.5)
+        XCTAssertFalse(view.trailingTransitionAcceptsTouchesForTesting)
+        XCTAssertTrue(view.trailingTransitionIsVisibleForTesting)
         XCTAssertEqual(view.scrollViewFrameForTesting.minX, 8)
     }
 
@@ -118,6 +122,7 @@ final class MobileNativeFileTabBarTests: XCTestCase {
         XCTAssertGreaterThan(view.horizontalContentWidthForTesting, view.scrollViewFrameForTesting.width)
         XCTAssertGreaterThan(view.horizontalContentOffsetForTesting, 0)
         XCTAssertGreaterThan(try XCTUnwrap(view.tabFrameForTesting(lastID)).minX, view.scrollViewFrameForTesting.width)
+        XCTAssertFalse(view.trailingTransitionIsVisibleForTesting)
     }
 
     func testSelectingFirstTabAfterScrollingRightReturnsItFullyIntoView() throws {
@@ -135,9 +140,26 @@ final class MobileNativeFileTabBarTests: XCTestCase {
         view.layoutIfNeeded()
 
         XCTAssertEqual(view.horizontalContentOffsetForTesting, 0, accuracy: 0.5)
+        XCTAssertTrue(view.trailingTransitionIsVisibleForTesting)
         let visibleFrame = try XCTUnwrap(view.tabFrameInScrollViewForTesting(firstID))
         XCTAssertGreaterThanOrEqual(visibleFrame.minX, -0.5)
         XCTAssertLessThanOrEqual(visibleFrame.maxX, view.scrollViewFrameForTesting.width + 0.5)
+    }
+
+    func testRelayoutKeepsSelectedFirstTabAtTheLeadingEdge() throws {
+        let ids = (0..<10).map { _ in UUID() }
+        let firstID = try XCTUnwrap(ids.first)
+        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 390, height: 42))
+        let tabs = ids.enumerated().map { snapshot(id: $0.element, title: "Document \($0.offset)") }
+
+        view.apply(tabs: tabs, selectedTabID: firstID)
+        view.layoutIfNeeded()
+        view.setContentOffsetForTesting(x: 120)
+        view.frame.size.width = 320
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+
+        XCTAssertEqual(view.horizontalContentOffsetForTesting, 0, accuracy: 0.5)
     }
 
     func testPhoneTabsUseAReadableDefaultWidthForLongFilenames() throws {


### PR DESCRIPTION
Promote the merged develop changes, including the mobile tab transition spacing fix, into main.

## Summary by Sourcery

Fix mobile tab bar spacing and selection visibility while promoting the related changes into main.

Bug Fixes:
- Fix mobile tab bar transition spacing and ensure the selected tab remains fully visible after scrolling or layout changes.

Enhancements:
- Refine mobile tab bar sizing and add a non-interactive trailing transition indicator that reflects whether additional tabs are available.

Tests:
- Expand mobile tab bar coverage for transition layout, visibility, touch handling, and relayout behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a trailing fade indicator to show when additional tabs are available off-screen.
  * The indicator adapts to window translucency for improved visual integration.

* **Improvements**
  * Tab widths remain compact instead of expanding to fill the available space.
  * Reduced the add-tab button width to provide more room for open tabs.
  * Selecting tabs now keeps scrolling smooth and reliably positions the selected tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->