### PR TITLE
Permit post-release workflow dispatch

### DIFF
--- a/.github/workflows/release-notarized-selfhosted.yml
+++ b/.github/workflows/release-notarized-selfhosted.yml
@@ -15,7 +15,7 @@ on:
         type: boolean
 
 permissions:
-  actions: read
+  actions: write
   contents: write
   issues: write
 

--- a/.github/workflows/release-notarized.yml
+++ b/.github/workflows/release-notarized.yml
@@ -15,6 +15,7 @@ on:
         type: boolean
 
 permissions:
+  actions: write
   contents: write
   issues: write
 

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -86,6 +86,17 @@ class ReleaseWorkflowTests(unittest.TestCase):
                 self.assertNotIn('grep -nE "^- Latest release:', workflow)
                 self.assertNotIn("releases/tag/${TAG_NAME}", workflow)
 
+    def test_fallbacks_can_dispatch_post_release_workflows(self):
+        workflows = (
+            ".github/workflows/release-notarized.yml",
+            ".github/workflows/release-notarized-selfhosted.yml",
+        )
+        for path in workflows:
+            with self.subTest(workflow=path):
+                workflow = (ROOT / path).read_text()
+                permissions = workflow.split("permissions:\n", 1)[1].split("\njobs:\n", 1)[0]
+                self.assertIn("  actions: write\n", permissions)
+
     def test_release_all_forwards_resume_auto_to_both_preparation_calls(self):
         script = (ROOT / "scripts/release_all.sh").read_text()
         self.assertEqual(script.count('prep_cmd+=(--resume)'), 1)


### PR DESCRIPTION
## Summary

- What changed: Promotes the reviewed fallback workflow dispatch-permission fix from develop to main.
- Why: Release run #34582027498 completed every archive, notarization, packaging, publication, and asset-validation stage but could not dispatch the delayed documentation self-heal workflow without `actions: write`.
- Scope: Bugfix / Release
- Linked issue/milestone: v1.7.3

## Validation

- [x] Built on macOS (release run #34582027498 before the permission-only failure)
- [x] Built on iOS simulator (v1.7.3 release gate)
- [x] Built on iPad simulator (v1.7.3 release gate)
- [x] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

Expected: the release workflow can dispatch its post-release documentation workflow.
Actual before fix: the GitHub API returned HTTP 403 after all release artifacts had passed validation.

## Checklist

- [x] Accessibility checked (no UI touched)
- [x] Keyboard navigation verified (no UI touched)
- [x] VoiceOver impact evaluated (no UI touched)
- [x] Changelog updated (not user-facing)
- [x] Documentation updated (no behavior/UI documentation change)
- [x] No unrelated refactors

## Risk

- Risk level: Low
- User-facing risk: None; permission remains limited to GitHub Actions workflow dispatch.
- Rollback plan: Revert 79a0db3b.

## Summary by Sourcery

Restore post-release workflow dispatch capability for notarized release workflows.

Bug Fixes:
- Allow release workflows to dispatch post-release documentation workflows by granting them the required GitHub Actions write permission.

Tests:
- Add regression coverage verifying both notarized release workflows retain workflow-dispatch permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release workflows can now trigger follow-up workflows after publishing releases.
  * Added validation to ensure the required workflow permissions remain configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->