### PR TITLE
chore(release): prepare v1.7.5

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Neon Vision Editor Architecture
 
-Last updated: 2026-09-11 (v1.7.4 release-aligned architecture)
+Last updated: 2026-09-11 (v1.7.5 release-aligned architecture)
 
 Neon Vision Editor is a native Swift 6 editor for macOS, iOS, iPadOS, and visionOS. The app favors a small editor-first surface: fast file access, lightweight project navigation, native text editing, syntax highlighting, structured document inspection, Markdown/HTML/SVG/PDF/PNG preview, project-level Markdown/PDF cards, Finder Quick Look previews, PDF highlights and attached Markdown notes, Git and terminal helpers on macOS, remote-session clients on supported Apple platforms, and optional contextual AI assistance.
 
@@ -9,18 +9,17 @@ The visual summary in [`docs/images/architecture-at-a-glance.svg`](docs/images/a
 <!-- RELEASE_ARCHITECTURE_ALIGNMENT:START -->
 ## Current Release Alignment
 
+### v1.7.5 (2026-09-11)
+
+- Reuses prepared Core Text rows across fine-grained scrolling while retaining an ahead-of-viewport render window.
+- Prevents native tab items from being treated as draggable window background instead of receiving their own reorder gesture.
+- Stops ordinary macOS editor scrolling from invalidating the complete canvas and rebuilding visual rows for subpoint movement.
+- Coalesces editor viewport publications and avoids duplicate SwiftUI minimap state updates.
+
 ### v1.7.4 (2026-09-11)
 
 - Updates project-preview cards and progress in bounded batches instead of invalidating the complete panel for every indexed file.
 - Prevents per-file loading-status publications from triggering redundant SwiftUI project-preview refreshes.
-
-### v1.7.3 (2026-09-11)
-
-- Enables the macOS 27 Agent Mode sources in Xcode 27 App Store and notarized builds while preserving runtime availability checks and older-OS compatibility.
-- Validates the application with the macOS, iOS/iPadOS, and visionOS 27 SDKs accepted by App Store Connect.
-- Prevents a theme selection from publishing ten process-wide preference changes and removes unrelated full-window composition work from theme updates.
-- Avoids unnecessary editor highlighting and window-chrome refreshes during macOS settings changes and tab activation.
-- Keeps visionOS System Glass light in light mode and prevents mixed light and dark surfaces in Paper and other appearance themes.
 
 This block is regenerated from `CHANGELOG.md` after each stable release. The sections below remain the authoritative description of ownership and runtime boundaries.
 <!-- RELEASE_ARCHITECTURE_ALIGNMENT:END -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ## [Unreleased]
 
+### Why Upgrade
+
+- Restores reliable drag-to-reorder behavior for native macOS document tabs.
+- Makes large-document scrolling smoother by keeping ordinary scroll events on AppKit's composited path.
+- Keeps the editor and minimap synchronized without repeating imperceptible viewport updates.
+
+### Highlights
+
+- Reuses prepared Core Text rows across fine-grained scrolling while retaining an ahead-of-viewport render window.
+
+### Fixes
+
+- Prevents native tab items from being treated as draggable window background instead of receiving their own reorder gesture.
+- Stops ordinary macOS editor scrolling from invalidating the complete canvas and rebuilding visual rows for subpoint movement.
+- Coalesces editor viewport publications and avoids duplicate SwiftUI minimap state updates.
+
+### Breaking changes
+
+- None.
+
+### Migration
+
+- None.
+
 ## [v1.7.4] - 2026-09-11
 
 ### Why Upgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ## [Unreleased]
 
+## [v1.7.5] - 2026-09-11
+
 ### Why Upgrade
 
 - Restores reliable drag-to-reorder behavior for native macOS document tabs.

--- a/Neon Vision Editor.xcodeproj/project.pbxproj
+++ b/Neon Vision Editor.xcodeproj/project.pbxproj
@@ -752,7 +752,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor App Clip/Neon Vision Editor App Clip.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_PREVIEWS = YES;
@@ -763,7 +763,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -791,7 +791,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_PREVIEWS = YES;
@@ -802,7 +802,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -903,7 +903,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -957,7 +957,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1139,7 +1139,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]" = "Neon Vision Editor/Neon Vision Editor iOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Neon Vision Editor/Neon Vision Editor macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1192,7 +1192,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1306,7 +1306,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1358,7 +1358,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1395,7 +1395,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1409,7 +1409,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				REGISTER_APP_GROUPS = YES;
@@ -1435,7 +1435,7 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Share Extension/Neon Vision Editor Share Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1460,7 +1460,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1490,7 +1490,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = CS727NF72U;
@@ -1516,7 +1516,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1570,7 +1570,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1579,7 +1579,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1600,7 +1600,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1609,7 +1609,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1630,7 +1630,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1638,7 +1638,7 @@
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "h3p.Neon-Vision-Editor";
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1658,7 +1658,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1666,7 +1666,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1686,7 +1686,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1694,7 +1694,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1714,7 +1714,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1722,7 +1722,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1743,13 +1743,13 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				SDKROOT = macosx;
@@ -1768,14 +1768,14 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				SDKROOT = macosx;
@@ -1795,14 +1795,14 @@
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1043;
+				CURRENT_PROJECT_VERSION = 1044;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.4;
+				MARKETING_VERSION = 1.7.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Neon Vision Editor/UI/CodeMinimapView.swift
+++ b/Neon Vision Editor/UI/CodeMinimapView.swift
@@ -456,7 +456,9 @@ struct CodeMinimapView: View {
                   idString == documentID.uuidString,
                   let top = notification.userInfo?[EditorCommandUserInfo.viewportTopFraction] as? Double,
                   let height = notification.userInfo?[EditorCommandUserInfo.viewportHeightFraction] as? Double else { return }
-            viewport = CodeMinimapViewport(topFraction: top, heightFraction: height)
+            let nextViewport = CodeMinimapViewport(topFraction: top, heightFraction: height)
+            guard viewport != nextViewport else { return }
+            viewport = nextViewport
             EditorPerformanceMonitor.shared.endMinimapViewportUpdate(tabID: documentID)
         }
         .onAppear {

--- a/Neon Vision Editor/UI/MacNativeFileTabBar.swift
+++ b/Neon Vision Editor/UI/MacNativeFileTabBar.swift
@@ -408,6 +408,7 @@ private final class MacNativeFileTabItemView: NSView, NSDraggingSource {
 
     override var isFlipped: Bool { true }
     override var acceptsFirstResponder: Bool { true }
+    override var mouseDownCanMoveWindow: Bool { false }
 
     override func keyDown(with event: NSEvent) {
         switch event.keyCode {

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -2787,15 +2787,15 @@ struct WelcomeTourView: View {
 
     private let pages: [TourPage] = [
         TourPage(
-            title: "What’s New in v1.7.4",
-            subtitle: "Release highlights for v1.7.4.",
+            title: "What’s New in v1.7.5",
+            subtitle: "Release highlights for v1.7.5.",
             bullets: [
-                "Editor Performance: Keeps Markdown and PDF project browsing responsive while large preview collections are prepared.",
-                "Workflow Refinements: Reduces avoidable SwiftUI panel invalidations as indexed project files finish loading.",
-                "Performance Updates: Preserves progressive preview feedback while publishing UI changes in bounded batches.",
-                "Usability Updates: Updates project-preview cards and progress in bounded batches instead of invalidating the complete panel for every indexed…",
-                "Editor Improvements: Prevents per-file loading-status publications from triggering redundant SwiftUI project-preview refreshes.",
-                "Workflow Refinements: Completes macOS 27 release readiness while keeping existing deployment targets and runtime availability checks for older…"
+                "Editor Improvements: Restores reliable drag-to-reorder behavior for native macOS document tabs.",
+                "Workflow Refinements: Makes large-document scrolling smoother by keeping ordinary scroll events on AppKit's composited path.",
+                "Performance Updates: Keeps the editor and minimap synchronized without repeating imperceptible viewport updates.",
+                "Usability Updates: Reuses prepared Core Text rows across fine-grained scrolling while retaining an ahead-of-viewport render window.",
+                "Editor Improvements: Prevents native tab items from being treated as draggable window background instead of receiving their own reorder gesture.",
+                "Workflow Refinements: Stops ordinary macOS editor scrolling from invalidating the complete canvas and rebuilding visual rows for subpoint movement."
             ],
             iconName: "sparkles.rectangle.stack",
             colors: [Color(red: 0.40, green: 0.28, blue: 0.90), Color(red: 0.96, green: 0.46, blue: 0.55)],

--- a/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
+++ b/Neon Vision Editor/UI/VirtualEditorView+macOS.swift
@@ -349,6 +349,59 @@ enum VirtualEditorScrollAnchorPolicy {
     }
 }
 
+struct VirtualEditorVisualRowsCacheKey: Equatable {
+    let configuration: String
+    let contentRevision: Int?
+    let externalContentRevision: Int?
+    let viewportLineOrigin: Int
+    let availableWidthInHalfPoints: Int
+    let lineHeightInHundredths: Int
+}
+
+enum VirtualEditorVisualRowWindowPolicy {
+    /// Keeps one full viewport of rows prepared beyond the visible bottom. The
+    /// coverage boundary advances one page at a time, so subpoint scrolling
+    /// never invalidates an otherwise reusable Core Text row snapshot.
+    static func coveredMaxY(
+        visibleMaxY: CGFloat,
+        viewportHeight: CGFloat,
+        lineHeight: CGFloat
+    ) -> CGFloat {
+        let safeLineHeight = max(1, lineHeight)
+        let rowsPerPage = max(1, Int(ceil(max(safeLineHeight, viewportHeight) / safeLineHeight)))
+        let requiredRow = max(1, Int(ceil((max(0, visibleMaxY) + max(safeLineHeight, viewportHeight)) / safeLineHeight)))
+        let coveredRows = Int(ceil(Double(requiredRow) / Double(rowsPerPage))) * rowsPerPage
+        return CGFloat(coveredRows) * safeLineHeight
+    }
+}
+
+struct VirtualEditorViewportPublicationSnapshot: Equatable {
+    let documentIdentifier: String?
+    let topFraction: Double
+    let heightFraction: Double
+}
+
+enum VirtualEditorViewportPublicationPolicy {
+    static let minimumFractionDelta = 0.001
+
+    static func shouldPublish(
+        previous: VirtualEditorViewportPublicationSnapshot?,
+        next: VirtualEditorViewportPublicationSnapshot,
+        force: Bool = false
+    ) -> Bool {
+        guard !force, let previous else { return true }
+        guard previous.documentIdentifier == next.documentIdentifier else { return true }
+        return abs(previous.topFraction - next.topFraction) >= minimumFractionDelta ||
+            abs(previous.heightFraction - next.heightFraction) >= minimumFractionDelta
+    }
+}
+
+enum VirtualEditorCanvasInvalidationPolicy {
+    static func requiresFullInvalidation(didReloadViewport: Bool, didResize: Bool) -> Bool {
+        didReloadViewport || didResize
+    }
+}
+
 /// The macOS production editor surface. It intentionally does not use NSTextView
 /// or TextKit: only a bounded EditorDocument viewport is decoded and laid out.
 struct VirtualEditorView: NSViewRepresentable {
@@ -608,6 +661,8 @@ final class VirtualEditorScrollView: NSScrollView {
     private var isSplitPaneResizeInProgress = false
     private var viewportGeometryRetryCount = 0
     private var isViewportGeometryRetryScheduled = false
+    private var isViewportPublicationScheduled = false
+    private var lastPublishedViewport: VirtualEditorViewportPublicationSnapshot?
     var focusesEditorOnInitialWindowAttachment = false
     private var didRequestInitialEditorFocus = false
 
@@ -666,7 +721,7 @@ final class VirtualEditorScrollView: NSScrollView {
     @objc private func handleEditorViewportRequest(_ notification: Notification) {
         guard let requestedID = notification.userInfo?[EditorCommandUserInfo.documentID] as? String,
               requestedID == canvas.documentIdentifier else { return }
-        publishViewport()
+        publishViewport(force: true)
     }
 
     override func magnify(with event: NSEvent) {
@@ -804,6 +859,10 @@ final class VirtualEditorScrollView: NSScrollView {
     }
 
     @objc private func boundsDidChange() {
+        updateForVisibleBoundsChange()
+    }
+
+    func updateForVisibleBoundsChange() {
         let scrollY = contentView.bounds.minY
         let didScroll = abs(scrollY - canvas.lastScrollY) >= 0.5
         let didResize: Bool
@@ -820,30 +879,52 @@ final class VirtualEditorScrollView: NSScrollView {
         let previousViewportOrigin = canvas.viewportLineOrigin
         canvas.reloadViewportIfNeeded(scrollY: scrollY)
         let didReloadViewport = previousViewportOrigin != canvas.viewportLineOrigin
-        if didReloadViewport || didResize {
+        if VirtualEditorCanvasInvalidationPolicy.requiresFullInvalidation(
+            didReloadViewport: didReloadViewport,
+            didResize: didResize
+        ) {
             canvas.recalculateVisualMetrics()
             canvas.setFrameSize(NSSize(width: canvas.contentWidth, height: canvas.logicalHeight))
             canvas.lastReloadAnchorLine = canvas.viewportLineOrigin
+            // Viewport replacement and geometry changes alter pixels. Ordinary
+            // scrolling only moves the clip view across the existing canvas.
+            canvas.needsLayout = true
+            canvas.needsDisplay = true
+            reflectScrolledClipView(contentView)
         }
-        // A bounded viewport replacement invalidates the canvas while the clip
-        // view is scrolling. Let AppKit coalesce the redraw with its normal
-        // layout transaction instead of forcing synchronous layout and display
-        // work into the scroll callback.
-        canvas.needsLayout = true
-        canvas.needsDisplay = true
-        reflectScrolledClipView(contentView)
-        publishViewport()
+        scheduleViewportPublication()
     }
 
-    private func publishViewport() {
+    private func scheduleViewportPublication() {
+        guard !isViewportPublicationScheduled else { return }
+        isViewportPublicationScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isViewportPublicationScheduled = false
+            self.publishViewport()
+        }
+    }
+
+    private func publishViewport(force: Bool = false) {
         let maximum = max(1, canvas.logicalHeight - contentView.bounds.height)
+        let next = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: canvas.documentIdentifier,
+            topFraction: Double(contentView.bounds.minY / maximum),
+            heightFraction: Double(contentView.bounds.height / max(1, canvas.logicalHeight))
+        )
+        guard VirtualEditorViewportPublicationPolicy.shouldPublish(
+            previous: lastPublishedViewport,
+            next: next,
+            force: force
+        ) else { return }
+        lastPublishedViewport = next
         NotificationCenter.default.post(
             name: .editorViewportDidChange,
             object: nil,
             userInfo: [
-                EditorCommandUserInfo.documentID: canvas.documentIdentifier as Any,
-                EditorCommandUserInfo.viewportTopFraction: Double(contentView.bounds.minY / maximum),
-                EditorCommandUserInfo.viewportHeightFraction: Double(contentView.bounds.height / max(1, canvas.logicalHeight))
+                EditorCommandUserInfo.documentID: next.documentIdentifier as Any,
+                EditorCommandUserInfo.viewportTopFraction: next.topFraction,
+                EditorCommandUserInfo.viewportHeightFraction: next.heightFraction
             ]
         )
     }
@@ -957,7 +1038,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
     private var layoutCache: [Int: CTLine] = [:]
     private var attributedLineCache: [Int: NSAttributedString] = [:]
     private var visualFragmentCache = VirtualEditorVisualFragmentCache()
-    private var visualRowsSnapshot: (key: String, rows: [VisualRow])?
+    private var visualRowsSnapshot: (key: VirtualEditorVisualRowsCacheKey, coveredMaxY: CGFloat, rows: [VisualRow])?
     private var syntaxSpansByLine: [Int: [VirtualEditorSyntaxSpan]] = [:]
     private(set) var syntaxHighlightTask: Task<Void, Never>?
     private var deferredViewportTask: Task<Void, Never>?
@@ -1712,16 +1793,23 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         // metrics have been recalculated. The viewport is the current editor
         // allocation and is therefore the authoritative wrapping width.
         let availableWidth = max(1, viewportSize.width - gutterWidth - 16)
-        let snapshotKey = [
-            lastConfigurationKey,
-            String(configuredContentRevision ?? 0),
-            String(configuredExternalContentRevision ?? 0),
-            String(viewportLineOrigin),
-            String(Int((availableWidth * 2).rounded())),
-            String(Int(((enclosingScrollView?.contentView.bounds.maxY ?? viewportSize.height) * 2).rounded())),
-            String(Int((lineHeight * 100).rounded()))
-        ].joined(separator: "|")
-        if let visualRowsSnapshot, visualRowsSnapshot.key == snapshotKey {
+        let snapshotKey = VirtualEditorVisualRowsCacheKey(
+            configuration: lastConfigurationKey,
+            contentRevision: configuredContentRevision,
+            externalContentRevision: configuredExternalContentRevision,
+            viewportLineOrigin: viewportLineOrigin,
+            availableWidthInHalfPoints: Int((availableWidth * 2).rounded()),
+            lineHeightInHundredths: Int((lineHeight * 100).rounded())
+        )
+        let visibleBounds = enclosingScrollView?.contentView.bounds
+        let coveredMaxY = VirtualEditorVisualRowWindowPolicy.coveredMaxY(
+            visibleMaxY: visibleBounds?.maxY ?? viewportSize.height,
+            viewportHeight: visibleBounds?.height ?? viewportSize.height,
+            lineHeight: lineHeight
+        )
+        if let visualRowsSnapshot,
+           visualRowsSnapshot.key == snapshotKey,
+           visualRowsSnapshot.coveredMaxY >= coveredMaxY {
             return visualRowsSnapshot.rows
         }
         var rows: [VisualRow] = []
@@ -1732,8 +1820,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
         )
         for viewportLine in viewportLines {
             let estimatedBaseline = baseline
-            let viewportMaxY = (enclosingScrollView?.contentView.bounds.maxY ?? viewportSize.height) + lineHeight * 2
-            if estimatedBaseline > viewportMaxY {
+            if estimatedBaseline > coveredMaxY {
                 break
             }
             let fragments = cachedVisualFragments(
@@ -1753,7 +1840,7 @@ final class VirtualEditorCanvas: NSView, NSTextInputClient {
                 baseline += lineHeight
             }
         }
-        visualRowsSnapshot = (snapshotKey, rows)
+        visualRowsSnapshot = (snapshotKey, coveredMaxY, rows)
         return rows
     }
 

--- a/Neon Vision EditorTests/MacNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MacNativeFileTabBarTests.swift
@@ -68,6 +68,17 @@ final class MacNativeFileTabBarTests: XCTestCase {
         XCTAssertEqual(move?.2, false)
     }
 
+    func testTabItemsRejectWindowBackgroundDraggingSoReorderingReceivesMouseDrags() throws {
+        let id = UUID()
+        let view = MacNativeFileTabBarView(frame: NSRect(x: 0, y: 0, width: 600, height: 42))
+        view.apply(tabs: [snapshot(id: id, title: "Document")], selectedTabID: id)
+
+        let tabItem = try XCTUnwrap(view.descendants.first {
+            NSStringFromClass(type(of: $0)).contains("MacNativeFileTabItemView")
+        })
+        XCTAssertFalse(tabItem.mouseDownCanMoveWindow)
+    }
+
     func testKeyboardAdjacentSelectionUsesOrderedTabsAndStopsAtEdges() {
         let firstID = UUID()
         let secondID = UUID()
@@ -242,6 +253,12 @@ final class MacNativeFileTabBarTests: XCTestCase {
             isRemote: false,
             isReadOnly: false
         )
+    }
+}
+
+private extension NSView {
+    var descendants: [NSView] {
+        subviews + subviews.flatMap(\.descendants)
     }
 }
 #endif

--- a/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
+++ b/Neon Vision EditorTests/VirtualEditorLayoutTests.swift
@@ -658,6 +658,90 @@ final class VirtualEditorLayoutTests: XCTestCase {
         )
     }
 
+    func testOrdinaryScrollDoesNotRequireWholeCanvasInvalidation() {
+        XCTAssertFalse(VirtualEditorCanvasInvalidationPolicy.requiresFullInvalidation(
+            didReloadViewport: false,
+            didResize: false
+        ))
+        XCTAssertTrue(VirtualEditorCanvasInvalidationPolicy.requiresFullInvalidation(
+            didReloadViewport: true,
+            didResize: false
+        ))
+        XCTAssertTrue(VirtualEditorCanvasInvalidationPolicy.requiresFullInvalidation(
+            didReloadViewport: false,
+            didResize: true
+        ))
+    }
+
+    func testOrdinaryBoundsChangeLeavesCanvasLayoutAndDisplayValid() throws {
+        let scrollView = VirtualEditorScrollView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        scrollView.layoutSubtreeIfNeeded()
+        scrollView.updateForVisibleBoundsChange()
+        let canvas = try XCTUnwrap(scrollView.documentView as? VirtualEditorCanvas)
+
+        scrollView.contentView.postsBoundsChangedNotifications = false
+        scrollView.contentView.setBoundsOrigin(NSPoint(x: 0, y: 1))
+        canvas.needsLayout = false
+        canvas.needsDisplay = false
+        scrollView.updateForVisibleBoundsChange()
+
+        XCTAssertFalse(canvas.needsLayout)
+        XCTAssertFalse(canvas.needsDisplay)
+    }
+
+    func testVisualRowCoverageIsStableAcrossSubpointScrolling() {
+        let first = VirtualEditorVisualRowWindowPolicy.coveredMaxY(
+            visibleMaxY: 550,
+            viewportHeight: 600,
+            lineHeight: 20
+        )
+        let next = VirtualEditorVisualRowWindowPolicy.coveredMaxY(
+            visibleMaxY: 550.5,
+            viewportHeight: 600,
+            lineHeight: 20
+        )
+
+        XCTAssertEqual(first, next)
+        XCTAssertGreaterThanOrEqual(first, 1_150)
+        XCTAssertEqual(first.truncatingRemainder(dividingBy: 20), 0)
+    }
+
+    func testViewportPublicationIgnoresImperceptibleMovementButNotDocumentChanges() {
+        let previous = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: "first",
+            topFraction: 0.25,
+            heightFraction: 0.1
+        )
+        let subthreshold = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: "first",
+            topFraction: 0.2505,
+            heightFraction: 0.1
+        )
+        let visibleMovement = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: "first",
+            topFraction: 0.251,
+            heightFraction: 0.1
+        )
+        let differentDocument = VirtualEditorViewportPublicationSnapshot(
+            documentIdentifier: "second",
+            topFraction: 0.2505,
+            heightFraction: 0.1
+        )
+
+        XCTAssertFalse(VirtualEditorViewportPublicationPolicy.shouldPublish(
+            previous: previous,
+            next: subthreshold
+        ))
+        XCTAssertTrue(VirtualEditorViewportPublicationPolicy.shouldPublish(
+            previous: previous,
+            next: visibleMovement
+        ))
+        XCTAssertTrue(VirtualEditorViewportPublicationPolicy.shouldPublish(
+            previous: previous,
+            next: differentDocument
+        ))
+    }
+
     func testVisualRowEstimateSmoothingIsBoundedAndExplicit() {
         XCTAssertEqual(
             VirtualEditorVisualRowIndex.smoothedEstimate(previous: 1, observed: 3),

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <p align="center"><a href="https://apps-h3p.com"><img alt="Docs on h3p apps" src="https://img.shields.io/badge/Docs-h3p%20apps-111827?style=for-the-badge"></a><a href="https://buymeacoffee.com/h3pdesign"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a-Coffee-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=111827"></a><a href="https://www.patreon.com/h3p"><img alt="Support on Patreon" src="https://img.shields.io/badge/Support%20on-Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white"></a><a href="https://www.paypal.com/paypalme/HilthartPedersen"><img alt="Support via PayPal" src="https://img.shields.io/badge/Support%20via-PayPal-0070BA?style=for-the-badge&logo=paypal&logoColor=white"></a></p>
 
+> Prepared release: **v1.7.5** — not published. See [candidate notes](CHANGELOG.md).
+
 <p align="center">
   <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases"><img alt="Latest Release" src="https://img.shields.io/badge/release-v1.7.4-0A84FF"></a>
   <a href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965"><img alt="Platforms" src="https://img.shields.io/badge/platforms-macOS%20%7C%20iOS%20%7C%20iPadOS%20%7C%20visionOS-0A84FF"></a>

--- a/release/RELEASE-WORKFLOW.md
+++ b/release/RELEASE-WORKFLOW.md
@@ -1,7 +1,7 @@
 # Release workflow
 
 When asked to make a new release, start from clean `develop` aligned with
-`origin/develop`. The next planned version is **1.7.4**. OS 27 features are
+`origin/develop`. The next planned version is **1.7.5**. OS 27 features are
 part of `develop`; App Store builds must use Xcode 27 or later so their
 SDK-qualified sources are included, while older SDK builds retain compatibility.
 
@@ -23,7 +23,7 @@ the GitHub release version or a pending review submission.
 ## Offline rehearsal
 
 ```bash
-bash scripts/release_all.sh v1.7.4 --dry-run
+bash scripts/release_all.sh v1.7.5 --dry-run
 python3 scripts/ci/test_release_workflow.py
 ```
 
@@ -103,14 +103,14 @@ Manual non-Cloud App Store uploads also need separate coordination.
    tag and the release notes. Move every issue that remains open in the release
    milestone to the next planned version milestone without closing the issue,
    then close the emptied release milestone before running the release gate.
-2. Run `bash scripts/release_prep.sh v1.7.4`. This creates a sibling worktree on
-   `release/1.7.4`, writes `release/prepared-release.json`, generates documentation
+2. Run `bash scripts/release_prep.sh v1.7.5`. This creates a sibling worktree on
+   `release/1.7.5`, writes `release/prepared-release.json`, generates documentation
    and makes a signed commit. The original checkout stays unchanged.
 3. Review the worktree. Repeating preparation reuses its source, date and build.
    If interrupted, inspect the preserved worktree before using `--resume`.
    That explicit option regenerates release-owned files only; unrelated edits
    block it. Changed develop or a conflicting date requires manual reconciliation.
-4. For the complete authorized release, run `bash scripts/release_all.sh v1.7.4
+4. For the complete authorized release, run `bash scripts/release_all.sh v1.7.5
    --github-hosted`. Preparation is followed by documentation and platform/release
    gates before pushing the protected main PR. Existing prepared work is reused.
 5. After the PR merges, dispatch the hosted workflow with the exact merge SHA.

--- a/release/prepared-release.json
+++ b/release/prepared-release.json
@@ -1,11 +1,11 @@
 {
-  "tag": "v1.7.4",
-  "source": "0f721a02410624dba23ab2a4759bd4aad15417a1",
+  "tag": "v1.7.5",
+  "source": "1caf1936e0db12af287363d05ce5359332af5e29",
   "date": "2026-09-11",
-  "build": 1043,
-  "published_tag": "v1.7.3",
-  "published_build": 1042,
-  "status": "published",
+  "build": 1044,
+  "published_tag": "v1.7.4",
+  "published_build": 1043,
+  "status": "prepared",
   "cloud": {
     "product_id": "6BA578EC-8F26-47BC-81A9-94246EAF48E0",
     "max_number": 1042

--- a/scripts/prepare_release_docs.py
+++ b/scripts/prepare_release_docs.py
@@ -597,6 +597,7 @@ def rebuild_changelog_page(page: str, changelog: str, current_tag: str) -> str:
 
 LOCALIZED_TIMELINE_COPY = {
     "de": {
+        "v1.7.5": ("Flüssigeres Scrollen und zuverlässige Tabs", "Hält feine Scrollbewegungen auf dem schnellen AppKit-Pfad, vermeidet redundante Minimap-Aktualisierungen und stellt das Verschieben nativer macOS-Tabs wieder her.", ["Editor", "Leistung", "Tabs"]),
         "v1.7.4": ("Flüssigere Projektvorschauen", "Aktualisiert Markdown- und PDF-Projektkarten in begrenzten Gruppen und vermeidet redundante SwiftUI-Aktualisierungen für jede indizierte Datei.", ["Vorschau", "Leistung", "Projekte"]),
         "v1.7.3": ("Bereit für macOS 27 und schnellere Einstellungen", "Aktiviert Agent Mode in Xcode-27-Builds, reduziert redundante Arbeit bei Themes und Tabs und vereinheitlicht System-Glass-Flächen unter visionOS.", ["macOS 27", "Leistung", "Themes"]),
         "v1.7.2": ("Schnellere Tabs und konsistente Editorflächen", "Verbessert mobile Tabs, Toolbar- und AI-Seitenleistenflächen, verhindert macOS-Auswahlfehler beim Fensterziehen und startet die Syntaxhervorhebung beim Tabwechsel früher.", ["Tabs", "Editor", "Leistung"]),
@@ -624,6 +625,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor und Snapshots werden verlässlicher", "Verbessert Auswahl, Tastaturnavigation und Themes im macOS-Editor und erweitert den Code-Snapshot-Export.", ["Editor", "Themes", "Snapshots"]),
     },
     "da": {
+        "v1.7.5": ("Mere flydende rulning og pålidelige faner", "Holder fine rullebevægelser på den hurtige AppKit-sti, undgår overflødige minimap-opdateringer og gendanner flytning af native macOS-faner.", ["Editor", "Ydeevne", "Faner"]),
         "v1.7.4": ("Mere flydende projektvisninger", "Opdaterer Markdown- og PDF-projektkort i afgrænsede grupper og undgår overflødige SwiftUI-opdateringer for hver indekseret fil.", ["Forhåndsvisning", "Ydeevne", "Projekter"]),
         "v1.7.3": ("Klar til macOS 27 og hurtigere indstillinger", "Aktiverer Agent Mode i Xcode 27-builds, reducerer overflødigt arbejde ved tema- og faneskift og ensretter System Glass-flader på visionOS.", ["macOS 27", "Ydeevne", "Temaer"]),
         "v1.7.2": ("Hurtigere faner og ensartede editorflader", "Forbedrer mobile faner, værktøjslinjer og AI-sidepaneler, forhindrer markeringsfejl ved vinduesflytning på macOS og starter syntaksfarver tidligere ved faneskift.", ["Faner", "Editor", "Ydeevne"]),
@@ -651,6 +653,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor og snapshots bliver mere pålidelige", "Forbedrer markering, tastaturnavigation og temaer i macOS-editoren og udvider eksporten af kodesnapshots.", ["Editor", "Temaer", "Snapshots"]),
     },
     "fr": {
+        "v1.7.5": ("Défilement plus fluide et onglets fiables", "Conserve les petits défilements sur le chemin AppKit rapide, évite les mises à jour redondantes de la minicarte et rétablit le déplacement des onglets natifs macOS.", ["Éditeur", "Performances", "Onglets"]),
         "v1.7.4": ("Aperçus de projet plus fluides", "Actualise les cartes de projet Markdown et PDF par lots limités et évite les mises à jour SwiftUI redondantes pour chaque fichier indexé.", ["Aperçu", "Performances", "Projets"]),
         "v1.7.3": ("Prêt pour macOS 27 et réglages plus rapides", "Active le mode Agent dans les builds Xcode 27, réduit le travail superflu lors des changements de thème et d’onglet et harmonise les surfaces System Glass sur visionOS.", ["macOS 27", "Performances", "Thèmes"]),
         "v1.7.2": ("Onglets plus rapides et surfaces cohérentes", "Améliore les onglets mobiles, les barres d’outils et les panneaux AI, évite les sélections involontaires lors du déplacement d’une fenêtre macOS et lance plus tôt la coloration syntaxique.", ["Onglets", "Éditeur", "Performances"]),
@@ -678,6 +681,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Éditeur et instantanés plus fiables", "Améliore la sélection, la navigation au clavier et les thèmes dans l’éditeur macOS, tout en enrichissant l’export d’instantanés de code.", ["Éditeur", "Thèmes", "Instantanés"]),
     },
     "es": {
+        "v1.7.5": ("Desplazamiento más fluido y pestañas fiables", "Mantiene los pequeños desplazamientos en la ruta rápida de AppKit, evita actualizaciones redundantes del minimapa y restaura el movimiento de pestañas nativas de macOS.", ["Editor", "Rendimiento", "Pestañas"]),
         "v1.7.4": ("Vistas previas de proyecto más fluidas", "Actualiza las tarjetas de proyecto Markdown y PDF en lotes limitados y evita actualizaciones redundantes de SwiftUI por cada archivo indexado.", ["Vista previa", "Rendimiento", "Proyectos"]),
         "v1.7.3": ("Preparado para macOS 27 y ajustes más rápidos", "Activa el modo Agente en builds con Xcode 27, reduce el trabajo redundante al cambiar temas y pestañas y unifica las superficies System Glass en visionOS.", ["macOS 27", "Rendimiento", "Temas"]),
         "v1.7.2": ("Pestañas más rápidas y superficies coherentes", "Mejora las pestañas móviles, las barras y los paneles de IA, evita selecciones involuntarias al mover ventanas en macOS e inicia antes el resaltado de sintaxis.", ["Pestañas", "Editor", "Rendimiento"]),
@@ -705,6 +709,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("Editor y capturas más fiables", "Mejora la selección, la navegación por teclado y los temas del editor de macOS, y amplía la exportación de capturas de código.", ["Editor", "Temas", "Capturas"]),
     },
     "ja": {
+        "v1.7.5": ("より滑らかなスクロールと確実なタブ操作", "細かなスクロールを高速な AppKit 経路で処理し、不要なミニマップ更新を避け、macOS のネイティブタブ移動を復元します。", ["エディタ", "パフォーマンス", "タブ"]),
         "v1.7.4": ("より滑らかなプロジェクトプレビュー", "Markdown と PDF のプロジェクトカードを制限された単位で更新し、インデックスされたファイルごとの不要な SwiftUI 更新を防ぎます。", ["プレビュー", "パフォーマンス", "プロジェクト"]),
         "v1.7.3": ("macOS 27 対応と設定操作の高速化", "Xcode 27 ビルドで Agent Mode を有効にし、テーマとタブ切り替え時の不要な処理を減らし、visionOS の System Glass 表示を統一します。", ["macOS 27", "パフォーマンス", "テーマ"]),
         "v1.7.2": ("高速なタブ切り替えと一貫したエディタ表示", "モバイルタブ、ツールバー、AI サイドバーを改善し、macOS のウインドウ移動時の意図しない選択を防ぎ、タブ切り替え時の構文色表示を早めます。", ["タブ", "エディタ", "パフォーマンス"]),
@@ -732,6 +737,7 @@ LOCALIZED_TIMELINE_COPY = {
         "v1.5.0": ("エディタとスナップショットをさらに信頼性向上", "macOS エディタの選択、キーボード操作、テーマを改善し、コードスナップショットの書き出しを拡充します。", ["エディタ", "テーマ", "スナップショット"]),
     },
     "zh-Hans": {
+        "v1.7.5": ("更流畅的滚动与可靠的标签页", "让细微滚动保持在快速的 AppKit 路径上，避免重复更新小地图，并恢复 macOS 原生标签页拖动排序。", ["编辑器", "性能", "标签页"]),
         "v1.7.4": ("更流畅的项目预览", "以有限批次更新 Markdown 和 PDF 项目卡片，避免每个索引文件触发重复的 SwiftUI 刷新。", ["预览", "性能", "项目"]),
         "v1.7.3": ("支持 macOS 27，并提升设置响应速度", "在 Xcode 27 构建中启用 Agent Mode，减少切换主题和标签页时的重复工作，并统一 visionOS 的 System Glass 表面。", ["macOS 27", "性能", "主题"]),
         "v1.7.2": ("更快的标签页与一致的编辑器表面", "改进移动标签页、工具栏和 AI 侧边栏，避免 macOS 拖动窗口时意外选择文本，并在切换标签页时更早启动语法高亮。", ["标签页", "编辑器", "性能"]),


### PR DESCRIPTION
Prepared from develop 1caf1936e0db12af287363d05ce5359332af5e29. Build 1044. Publication remains gated by signed archive and notarization checks.

## Summary by Sourcery

Prepare the v1.7.5 release with smoother editor scrolling, more efficient viewport updates, and reliable native tab reordering.

Bug Fixes:
- Restore reliable drag-to-reorder behavior for native macOS document tabs.
- Prevent ordinary macOS editor scrolling from triggering unnecessary full-canvas invalidation and visual-row rebuilding.
- Avoid redundant minimap updates and coalesce editor viewport publications.

Enhancements:
- Reuse prepared Core Text rows across fine-grained scrolling while maintaining an ahead-of-viewport render window.

Build:
- Prepare the v1.7.5 release metadata and project version updates.

Documentation:
- Update release-aligned architecture, changelog, release workflow, localized release copy, and release-preparation status for v1.7.5.

Tests:
- Add coverage for native tab dragging, scroll invalidation, visual-row coverage stability, and viewport publication thresholds.