### PR TITLE
Fix automatic release resumption

### DIFF
--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -49,6 +49,11 @@ def fixture(root):
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
+    def test_release_all_forwards_resume_auto_to_both_preparation_calls(self):
+        script = (ROOT / "scripts/release_all.sh").read_text()
+        self.assertEqual(script.count('prep_cmd+=(--resume)'), 1)
+        self.assertEqual(script.count('preparation+=(--resume)'), 1)
+
     def test_xcode_selector_rejects_underscored_beta_candidates_for_production(self):
         with tempfile.TemporaryDirectory(prefix="nve-xcode-selector-") as temp:
             fake_xcodebuild = Path(temp) / "xcodebuild"

--- a/scripts/release_all.sh
+++ b/scripts/release_all.sh
@@ -685,6 +685,7 @@ VALIDATION_ROOT="$ROOT"
 if step_enabled prep && ! git rev-parse --verify "refs/tags/$TAG" >/dev/null 2>&1; then
   preparation=(bash scripts/release_prep.sh "$TAG")
   if [[ ${#DATE_ARG[@]} -gt 0 ]]; then preparation+=("${DATE_ARG[@]}"); fi
+  if [[ "$RESUME_AUTO" -eq 1 ]]; then preparation+=(--resume); fi
   "${preparation[@]}"
   VALIDATION_ROOT="$(dirname "$ROOT")/$(basename "$ROOT")-release-${TAG#v}"
 fi
@@ -768,6 +769,9 @@ if step_enabled prep; then
     prep_cmd=(scripts/release_prep.sh "$TAG")
     if [[ ${#DATE_ARG[@]} -gt 0 ]]; then
       prep_cmd+=("${DATE_ARG[@]}")
+    fi
+    if [[ "$RESUME_AUTO" -eq 1 ]]; then
+      prep_cmd+=(--resume)
     fi
     prep_cmd+=(--push)
     "${prep_cmd[@]}"


### PR DESCRIPTION
## Summary

- What changed: Forwards `--resume-auto` as `--resume` to both release-preparation invocations.
- Why: The release orchestrator selected a continuation point but the fail-closed preparation subprocess rejected its own preserved release metadata because the resume flag was dropped.
- Scope: Bugfix / Release
- Linked issue/milestone: v1.7.3 release

## Validation

- [x] Built on macOS
- [x] Built on iOS simulator
- [x] Built on iPad simulator
- [x] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

Reproduced with `scripts/release_all.sh v1.7.3 --self-hosted --resume-auto`: it stopped on preserved generated metadata. Added an offline regression contract for both preparation call sites; all 33 release workflow tests pass and `bash -n scripts/release_all.sh` passes. The OS 27 platform matrix already passed on this base.

## Checklist

- [x] Accessibility checked (labels, focus order, no traps)
- [x] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [x] VoiceOver impact evaluated (if UI touched)
- [x] Changelog updated (if user-facing change)
- [x] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

No UI, accessibility, or user-facing behavior changed.

## Risk

- Risk level: Low
- User-facing risk: None. The flag is forwarded only when the operator explicitly selects `--resume-auto`; release preparation retains its existing release-owned-file validation.
- Rollback plan: Revert this commit; manual `release_prep.sh --resume` remains available.

## Summary by Sourcery

Fix automatic release resumption by passing the resume option through every release-preparation path.

Bug Fixes:
- Ensure automatic release resumption forwards the resume option to both release-preparation invocations, allowing preserved release metadata to be accepted during continuation.

Tests:
- Add a regression contract verifying that automatic resumption is forwarded at both release-preparation call sites.