### PR TITLE
Complete release publication parity

### DIFF
--- a/.github/workflows/release-notarized-selfhosted.yml
+++ b/.github/workflows/release-notarized-selfhosted.yml
@@ -287,6 +287,12 @@ jobs:
           done
           rm -rf "$DMG_STAGE"
 
+      - name: Create release checksums
+        run: |
+          set -euo pipefail
+          shasum -a 256 Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg > SHA256SUMS.txt
+          shasum -a 256 -c SHA256SUMS.txt
+
       - name: Extract changelog section
         env:
           TAG_NAME: ${{ inputs.tag }}
@@ -318,10 +324,10 @@ jobs:
 
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             bash scripts/preserve_release_download_baseline.sh "$TAG_NAME" release-notes.md
-            gh release upload "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg --clobber
-            gh release edit "$TAG_NAME" --title "Neon Vision Editor $TAG_NAME" --notes-file release-notes.md
+            gh release upload "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg SHA256SUMS.txt --clobber
+            gh release edit "$TAG_NAME" --title "Neon Vision Editor $TAG_NAME" --notes-file release-notes.md --draft=false
           else
-            gh release create "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg \
+            gh release create "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg SHA256SUMS.txt \
               --title "Neon Vision Editor $TAG_NAME" \
               --notes-file release-notes.md
           fi
@@ -342,7 +348,8 @@ jobs:
             rm -rf "$WORK_DIR"
           }
           trap cleanup_mount EXIT
-          gh release download "$TAG_NAME" -p Neon.Vision.Editor.app.zip -p Neon.Vision.Editor.app.dmg -D "$WORK_DIR"
+          gh release download "$TAG_NAME" -p Neon.Vision.Editor.app.zip -p Neon.Vision.Editor.app.dmg -p SHA256SUMS.txt -D "$WORK_DIR"
+          (cd "$WORK_DIR" && shasum -a 256 -c SHA256SUMS.txt)
           ditto -x -k "$WORK_DIR/Neon.Vision.Editor.app.zip" "$WORK_DIR/extracted"
           /usr/bin/codesign --verify --deep --strict "$WORK_DIR/extracted/Neon Vision Editor.app"
           scripts/ci/verify_icon_payload.sh "$WORK_DIR/extracted/Neon Vision Editor.app"
@@ -371,6 +378,7 @@ jobs:
           set -euo pipefail
           gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.zip" -y || true
           gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.dmg" -y || true
+          gh release delete-asset "$TAG_NAME" "SHA256SUMS.txt" -y || true
           gh release edit "$TAG_NAME" --draft true || true
           echo "Rolled back release asset and marked release as draft due to post-publish verification failure."
 

--- a/.github/workflows/release-notarized.yml
+++ b/.github/workflows/release-notarized.yml
@@ -248,6 +248,12 @@ jobs:
           done
           rm -rf "$DMG_STAGE"
 
+      - name: Create release checksums
+        run: |
+          set -euo pipefail
+          shasum -a 256 Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg > SHA256SUMS.txt
+          shasum -a 256 -c SHA256SUMS.txt
+
       - name: Extract changelog section
         env:
           TAG_NAME: ${{ inputs.tag }}
@@ -279,10 +285,10 @@ jobs:
 
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             bash scripts/preserve_release_download_baseline.sh "$TAG_NAME" release-notes.md
-            gh release upload "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg --clobber
+            gh release upload "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg SHA256SUMS.txt --clobber
             gh release edit "$TAG_NAME" --title "Neon Vision Editor $TAG_NAME" --notes-file release-notes.md --draft=false
           else
-            gh release create "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg \
+            gh release create "$TAG_NAME" Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg SHA256SUMS.txt \
               --title "Neon Vision Editor $TAG_NAME" \
               --notes-file release-notes.md
           fi
@@ -303,7 +309,8 @@ jobs:
             rm -rf "$WORK_DIR"
           }
           trap cleanup_mount EXIT
-          gh release download "$TAG_NAME" -p Neon.Vision.Editor.app.zip -p Neon.Vision.Editor.app.dmg -D "$WORK_DIR"
+          gh release download "$TAG_NAME" -p Neon.Vision.Editor.app.zip -p Neon.Vision.Editor.app.dmg -p SHA256SUMS.txt -D "$WORK_DIR"
+          (cd "$WORK_DIR" && shasum -a 256 -c SHA256SUMS.txt)
           ditto -x -k "$WORK_DIR/Neon.Vision.Editor.app.zip" "$WORK_DIR/extracted"
           /usr/bin/codesign --verify --deep --strict "$WORK_DIR/extracted/Neon Vision Editor.app"
           scripts/ci/verify_icon_payload.sh "$WORK_DIR/extracted/Neon Vision Editor.app"
@@ -332,6 +339,7 @@ jobs:
           set -euo pipefail
           gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.zip" -y || true
           gh release delete-asset "$TAG_NAME" "Neon.Vision.Editor.app.dmg" -y || true
+          gh release delete-asset "$TAG_NAME" "SHA256SUMS.txt" -y || true
           gh release edit "$TAG_NAME" --draft true || true
           echo "Rolled back release asset and marked release as draft due to post-publish verification failure."
 

--- a/release/RELEASE-WORKFLOW.md
+++ b/release/RELEASE-WORKFLOW.md
@@ -1,7 +1,7 @@
 # Release workflow
 
 When asked to make a new release, start from clean `develop` aligned with
-`origin/develop`. The next planned version is **1.7.3**. OS 27 features are
+`origin/develop`. The next planned version is **1.7.4**. OS 27 features are
 part of `develop`; App Store builds must use Xcode 27 or later so their
 SDK-qualified sources are included, while older SDK builds retain compatibility.
 
@@ -23,7 +23,7 @@ the GitHub release version or a pending review submission.
 ## Offline rehearsal
 
 ```bash
-bash scripts/release_all.sh v1.7.3 --dry-run
+bash scripts/release_all.sh v1.7.4 --dry-run
 python3 scripts/ci/test_release_workflow.py
 ```
 
@@ -101,14 +101,14 @@ Manual non-Cloud App Store uploads also need separate coordination.
 
 1. Fetch and review `develop`, the proposed version, the diff since the previous
    tag, the closed release milestone and the release notes.
-2. Run `bash scripts/release_prep.sh v1.7.3`. This creates a sibling worktree on
-   `release/1.7.3`, writes `release/prepared-release.json`, generates documentation
+2. Run `bash scripts/release_prep.sh v1.7.4`. This creates a sibling worktree on
+   `release/1.7.4`, writes `release/prepared-release.json`, generates documentation
    and makes a signed commit. The original checkout stays unchanged.
 3. Review the worktree. Repeating preparation reuses its source, date and build.
    If interrupted, inspect the preserved worktree before using `--resume`.
    That explicit option regenerates release-owned files only; unrelated edits
    block it. Changed develop or a conflicting date requires manual reconciliation.
-4. For the complete authorized release, run `bash scripts/release_all.sh v1.7.3
+4. For the complete authorized release, run `bash scripts/release_all.sh v1.7.4
    --github-hosted`. Preparation is followed by documentation and platform/release
    gates before pushing the protected main PR. Existing prepared work is reused.
 5. After the PR merges, dispatch the hosted workflow with the exact merge SHA.

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -97,6 +97,28 @@ class ReleaseWorkflowTests(unittest.TestCase):
                 permissions = workflow.split("permissions:\n", 1)[1].split("\njobs:\n", 1)[0]
                 self.assertIn("  actions: write\n", permissions)
 
+    def test_fallbacks_publish_an_existing_draft_release(self):
+        workflows = (
+            ".github/workflows/release-notarized.yml",
+            ".github/workflows/release-notarized-selfhosted.yml",
+        )
+        for path in workflows:
+            with self.subTest(workflow=path):
+                workflow = (ROOT / path).read_text()
+                self.assertRegex(workflow, r'gh release edit "\$TAG_NAME"[^\n]*--draft=false')
+
+    def test_fallbacks_publish_and_verify_release_checksums(self):
+        workflows = (
+            ".github/workflows/release-notarized.yml",
+            ".github/workflows/release-notarized-selfhosted.yml",
+        )
+        for path in workflows:
+            with self.subTest(workflow=path):
+                workflow = (ROOT / path).read_text()
+                self.assertIn("shasum -a 256 Neon.Vision.Editor.app.zip Neon.Vision.Editor.app.dmg > SHA256SUMS.txt", workflow)
+                self.assertGreaterEqual(workflow.count("shasum -a 256 -c SHA256SUMS.txt"), 2)
+                self.assertIn('gh release delete-asset "$TAG_NAME" "SHA256SUMS.txt"', workflow)
+
     def test_release_all_forwards_resume_auto_to_both_preparation_calls(self):
         script = (ROOT / "scripts/release_all.sh").read_text()
         self.assertEqual(script.count('prep_cmd+=(--resume)'), 1)


### PR DESCRIPTION
## Summary

- What changed: Promotes the reviewed release-publication parity fix from develop to main. Both notarized fallback workflows publish existing drafts and include the checksum manifest expected by the public release verifier. The completed-release runbook now advances to v1.7.4.
- Why: The v1.7.3 recovery exposed two fallback-only differences: the self-hosted path retained draft state, and both fallback paths omitted `SHA256SUMS.txt`.
- Scope: Bugfix / Release
- Linked issue/milestone: v1.7.3

## Validation

- [x] Built on macOS
- [x] Built on iOS simulator
- [x] Built on iPad simulator
- [x] Tested key flow manually
- [x] Repro steps included (for bug/regression fixes)
- [x] Expected vs actual behavior documented (for bug/regression fixes)

Validation on PR #456: Xcode 27 full platform matrix passed in 15m54s; preflight, macOS syntax regressions, GitGuardian, and offline release workflow tests passed. The published v1.7.3 ZIP and DMG also pass checksums, strict code signing, stapler validation, and icon checks.

## Checklist

- [x] Accessibility checked (no UI touched)
- [x] Keyboard navigation verified (no UI touched)
- [x] VoiceOver impact evaluated (no UI touched)
- [x] Changelog updated (not user-facing)
- [x] Documentation updated (post-release documentation sync completed)
- [x] No unrelated refactors

## Risk

- Risk level: Low
- User-facing risk: The workflow publishes only after archive, notarization, documentation, and package gates; checksum verification tightens the existing contract.
- Rollback plan: Revert 05ef53a2.
