### PR TITLE
Fix email address and wording in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Neon Vision Editor expects everyone who participates in the project to behave
+We expects everyone who participates in the project to behave
 professionally. This Code of Conduct supports productive collaboration; it is
 not intended to regulate ordinary interpersonal friction or require agreement.
 
@@ -47,7 +47,7 @@ context, and avoid deciding significant conflicts of interest where practical.
 ## Reporting concerns
 
 Conduct concerns may be reported privately to
-[`contact@sylwellsoftware.com`](mailto:contact@sylwellsoftware.com). Reports
+[`contact@sylwellsoftware.com`](mailto:contact@apps-h3p.com). Reports
 will be handled with appropriate discretion. Please include the relevant
 project space, links or other evidence, and any immediate safety or access
 concerns when it is safe to do so.


### PR DESCRIPTION
## Summary

- What changed:
- Why:
- Scope: Bugfix / Feature / Docs / Release
- Linked issue/milestone:

## Validation

- [ ] Built on macOS
- [ ] Built on iOS simulator
- [ ] Built on iPad simulator
- [ ] Tested key flow manually
- [ ] Repro steps included (for bug/regression fixes)
- [ ] Expected vs actual behavior documented (for bug/regression fixes)

## Checklist

- [ ] Accessibility checked (labels, focus order, no traps)
- [ ] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [ ] VoiceOver impact evaluated (if UI touched)
- [ ] Changelog updated (if user-facing change)
- [ ] Documentation updated (if behavior/UI changed)
- [ ] No unrelated refactors

## Risk

- Risk level: Low / Medium / High
- User-facing risk:
- Rollback plan:

## Summary by Sourcery

Documentation:
- Correct the Code of Conduct’s purpose statement and update the private reporting contact address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Code of Conduct’s Purpose section wording.
  - Changed the contact email for reporting concerns to `contact@apps-h3p.com`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->