### PR TITLE
Fix fallback release validation order

### DIFF
--- a/.github/workflows/release-notarized-selfhosted.yml
+++ b/.github/workflows/release-notarized-selfhosted.yml
@@ -307,9 +307,6 @@ jobs:
             echo "CHANGELOG section for ${TAG_NAME} still contains TODO entries." >&2
             exit 1
           fi
-          grep -nE "^> Latest release: \\*\\*${TAG_NAME}\\*\\*\r?$" README.md >/dev/null
-          grep -nE "^- Latest release: \\*\\*${TAG_NAME}\\*\\*\r?$" README.md >/dev/null
-          grep -nE "^\\| .*\\(https://github\\.com/h3pdesign/Neon-Vision-Editor/releases/tag/${TAG_NAME}\\) \\|" README.md >/dev/null
 
       - name: Create or Update GitHub Release
         id: publish_release

--- a/.github/workflows/release-notarized.yml
+++ b/.github/workflows/release-notarized.yml
@@ -267,9 +267,6 @@ jobs:
             echo "CHANGELOG section for ${TAG_NAME} still contains TODO entries." >&2
             exit 1
           fi
-          grep -nE "^> Latest release: \\*\\*${TAG_NAME}\\*\\*\r?$" README.md >/dev/null
-          grep -nE "^- Latest release: \\*\\*${TAG_NAME}\\*\\*\r?$" README.md >/dev/null
-          grep -nE "^\\| .*\\(https://github\\.com/h3pdesign/Neon-Vision-Editor/releases/tag/${TAG_NAME}\\) \\|" README.md >/dev/null
 
       - name: Create or Update GitHub Release
         id: publish_release

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -74,6 +74,18 @@ class ReleaseWorkflowTests(unittest.TestCase):
                 self.assertNotIn(greedy_pattern, workflow)
                 self.assertGreaterEqual(workflow.count(balanced_pattern), 4)
 
+    def test_fallbacks_do_not_require_published_readme_before_publication(self):
+        workflows = (
+            ".github/workflows/release-notarized.yml",
+            ".github/workflows/release-notarized-selfhosted.yml",
+        )
+        for path in workflows:
+            with self.subTest(workflow=path):
+                workflow = (ROOT / path).read_text()
+                self.assertNotIn('grep -nE "^> Latest release:', workflow)
+                self.assertNotIn('grep -nE "^- Latest release:', workflow)
+                self.assertNotIn("releases/tag/${TAG_NAME}", workflow)
+
     def test_release_all_forwards_resume_auto_to_both_preparation_calls(self):
         script = (ROOT / "scripts/release_all.sh").read_text()
         self.assertEqual(script.count('prep_cmd+=(--resume)'), 1)


### PR DESCRIPTION
## Summary

- What changed: Removes fallback checks that required README to advertise v1.7.3 before the GitHub release exists, while retaining generated-doc, metadata, changelog, notarization, package, and post-publication asset gates.
- Why: The fallback successfully notarized and packaged v1.7.3, then failed because release preparation intentionally keeps the previous public download current until publication completes.
- Scope: Bugfix / Release
- Linked issue/milestone: v1.7.3; failed run 34581110679

## Validation

- [x] Built on macOS
- [x] Built on iOS simulator
- [x] Built on iPad simulator
- [x] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

Run 34581110679 passed archive, export, icon payload, Apple notarization, stapling, ZIP, and DMG before reproducing the premature README check. YAML parsing passes and all 36 offline release workflow tests pass, including the new publication-order regression.

## Checklist

- [x] Accessibility checked (labels, focus order, no traps)
- [x] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [x] VoiceOver impact evaluated (if UI touched)
- [x] Changelog updated (if user-facing change)
- [x] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

No application UI or public documentation content changed.

## Risk

- Risk level: Low
- User-facing risk: None. The remaining pre-publication and post-publication gates still fail closed.
- Rollback plan: Revert this commit and use the primary hosted workflow after its Xcode 27 image reaches RC/GA.

## Summary by Sourcery

Allow fallback release workflows to complete pre-publication validation before updating public README release references.

Bug Fixes:
- Prevent fallback release workflows from failing before publication because README links and latest-release markers still reference the previous public release.

Tests:
- Add regression coverage ensuring both fallback workflows do not require published README release references before creating the GitHub release.