### PR TITLE
Fix macOS tab dragging and editor scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ## [Unreleased]
 
+### Why Upgrade
+
+- Restores reliable drag-to-reorder behavior for native macOS document tabs.
+- Makes large-document scrolling smoother by keeping ordinary scroll events on AppKit's composited path.
+- Keeps the editor and minimap synchronized without repeating imperceptible viewport updates.
+
+### Highlights
+
+- Reuses prepared Core Text rows across fine-grained scrolling while retaining an ahead-of-viewport render window.
+
+### Fixes
+
+- Prevents native tab items from being treated as draggable window background instead of receiving their own reorder gesture.
+- Stops ordinary macOS editor scrolling from invalidating the complete canvas and rebuilding visual rows for subpoint movement.
+- Coalesces editor viewport publications and avoids duplicate SwiftUI minimap state updates.
+
+### Breaking changes
+
+- None.
+
+### Migration
+
+- None.
+
 ## [v1.7.4] - 2026-09-11
 
 ### Why Upgrade

--- a/Neon Vision Editor/UI/CodeMinimapView.swift
+++ b/Neon Vision Editor/UI/CodeMinimapView.swift
@@ -456,7 +456,9 @@ struct CodeMinimapView: View {
                   idString == documentID.uuidString,
                   let top = notification.userInfo?[EditorCommandUserInfo.viewportTopFraction] as? Double,
                   let height = notification.userInfo?[EditorCommandUserInfo.viewportHeightFraction] as? Double else { return }
-            viewport = CodeMinimapViewport(topFraction: top, heightFraction: height)
+            let nextViewport = CodeMinimapViewport(topFraction: top, heightFraction: height)
+            guard viewport != nextViewport else { return }
+            viewport = nextViewport
             EditorPerformanceMonitor.shared.endMinimapViewportUpdate(tabID: documentID)
         }
         .onAppear {

--- a/Neon Vision Editor/UI/MacNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MacNativeFileTabBar.swift
@@ -408,6 +408,7 @@ private final class MacNativeFileTabItemView: NSView, NSDraggingSource {
 
     override var isFlipped: Bool { true }
     override var acceptsFirstResponder: Bool { true }
+    override var mouseDownCanMoveWindow: Bool { false }
 
     override func keyDown(with event: NSEvent) {
         switch event.keyCode {

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -349,6 +349,59 @@ enum VirtualEditorScrollAnchorPolicy {
     }
 }
 
+struct VirtualEditorVisualRowsCacheKey: Equatable {
+    let configuration: String
+    let contentRevision: Int?
+    let externalContentRevision: Int?
+    let viewportLineOrigin: Int
+    let availableWidthInHalfPoints: Int
+    let lineHeightInHundredths: Int
+}
+
+enum VirtualEditorVisualRowWindowPolicy {
+    /// Keeps one full viewport of rows prepared beyond the visible bottom. The
+    /// coverage boundary advances one page at a time, so subpoint scrolling
+    /// never invalidates an otherwise reusable Core Text row snapshot.
+    static func coveredMaxY(
+        visibleMaxY: CGFloat,
+        viewportHeight: CGFloat,
+        lineHeight: CGFloat
+    ) -> CGFloat {
+        let safeLineHeight = max(1, lineHeight)
+        let rowsPerPage = max(1, Int(ceil(max(safeLineHeight, viewportHeight) / safeLineHeight)))
+        let requiredRow = max(1, Int(ceil((max(0, visibleMaxY) + max(safeLineHeight, viewportHeight)) / safeLineHeight)))
+        let coveredRows = Int(ceil(Double(requiredRow) / Double(rowsPerPage))) * rowsPerPage
+        return CGFloat(coveredRows) * safeLineHeight
+    }
+}
+
+struct VirtualEditorViewportPublicationSnapshot: Equatable {
+    let documentIdentifier: String?
+    let topFraction: Double
+    let heightFraction: Double
+}
+
+enum VirtualEditorViewportPublicationPolicy {
+    static let minimumFractionDelta = 0.001
+
+    static func shouldPublish(
+        previous: VirtualEditorViewportPublicationSnapshot?,
+        next: VirtualEditorViewportPublicationSnapshot,
+        force: Bool = false
+    ) -> Bool {
+        guard !force, let previous else { return true }
+        guard previous.documentIdentifier == next.documentIdentifier else { return true }
+        return abs(previous.topFraction - next.topFraction) >= minimumFractionDelta ||
+            abs(previous.heightFraction - next.heightFraction) >= minimumFractionDelta
+    }
+}
+
+enum VirtualEditorCanvasInvalidationPolicy {
+    static func requiresFullInvalidation(didReloadViewport: Bool, didResize: Bool) -> Bool {
+        didReloadViewport || didResize
+    }
+}
+
 /// The macOS production editor surface. It intentionally does not use NSTextView
 /// or TextKit: only a bounded EditorDocument viewport is decoded and laid out.
 struct VirtualEditorView: NSViewRepresentable {
@@ -608,6 +661,8 @@ final class VirtualEditorScrollView: NSScrollView {
     private var isSplitPaneResizeInProgress = false
     private var viewportGeometryRetryCount = 0
     private var isViewportGeometryRetryScheduled = false
+    private var isViewportPublicationScheduled = false
+    private var lastPublishedViewport: VirtualEditorViewportPublicationSnapshot?
     var focusesEditorOnInitialWindowAttachment = false
     private var didRequestInitialEditorFocus = false
 
@@ -666,7 +721,7 @@ final class VirtualEditorScrollView: NSScrollView {
     @objc private func handleEditorViewportRequest(_ notification: Notification) {
         guard let requestedID = notification.userInfo?[EditorCommandUserInfo.documentID] as? String,
               requestedID == canvas.documentIdentifier else { return }
-        publishViewport()
+        publishViewport(force: true)
     }
 
     override func magnify(with event: NSEvent) {
@@ -804,6 +859,10 @@ final class VirtualEditorScrollView: NSScrollView {
     }
 
     @objc private func boundsDidChange() {
+        updateForVisibleBoundsChange()
+    }
+
+    func updateForVisibleBoundsChange() {
         let scrollY = contentView.bounds.minY
         let didScroll = abs(scrollY - canvas.lastScrollY) >= 0.5
         let didResize: Bool
@@ -820,30 +879,52 @@ final class VirtualEditorScrollView: NSScrollView {
         let previousViewportOrigin = canvas.viewportLineOrigin
         canvas.reloadViewportIfNeeded(scrollY: scrollY)
         let didReloadViewport = previousViewportOrigin != canvas.viewportLineOrigin
-        if didReloadViewport || didResize {
+        if VirtualEditorCanvasInvalidationPolicy.requiresFullInvalidation(
+            didReloadViewport: didReloadViewport,
+            didResize: didResize
+        ) {
             canvas.recalculateVisualMetrics()
             canvas.setFrameSize(NSSize(width: canvas.contentWidth, height: canvas.logicalHeight))
             canvas.lastReloadAnchorLine = canvas.viewportLineOrigin
+            // Viewport replacement and geometry changes alter pixels. Ordinary
+            // scrolling only moves the clip view across the existing canvas.
+            canvas.needsLayout = true
+            canvas.needsDisplay = true
+            reflectScrolledClipView(contentView)
         }
-        // A bounded viewport replacement invalidates the canvas while the clip
-        // view is scrolling. Let AppKit coalesce the redraw with its normal
-        // layout transaction instead of forcing synchronous layout and display
-        // work into the scroll callback.
-        canvas.needsLayout = true
-        canvas.needsDisplay = true
-        reflectScrolledClipView(contentView)
-        publishViewport()
+        scheduleViewportPublication()
     }
 
-    private func publishViewport() {
+    private func scheduleViewportPublication() {
+        guard !isViewportPublicationScheduled else { return }
+        isViewportPublicationScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isViewportPublicationScheduled = false
+            self.publishViewport()
+        }
+    }
+
+    private func publishViewport(force: Bool = false) {
         let maximum = max(1, canvas.logicalHeight - contentView.bounds.height)
+        let next = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: canvas.documentIdentifier,
+            topFraction: Double(contentView.bounds.minY / maximum),
+            heightFraction: Double(contentView.bounds.height / max(1, canvas.logicalHeight))
+        )
+        guard VirtualEditorViewportPublicationPolicy.shouldPublish(
+            previous: lastPublishedViewport,
+            next: next,
+            force: force
+        ) else { return }
+        lastPublishedViewport = next
         NotificationCenter.default.post(
             name: .editorViewportDidChange,
             object: nil,
             userInfo: [
-                EditorCommandUserInfo.documentID: canvas.documentIdentifier as Any,
-                EditorCommandUserInfo.viewportTopFraction: Double(contentView.bounds.minY / maximum),
-                EditorCommandUserInfo.viewportHeightFraction: Double(contentView.bounds.height / max(1, canvas.logicalHeight))
+                EditorCommandUserInfo.documentID: next.documentIdentifier as Any,
+                EditorCommandUserInfo.viewportTopFraction: next.topFraction,
+                EditorCommandUserInfo.viewportHeightFraction: next.heightFraction
             ]
         )
     }
@@ -957,7 +1038,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private var layoutCache: [Int: CTLine] = [:]
     private var attributedLineCache: [Int: NSAttributedString] = [:]
     private var visualFragmentCache = VirtualEditorVisualFragmentCache()
-    private var visualRowsSnapshot: (key: String, rows: [VisualRow])?
+    private var visualRowsSnapshot: (key: VirtualEditorVisualRowsCacheKey, coveredMaxY: CGFloat, rows: [VisualRow])?
     private var syntaxSpansByLine: [Int: [VirtualEditorSyntaxSpan]] = [:]
     private(set) var syntaxHighlightTask: Task<Void, Never>?
     private var deferredViewportTask: Task<Void, Never>?
@@ -1712,16 +1793,23 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         // metrics have been recalculated. The viewport is the current editor
         // allocation and is therefore the authoritative wrapping width.
         let availableWidth = max(1, viewportSize.width - gutterWidth - 16)
-        let snapshotKey = [
-            lastConfigurationKey,
-            String(configuredContentRevision ?? 0),
-            String(configuredExternalContentRevision ?? 0),
-            String(viewportLineOrigin),
-            String(Int((availableWidth * 2).rounded())),
-            String(Int(((enclosingScrollView?.contentView.bounds.maxY ?? viewportSize.height) * 2).rounded())),
-            String(Int((lineHeight * 100).rounded()))
-        ].joined(separator: "|")
-        if let visualRowsSnapshot, visualRowsSnapshot.key == snapshotKey {
+        let snapshotKey = VirtualEditorVisualRowsCacheKey(
+            configuration: lastConfigurationKey,
+            contentRevision: configuredContentRevision,
+            externalContentRevision: configuredExternalContentRevision,
+            viewportLineOrigin: viewportLineOrigin,
+            availableWidthInHalfPoints: Int((availableWidth * 2).rounded()),
+            lineHeightInHundredths: Int((lineHeight * 100).rounded())
+        )
+        let visibleBounds = enclosingScrollView?.contentView.bounds
+        let coveredMaxY = VirtualEditorVisualRowWindowPolicy.coveredMaxY(
+            visibleMaxY: visibleBounds?.maxY ?? viewportSize.height,
+            viewportHeight: visibleBounds?.height ?? viewportSize.height,
+            lineHeight: lineHeight
+        )
+        if let visualRowsSnapshot,
+           visualRowsSnapshot.key == snapshotKey,
+           visualRowsSnapshot.coveredMaxY >= coveredMaxY {
             return visualRowsSnapshot.rows
         }
         var rows: [VisualRow] = []
@@ -1732,8 +1820,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         )
         for viewportLine in viewportLines {
             let estimatedBaseline = baseline
-            let viewportMaxY = (enclosingScrollView?.contentView.bounds.maxY ?? viewportSize.height) + lineHeight * 2
-            if estimatedBaseline > viewportMaxY {
+            if estimatedBaseline > coveredMaxY {
                 break
             }
             let fragments = cachedVisualFragments(
@@ -1753,7 +1840,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
                 baseline += lineHeight
             }
         }
-        visualRowsSnapshot = (snapshotKey, rows)
+        visualRowsSnapshot = (snapshotKey, coveredMaxY, rows)
         return rows
     }
 

--- a/Neon Vision EditorTests/MacNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MacNativeFileTabBarTests.swift
@@ -68,6 +68,17 @@ final class MacNativeFileTabBarTests: XCTestCase {
         XCTAssertEqual(move?.2, false)
     }
 
+    func testTabItemsRejectWindowBackgroundDraggingSoReorderingReceivesMouseDrags() throws {
+        let id = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.apply(tabs: [snapshot(id: id, title: "Document")], selectedTabID: id)
+
+        let tabItem = try XCTUnwrap(view.descendants.first {
+            NSStringFromClass(type(of: $0)).contains("MacNativeFileTabItemView")
+        })
+        XCTAssertFalse(tabItem.mouseDownCanMoveWindow)
+    }
+
     func testKeyboardAdjacentSelectionUsesOrderedTabsAndStopsAtEdges() {
         let firstID = UUID()
         let secondID = UUID()
@@ -242,6 +253,12 @@ final class MacNativeFileTabBarTests: XCTestCase {
             isRemote: false,
             isReadOnly: false
         )
+    }
+}
+
+private extension NSView {
+    var descendants: [NSView] {
+        subviews + subviews.flatMap(\.descendants)
     }
 }
 #endif

--- a/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
+++ b/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
@@ -658,6 +658,90 @@ final class VirtualEditorLayoutTests: XCTestCase {
         )
     }
 
+    func testOrdinaryScrollDoesNotRequireWholeCanvasInvalidation() {
+        XCTAssertFalse(VirtualEditorCanvasInvalidationPolicy.requiresFullInvalidation(
+            didReloadViewport: false,
+            didResize: false
+        ))
+        XCTAssertTrue(VirtualEditorCanvasInvalidationPolicy.requiresFullInvalidation(
+            didReloadViewport: true,
+            didResize: false
+        ))
+        XCTAssertTrue(VirtualEditorCanvasInvalidationPolicy.requiresFullInvalidation(
+            didReloadViewport: false,
+            didResize: true
+        ))
+    }
+
+    func testOrdinaryBoundsChangeLeavesCanvasLayoutAndDisplayValid() throws {
+        let scrollView = VirtualEditorScrollView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        scrollView.layoutSubtreeIfNeeded()
+        scrollView.updateForVisibleBoundsChange()
+        let canvas = try XCTUnwrap(scrollView.documentView as? VirtualEditorCanvas)
+
+        scrollView.contentView.postsBoundsChangedNotifications = false
+        scrollView.contentView.setBoundsOrigin(NSPoint(x: 0, y: 1))
+        canvas.needsLayout = false
+        canvas.needsDisplay = false
+        scrollView.updateForVisibleBoundsChange()
+
+        XCTAssertFalse(canvas.needsLayout)
+        XCTAssertFalse(canvas.needsDisplay)
+    }
+
+    func testVisualRowCoverageIsStableAcrossSubpointScrolling() {
+        let first = VirtualEditorVisualRowWindowPolicy.coveredMaxY(
+            visibleMaxY: 550,
+            viewportHeight: 600,
+            lineHeight: 20
+        )
+        let next = VirtualEditorVisualRowWindowPolicy.coveredMaxY(
+            visibleMaxY: 550.5,
+            viewportHeight: 600,
+            lineHeight: 20
+        )
+
+        XCTAssertEqual(first, next)
+        XCTAssertGreaterThanOrEqual(first, 1_150)
+        XCTAssertEqual(first.truncatingRemainder(dividingBy: 20), 0)
+    }
+
+    func testViewportPublicationIgnoresImperceptibleMovementButNotDocumentChanges() {
+        let previous = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: "first",
+            topFraction: 0.25,
+            heightFraction: 0.1
+        )
+        let subthreshold = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: "first",
+            topFraction: 0.2505,
+            heightFraction: 0.1
+        )
+        let visibleMovement = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: "first",
+            topFraction: 0.251,
+            heightFraction: 0.1
+        )
+        let differentDocument = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: "second",
+            topFraction: 0.2505,
+            heightFraction: 0.1
+        )
+
+        XCTAssertFalse(VirtualEditorViewportPublicationPolicy.shouldPublish(
+            previous: previous,
+            next: subthreshold
+        ))
+        XCTAssertTrue(VirtualEditorViewportPublicationPolicy.shouldPublish(
+            previous: previous,
+            next: visibleMovement
+        ))
+        XCTAssertTrue(VirtualEditorViewportPublicationPolicy.shouldPublish(
+            previous: previous,
+            next: differentDocument
+        ))
+    }
+
     func testVisualRowEstimateSmoothingIsBoundedAndExplicit() {
         XCTAssertEqual(
             VirtualEditorVisualRowIndex.smoothedEstimate(previous: 1, observed: 3),

--- a/release/RELEASE-WORKFLOW.md
+++ b/release/RELEASE-WORKFLOW.md
@@ -1,7 +1,7 @@
 # Release workflow
 
 When asked to make a new release, start from clean `develop` aligned with
-`origin/develop`. The next planned version is **1.7.4**. OS 27 features are
+`origin/develop`. The next planned version is **1.7.5**. OS 27 features are
 part of `develop`; App Store builds must use Xcode 27 or later so their
 SDK-qualified sources are included, while older SDK builds retain compatibility.
 
@@ -23,7 +23,7 @@ the GitHub release version or a pending review submission.
 ## Offline rehearsal
 
 ```bash
-bash scripts/release_all.sh v1.7.4 --dry-run
+bash scripts/release_all.sh v1.7.5 --dry-run
 python3 scripts/ci/test_release_workflow.py
 ```
 
@@ -103,14 +103,14 @@ Manual non-Cloud App Store uploads also need separate coordination.
    tag and the release notes. Move every issue that remains open in the release
    milestone to the next planned version milestone without closing the issue,
    then close the emptied release milestone before running the release gate.
-2. Run `bash scripts/release_prep.sh v1.7.4`. This creates a sibling worktree on
-   `release/1.7.4`, writes `release/prepared-release.json`, generates documentation
+2. Run `bash scripts/release_prep.sh v1.7.5`. This creates a sibling worktree on
+   `release/1.7.5`, writes `release/prepared-release.json`, generates documentation
    and makes a signed commit. The original checkout stays unchanged.
 3. Review the worktree. Repeating preparation reuses its source, date and build.
    If interrupted, inspect the preserved worktree before using `--resume`.
    That explicit option regenerates release-owned files only; unrelated edits
    block it. Changed develop or a conflicting date requires manual reconciliation.
-4. For the complete authorized release, run `bash scripts/release_all.sh v1.7.4
+4. For the complete authorized release, run `bash scripts/release_all.sh v1.7.5
    --github-hosted`. Preparation is followed by documentation and platform/release
    gates before pushing the protected main PR. Existing prepared work is reused.
 5. After the PR merges, dispatch the hosted workflow with the exact merge SHA.

--- a/scripts/prepare_release_docs.py
+++ b/scripts/prepare_release_docs.py
@@ -597,6 +597,7 @@ def rebuild_changelog_page(page: str, changelog: str, current_tag: str) -> str:
 
 LOCALIZED_TIMELINE_COPY = {
     "de": {
+        "v1.7.5": ("Flüssigeres Scrollen und zuverlässige Tabs", "Hält feine Scrollbewegungen auf dem schnellen AppKit-Pfad, vermeidet redundante Minimap-Aktualisierungen und stellt das Verschieben nativer macOS-Tabs wieder her.", ["Editor", "Leistung", "Tabs"]),
         "v1.7.4": ("Flüssigere Projektvorschauen", "Aktualisiert Markdown- und PDF-Projektkarten in begrenzten Gruppen und vermeidet redundante SwiftUI-Aktualisierungen für jede indizierte Datei.", ["Vorschau", "Leistung", "Projekte"]),
         "v1.7.3": ("Bereit für macOS 27 und schnellere Einstellungen", "Aktiviert Agent Mode in Xcode-27-Builds, reduziert redundante Arbeit bei Themes und Tabs und vereinheitlicht System-Glass-Flächen unter visionOS.", ["macOS 27", "Leistung", "Themes"]),
         "v1.7.2": ("Schnellere Tabs und konsistente Editorflächen", "Verbessert mobile Tabs, Toolbar- und AI-Seitenleistenflächen, verhindert macOS-Auswahlfehler beim Fensterziehen und startet die Syntaxhervorhebung beim Tabwechsel früher.", ["Tabs", "Editor", "Leistung"]),
@@ -624,6 +625,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor und Snapshots werden verlässlicher", "Verbessert Auswahl, Tastaturnavigation und Themes im macOS-Editor und erweitert den Code-Snapshot-Export.", ["Editor", "Themes", "Snapshots"]),
     },
     "da": {
+        "v1.7.5": ("Mere flydende rulning og pålidelige faner", "Holder fine rullebevægelser på den hurtige AppKit-sti, undgår overflødige minimap-opdateringer og gendanner flytning af native macOS-faner.", ["Editor", "Ydeevne", "Faner"]),
         "v1.7.4": ("Mere flydende projektvisninger", "Opdaterer Markdown- og PDF-projektkort i afgrænsede grupper og undgår overflødige SwiftUI-opdateringer for hver indekseret fil.", ["Forhåndsvisning", "Ydeevne", "Projekter"]),
         "v1.7.3": ("Klar til macOS 27 og hurtigere indstillinger", "Aktiverer Agent Mode i Xcode 27-builds, reducerer overflødigt arbejde ved tema- og faneskift og ensretter System Glass-flader på visionOS.", ["macOS 27", "Ydeevne", "Temaer"]),
         "v1.7.2": ("Hurtigere faner og ensartede editorflader", "Forbedrer mobile faner, værktøjslinjer og AI-sidepaneler, forhindrer markeringsfejl ved vinduesflytning på macOS og starter syntaksfarver tidligere ved faneskift.", ["Faner", "Editor", "Ydeevne"]),
@@ -651,6 +653,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor og snapshots bliver mere pålidelige", "Forbedrer markering, tastaturnavigation og temaer i macOS-editoren og udvider eksporten af kodesnapshots.", ["Editor", "Temaer", "Snapshots"]),
     },
     "fr": {
+        "v1.7.5": ("Défilement plus fluide et onglets fiables", "Conserve les petits défilements sur le chemin AppKit rapide, évite les mises à jour redondantes de la minicarte et rétablit le déplacement des onglets natifs macOS.", ["Éditeur", "Performances", "Onglets"]),
         "v1.7.4": ("Aperçus de projet plus fluides", "Actualise les cartes de projet Markdown et PDF par lots limités et évite les mises à jour SwiftUI redondantes pour chaque fichier indexé.", ["Aperçu", "Performances", "Projets"]),
         "v1.7.3": ("Prêt pour macOS 27 et réglages plus rapides", "Active le mode Agent dans les builds Xcode 27, réduit le travail superflu lors des changements de thème et d’onglet et harmonise les surfaces System Glass sur visionOS.", ["macOS 27", "Performances", "Thèmes"]),
         "v1.7.2": ("Onglets plus rapides et surfaces cohérentes", "Améliore les onglets mobiles, les barres d’outils et les panneaux AI, évite les sélections involontaires lors du déplacement d’une fenêtre macOS et lance plus tôt la coloration syntaxique.", ["Onglets", "Éditeur", "Performances"]),
@@ -678,6 +681,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Éditeur et instantanés plus fiables", "Améliore la sélection, la navigation au clavier et les thèmes dans l’éditeur macOS, tout en enrichissant l’export d’instantanés de code.", ["Éditeur", "Thèmes", "Instantanés"]),
     },
     "es": {
+        "v1.7.5": ("Desplazamiento más fluido y pestañas fiables", "Mantiene los pequeños desplazamientos en la ruta rápida de AppKit, evita actualizaciones redundantes del minimapa y restaura el movimiento de pestañas nativas de macOS.", ["Editor", "Rendimiento", "Pestañas"]),
         "v1.7.4": ("Vistas previas de proyecto más fluidas", "Actualiza las tarjetas de proyecto Markdown y PDF en lotes limitados y evita actualizaciones redundantes de SwiftUI por cada archivo indexado.", ["Vista previa", "Rendimiento", "Proyectos"]),
         "v1.7.3": ("Preparado para macOS 27 y ajustes más rápidos", "Activa el modo Agente en builds con Xcode 27, reduce el trabajo redundante al cambiar temas y pestañas y unifica las superficies System Glass en visionOS.", ["macOS 27", "Rendimiento", "Temas"]),
         "v1.7.2": ("Pestañas más rápidas y superficies coherentes", "Mejora las pestañas móviles, las barras y los paneles de IA, evita selecciones involuntarias al mover ventanas en macOS e inicia antes el resaltado de sintaxis.", ["Pestañas", "Editor", "Rendimiento"]),
@@ -705,6 +709,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor y capturas más fiables", "Mejora la selección, la navegación por teclado y los temas del editor de macOS, y amplía la exportación de capturas de código.", ["Editor", "Temas", "Capturas"]),
     },
     "ja": {
+        "v1.7.5": ("より滑らかなスクロールと確実なタブ操作", "細かなスクロールを高速な AppKit 経路で処理し、不要なミニマップ更新を避け、macOS のネイティブタブ移動を復元します。", ["エディタ", "パフォーマンス", "タブ"]),
         "v1.7.4": ("より滑らかなプロジェクトプレビュー", "Markdown と PDF のプロジェクトカードを制限された単位で更新し、インデックスされたファイルごとの不要な SwiftUI 更新を防ぎます。", ["プレビュー", "パフォーマンス", "プロジェクト"]),
         "v1.7.3": ("macOS 27 対応と設定操作の高速化", "Xcode 27 ビルドで Agent Mode を有効にし、テーマとタブ切り替え時の不要な処理を減らし、visionOS の System Glass 表示を統一します。", ["macOS 27", "パフォーマンス", "テーマ"]),
         "v1.7.2": ("高速なタブ切り替えと一貫したエディタ表示", "モバイルタブ、ツールバー、AI サイドバーを改善し、macOS のウインドウ移動時の意図しない選択を防ぎ、タブ切り替え時の構文色表示を早めます。", ["タブ", "エディタ", "パフォーマンス"]),
@@ -732,6 +737,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("エディタとスナップショットをさらに信頼性向上", "macOS エディタの選択、キーボード操作、テーマを改善し、コードスナップショットの書き出しを拡充します。", ["エディタ", "テーマ", "スナップショット"]),
     },
     "zh-Hans": {
+        "v1.7.5": ("更流畅的滚动与可靠的标签页", "让细微滚动保持在快速的 AppKit 路径上，避免重复更新小地图，并恢复 macOS 原生标签页拖动排序。", ["编辑器", "性能", "标签页"]),
         "v1.7.4": ("更流畅的项目预览", "以有限批次更新 Markdown 和 PDF 项目卡片，避免每个索引文件触发重复的 SwiftUI 刷新。", ["预览", "性能", "项目"]),
         "v1.7.3": ("支持 macOS 27，并提升设置响应速度", "在 Xcode 27 构建中启用 Agent Mode，减少切换主题和标签页时的重复工作，并统一 visionOS 的 System Glass 表面。", ["macOS 27", "性能", "主题"]),
         "v1.7.2": ("更快的标签页与一致的编辑器表面", "改进移动标签页、工具栏和 AI 侧边栏，避免 macOS 拖动窗口时意外选择文本，并在切换标签页时更早启动语法高亮。", ["标签页", "编辑器", "性能"]),


### PR DESCRIPTION
## Summary\n\n- What changed: Restored macOS native tab reordering after the window-drag change; removed per-scroll whole-canvas invalidation, stabilized visual-row caching, and coalesced viewport/minimap updates; added v1.7.5 release notes and localized timeline copy.\n- Why: Tab drags were being consumed as window-background drags, and the editor scroll path was rebuilding and publishing work for fine-grained movement that the preview does not perform.\n- Scope: Bugfix / Release\n- Linked issue/milestone: v1.7.5\n\n## Validation\n\n- [x] Built on macOS\n- [x] Built on iOS simulator\n- [x] Built on iPad simulator\n- [x] Tested key flow manually\n- [x] Repro steps included (for bug/regression fixes)\n- [x] Expected vs actual behavior documented (for bug/regression fixes)\n\nRepro: drag a native macOS document tab after enabling titlebar window dragging; before this change the window-drag behavior consumed the gesture, after it the tab item receives the reorder drag. Scroll a large source document in fine increments; before this change each bounds update invalidated the full canvas and visual-row cache, after it ordinary scrolling reuses the canvas and row window.\n\nValidation completed:\n- Xcode 27 macOS, iOS Simulator, iPad Simulator, and visionOS build matrix\n- VirtualEditorLayoutTests\n- VirtualEditorPerformanceTests\n- Focused AppKit ordinary-scroll invalidation regression test\n- 39 release workflow tests\n- v1.7.5 offline release rehearsal\n- git diff --check\n\n## Checklist\n\n- [x] Accessibility checked (labels, focus order, no traps)\n- [x] Keyboard navigation verified (macOS + iPad keyboard if applicable)\n- [x] VoiceOver impact evaluated (if UI touched)\n- [x] Changelog updated (if user-facing change)\n- [x] Documentation updated (if behavior/UI changed)\n- [x] No unrelated refactors\n\n## Risk\n\n- Risk level: Medium\n- User-facing risk: Scroll invalidation and viewport notification cadence changed on macOS; viewport reloads and resize invalidation remain intact and are regression-tested.\n- Rollback plan: Revert commit a83312ad before release preparation.

## Summary by Sourcery

Restore reliable native macOS tab reordering and make large-document editor scrolling smoother and more efficient.

Bug Fixes:
- Restore native macOS document-tab drag reordering when titlebar window dragging is enabled.
- Improve macOS editor scrolling by avoiding unnecessary full-canvas invalidation and visual-row rebuilding during ordinary fine-grained movement.
- Reduce redundant minimap and editor viewport updates while preserving synchronization for meaningful changes.

Enhancements:
- Stabilize visual-row caching with a reusable ahead-of-viewport coverage window.
- Add v1.7.5 release notes and localized timeline copy.

Documentation:
- Update the release workflow to target version 1.7.5.

Tests:
- Add regression coverage for native tab dragging, ordinary-scroll invalidation, visual-row coverage stability, and viewport publication coalescing.