### PR TITLE
Publish resumed draft releases

### DIFF
--- a/.github/workflows/release-notarized-selfhosted.yml
+++ b/.github/workflows/release-notarized-selfhosted.yml
@@ -287,6 +287,12 @@ jobs:
           done
           rm -rf "$DMG_STAGE"
 
+      - name: Create release checksums
+        run: |
+          set -euo pipefail
+          shasum -a 256 Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg > SHA256SUMS.txt
+          shasum -a 256 -c SHA256SUMS.txt
+
       - name: Extract changelog section
         env:
           TAG_NAME: ${{ inputs.tag }}
@@ -318,10 +324,10 @@ jobs:
 
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             bash scripts/preserve_release_download_baseline.sh "$TAG_NAME" release-notes.md
-            gh release upload "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg --clobber
-            gh release edit "$TAG_NAME" --title "Neon Vision Editor $TAG_NAME" --notes-file release-notes.md
+            gh release upload "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg SHA256SUMS.txt --clobber
+            gh release edit "$TAG_NAME" --title "Neon Vision Editor $TAG_NAME" --notes-file release-notes.md --draft=false
           else
-            gh release create "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg \
+            gh release create "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg SHA256SUMS.txt \
               --title "Neon Vision Editor $TAG_NAME" \
               --notes-file release-notes.md
           fi
@@ -342,7 +348,8 @@ jobs:
             rm -rf "$WORK_DIR"
           }
           trap cleanup_mount EXIT
-          gh release download "$TAG_NAME" -p Neon.Vision.Editor.app.zip -p Neon.Vision.Editor.app.dmg -D "$WORK_DIR"
+          gh release download "$TAG_NAME" -p Neon.Vision.Editor.app.zip -p Neon.Vision.Editor.app.dmg -p SHA256SUMS.txt -D "$WORK_DIR"
+          (cd "$WORK_DIR" && shasum -a 256 -c SHA256SUMS.txt)
           ditto -x -k "$WORK_DIR/Neon.Vision.Editor.app.zip" "$WORK_DIR/extracted"
           /usr/bin/codesign --verify --deep --strict "$WORK_DIR/extracted/Neon Vision Editor.app"
           scripts/ci/verify_icon_payload.sh "$WORK_DIR/extracted/Neon Vision Editor.app"
@@ -371,6 +378,7 @@ jobs:
           set -euo pipefail
           gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.zip" -y || true
           gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.dmg" -y || true
+          gh release delete-asset "$TAG_NAME" "SHA256SUMS.txt" -y || true
           gh release edit "$TAG_NAME" --draft true || true
           echo "Rolled back release asset and marked release as draft due to post-publish verification failure."
 

--- a/.github/workflows/release-notarized.yml
+++ b/.github/workflows/release-notarized.yml
@@ -248,6 +248,12 @@ jobs:
           done
           rm -rf "$DMG_STAGE"
 
+      - name: Create release checksums
+        run: |
+          set -euo pipefail
+          shasum -a 256 Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg > SHA256SUMS.txt
+          shasum -a 256 -c SHA256SUMS.txt
+
       - name: Extract changelog section
         env:
           TAG_NAME: ${{ inputs.tag }}
@@ -279,10 +285,10 @@ jobs:
 
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             bash scripts/preserve_release_download_baseline.sh "$TAG_NAME" release-notes.md
-            gh release upload "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg --clobber
+            gh release upload "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg SHA256SUMS.txt --clobber
             gh release edit "$TAG_NAME" --title "Neon Vision Editor $TAG_NAME" --notes-file release-notes.md --draft=false
           else
-            gh release create "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg \
+            gh release create "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg SHA256SUMS.txt \
               --title "Neon Vision Editor $TAG_NAME" \
               --notes-file release-notes.md
           fi
@@ -303,7 +309,8 @@ jobs:
             rm -rf "$WORK_DIR"
           }
           trap cleanup_mount EXIT
-          gh release download "$TAG_NAME" -p Neon.Vision.Editor.app.zip -p Neon.Vision.Editor.app.dmg -D "$WORK_DIR"
+          gh release download "$TAG_NAME" -p Neon.Vision.Editor.app.zip -p Neon.Vision.Editor.app.dmg -p SHA256SUMS.txt -D "$WORK_DIR"
+          (cd "$WORK_DIR" && shasum -a 256 -c SHA256SUMS.txt)
           ditto -x -k "$WORK_DIR/Neon.Vision.Editor.app.zip" "$WORK_DIR/extracted"
           /usr/bin/codesign --verify --deep --strict "$WORK_DIR/extracted/Neon Vision Editor.app"
           scripts/ci/verify_icon_payload.sh "$WORK_DIR/extracted/Neon Vision Editor.app"
@@ -332,6 +339,7 @@ jobs:
           set -euo pipefail
           gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.zip" -y || true
           gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.dmg" -y || true
+          gh release delete-asset "$TAG_NAME" "SHA256SUMS.txt" -y || true
           gh release edit "$TAG_NAME" --draft true || true
           echo "Rolled back release asset and marked release as draft due to post-publish verification failure."
 

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -97,6 +97,28 @@ class ReleaseWorkflowTests(unittest.TestCase):
                 permissions = workflow.split("permissions:\n", 1)[1].split("\njobs:\n", 1)[0]
                 self.assertIn("  actions: write\n", permissions)
 
+    def test_fallbacks_publish_an_existing_draft_release(self):
+        workflows = (
+            ".github/workflows/release-notarized.yml",
+            ".github/workflows/release-notarized-selfhosted.yml",
+        )
+        for path in workflows:
+            with self.subTest(workflow=path):
+                workflow = (ROOT / path).read_text()
+                self.assertRegex(workflow, r'gh release edit "\$TAG_NAME"[^\n]*--draft=false')
+
+    def test_fallbacks_publish_and_verify_release_checksums(self):
+        workflows = (
+            ".github/workflows/release-notarized.yml",
+            ".github/workflows/release-notarized-selfhosted.yml",
+        )
+        for path in workflows:
+            with self.subTest(workflow=path):
+                workflow = (ROOT / path).read_text()
+                self.assertIn("shasum -a 256 Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg > SHA256SUMS.txt", workflow)
+                self.assertGreaterEqual(workflow.count("shasum -a 256 -c SHA256SUMS.txt"), 2)
+                self.assertIn('gh release delete-asset "$TAG_NAME" "SHA256SUMS.txt"', workflow)
+
     def test_release_all_forwards_resume_auto_to_both_preparation_calls(self):
         script = (ROOT / "scripts/release_all.sh").read_text()
         self.assertEqual(script.count('prep_cmd+=(--resume)'), 1)


### PR DESCRIPTION
## Summary

- What changed: Makes the self-hosted notarized fallback explicitly publish an existing draft release; both fallback workflows now generate, upload, validate, and roll back `SHA256SUMS.txt`; regression tests cover both invariants.
- Why: Deleting and recreating a still-assetless release tag caused GitHub to retain the release object as a draft. The resume path uploaded and validated its assets but did not clear draft state, so the downstream Homebrew repository received a release API 404.
- Scope: Bugfix / Release
- Linked issue/milestone: v1.7.3

## Validation

- [x] Built on macOS (release run #34583260601 archived and notarized build 1042)
- [x] Built on iOS simulator (v1.7.3 release gate)
- [x] Built on iPad simulator (v1.7.3 release gate)
- [x] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

Expected: updating an existing release makes it public before downstream consumers query it, and all release paths satisfy the public asset verifier.
Actual before fix: the release remained draft after verified assets were uploaded, the Homebrew tap API lookup returned 404, and the fallback omitted the checksum manifest required by the public verifier.

## Checklist

- [x] Accessibility checked (no UI touched)
- [x] Keyboard navigation verified (no UI touched)
- [x] VoiceOver impact evaluated (no UI touched)
- [x] Changelog updated (not user-facing)
- [x] Documentation updated (no behavior/UI documentation change)
- [x] No unrelated refactors

## Risk

- Risk level: Low
- User-facing risk: Existing resumed releases are made public only after assets have passed the preceding archive, notarization, and documentation gates.
- Rollback plan: Revert 287bf14f.
