### PR TITLE
Fix v1.7.3 fallback publication order

### DIFF
--- a/.github/workflows/release-notarized-selfhosted.yml
+++ b/.github/workflows/release-notarized-selfhosted.yml
@@ -307,9 +307,6 @@ jobs:
             echo "CHANGELOG section for ${TAG_NAME} still contains TODO entries." >&2
             exit 1
           fi
-          grep -nE "^> Latest release: \\*\\*${TAG_NAME}\\*\\*\r?$" README.md >/dev/null
-          grep -nE "^- Latest release: \\*\\*${TAG_NAME}\\*\\*\r?$" README.md >/dev/null
-          grep -nE "^\\| .*\\(https://github\\.com/h3pdesign/Neon-Vision-Editor/releases/tag/${TAG_NAME}\\) \\|" README.md >/dev/null
 
       - name: Create or Update GitHub Release
         id: publish_release

--- a/.github/workflows/release-notarized.yml
+++ b/.github/workflows/release-notarized.yml
@@ -267,9 +267,6 @@ jobs:
             echo "CHANGELOG section for ${TAG_NAME} still contains TODO entries." >&2
             exit 1
           fi
-          grep -nE "^> Latest release: \\*\\*${TAG_NAME}\\*\\*\r?$" README.md >/dev/null
-          grep -nE "^- Latest release: \\*\\*${TAG_NAME}\\*\\*\r?$" README.md >/dev/null
-          grep -nE "^\\| .*\\(https://github\\.com/h3pdesign/Neon-Vision-Editor/releases/tag/${TAG_NAME}\\) \\|" README.md >/dev/null
 
       - name: Create or Update GitHub Release
         id: publish_release

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -74,6 +74,18 @@ class ReleaseWorkflowTests(unittest.TestCase):
                 self.assertNotIn(greedy_pattern, workflow)
                 self.assertGreaterEqual(workflow.count(balanced_pattern), 4)
 
+    def test_fallbacks_do_not_require_published_readme_before_publication(self):
+        workflows = (
+            ".github/workflows/release-notarized.yml",
+            ".github/workflows/release-notarized-selfhosted.yml",
+        )
+        for path in workflows:
+            with self.subTest(workflow=path):
+                workflow = (ROOT / path).read_text()
+                self.assertNotIn('grep -nE "^> Latest release:', workflow)
+                self.assertNotIn('grep -nE "^- Latest release:', workflow)
+                self.assertNotIn("releases/tag/${TAG_NAME}", workflow)
+
     def test_release_all_forwards_resume_auto_to_both_preparation_calls(self):
         script = (ROOT / "scripts/release_all.sh").read_text()
         self.assertEqual(script.count('prep_cmd+=(--resume)'), 1)


### PR DESCRIPTION
## Summary

- What changed: Promotes the fallback release publication-order fix merged into `develop` by PR #452.
- Why: The fallback must validate prepared documentation before publication without requiring README to advertise an asset that does not exist yet.
- Scope: Bugfix / Release
- Linked issue/milestone: v1.7.3; PR #452; failed run 34581110679

## Validation

- [x] Built on macOS
- [x] Built on iOS simulator
- [x] Built on iPad simulator
- [x] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

The prior run passed archive, export, icon payload, Apple notarization, stapling, ZIP, and DMG before reproducing the ordering error. YAML parsing and all 36 release workflow tests pass.

## Checklist

- [x] Accessibility checked (labels, focus order, no traps)
- [x] Keyboard navigation verified (macOS + iPad keyboard if applicable)
- [x] VoiceOver impact evaluated (if UI touched)
- [x] Changelog updated (if user-facing change)
- [x] Documentation updated (if behavior/UI changed)
- [x] No unrelated refactors

No application UI or documentation content changed.

## Risk

- Risk level: Low
- User-facing risk: None; release automation only.
- Rollback plan: Revert this merge; all other notarization and asset gates remain unchanged.

## Summary by Sourcery

Fix fallback release publication ordering by deferring README release validation until after publication.

Bug Fixes:
- Allow fallback release workflows to validate prepared release artifacts without requiring the new release to already be published in README.md.

CI:
- Add regression coverage ensuring fallback workflows do not enforce pre-publication README release checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release validation no longer requires the README to reference the release tag or latest-release badge before publication.
  * Release checks continue to ensure changelog entries do not contain unfinished TODO items.

* **Tests**
  * Added coverage confirming notarized release workflows can proceed without published README release references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->