### PR TITLE
fix: gate macOS 27 agent APIs for older release SDKs

### DIFF
--- a/Neon Vision Editor/AI/AppleEditorAgentAIClient.swift
+++ b/Neon Vision Editor/AI/AppleEditorAgentAIClient.swift
@@ -1,4 +1,8 @@
-#if os(macOS) && USE_FOUNDATION_MODELS && canImport(FoundationModels)
+// The agent profile APIs (DynamicProfile and PrivateCloudComputeLanguageModel)
+// are introduced by the Xcode 27 SDK. Keep the rest of FoundationModels
+// available to Xcode 26.6 release builds while excluding this source entirely
+// when the newer SDK/compiler is not present.
+#if os(macOS) && USE_FOUNDATION_MODELS && canImport(FoundationModels) && compiler(>=6.3)
 import Foundation
 import FoundationModels
 

--- a/Neon Vision Editor/UI/ContentView+AIChat.swift
+++ b/Neon Vision Editor/UI/ContentView+AIChat.swift
@@ -128,7 +128,7 @@ extension ContentView {
     }
 
     private var supportsEditorAgentMode: Bool {
-#if os(macOS) && USE_FOUNDATION_MODELS && canImport(FoundationModels)
+#if os(macOS) && USE_FOUNDATION_MODELS && canImport(FoundationModels) && compiler(>=6.3)
         if #available(macOS 27.0, *) {
             return selectedModel == .appleIntelligence && appleModelAvailable &&
                 projectRootFolderURL != nil &&
@@ -181,7 +181,7 @@ extension ContentView {
 
     private func configuredAIChatClient(agentMode: EditorAgentMode? = nil) -> AIClient? {
         if let agentMode {
-#if os(macOS) && USE_FOUNDATION_MODELS && canImport(FoundationModels)
+#if os(macOS) && USE_FOUNDATION_MODELS && canImport(FoundationModels) && compiler(>=6.3)
             if #available(macOS 27.0, *),
                selectedModel == .appleIntelligence,
                appleModelAvailable,


### PR DESCRIPTION
Gate Xcode 27-only FoundationModels agent APIs behind the compiler version so Xcode 26.6 release builds keep the base FoundationModels integration while disabling only the macOS 27 agent mode. Xcode 27 builds retain the full agent implementation.

## Summary by Sourcery

Bug Fixes:
- Prevent older Xcode release builds from compiling unsupported macOS 27 FoundationModels agent APIs while preserving the existing FoundationModels integration.