### PR TITLE
docs: prepare v1.7.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ## [Unreleased]
 
+### Why Upgrade
+
+- Keeps editor chrome responsive and visually consistent across macOS, iOS, and iPadOS.
+- Reduces the visible delay before syntax highlighting appears when switching documents.
+
+### Highlights
+
+- Refines mobile tab transitions, tab spacing, toolbar placement, and theme-aware translucent surfaces.
+- Aligns the AI assistant panel, Markdown controls, and Find & Replace surfaces with the active sidebar and editor themes.
+
+### Fixes
+
+- Prevents mobile tabs and toolbar controls from clipping at the edges during selection and scrolling.
+- Prevents interrupted macOS window drags from extending editor text selection.
+- Starts macOS syntax highlighting as soon as the selected tab viewport is available.
+
+### Breaking changes
+
+- None.
+
+### Migration
+
+- None.
+
 ## [v1.7.1] - 2026-09-09
 
 ### Why Upgrade


### PR DESCRIPTION
Adds reviewed Unreleased notes for v1.7.2 and includes the merged macOS 27 editor changes from PR #421.

## Summary by Sourcery

Prepare the v1.7.2 changelog with reviewed release highlights and fixes for Apple-platform editor improvements.

Bug Fixes:
- Document fixes for mobile tab and toolbar clipping, interrupted macOS window drags affecting text selection, and delayed macOS syntax highlighting.

Enhancements:
- Document responsive, theme-consistent editor chrome and updated mobile and assistant-panel presentation across Apple platforms.

Documentation:
- Add reviewed Unreleased release notes for v1.7.2, including upgrade highlights, fixes, and migration guidance.