### PR TITLE
Sync v1.7.6 release back into develop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Neon Vision Editor Architecture
 
-Last updated: 2026-09-11 (v1.7.5 release-aligned architecture)
+Last updated: 2026-09-12 (v1.7.6 release-aligned architecture)
 
 Neon Vision Editor is a native Swift 6 editor for macOS, iOS, iPadOS, and visionOS. The app favors a small editor-first surface: fast file access, lightweight project navigation, native text editing, syntax highlighting, structured document inspection, Markdown/HTML/SVG/PDF/PNG preview, project-level Markdown/PDF cards, Finder Quick Look previews, PDF highlights and attached Markdown notes, Git and terminal helpers on macOS, remote-session clients on supported Apple platforms, and optional contextual AI assistance.
 
@@ -9,17 +9,17 @@ The visual summary in [`docs/images/architecture-at-a-glance.svg`](docs/images/a
 <!-- RELEASE_ARCHITECTURE_ALIGNMENT:START -->
 ## Current Release Alignment
 
+### v1.7.6 (2026-09-12)
+
+- Repaints only the visible Core Text canvas region during ordinary scrolling, preserving the fast virtualized layout path.
+- Prevents stale AppKit backing pixels from covering or clipping editor lines during macOS scrolling.
+
 ### v1.7.5 (2026-09-11)
 
 - Reuses prepared Core Text rows across fine-grained scrolling while retaining an ahead-of-viewport render window.
 - Prevents native tab items from being treated as draggable window background instead of receiving their own reorder gesture.
 - Stops ordinary macOS editor scrolling from invalidating the complete canvas and rebuilding visual rows for subpoint movement.
 - Coalesces editor viewport publications and avoids duplicate SwiftUI minimap state updates.
-
-### v1.7.4 (2026-09-11)
-
-- Updates project-preview cards and progress in bounded batches instead of invalidating the complete panel for every indexed file.
-- Prevents per-file loading-status publications from triggering redundant SwiftUI project-preview refreshes.
 
 This block is regenerated from `CHANGELOG.md` after each stable release. The sections below remain the authoritative description of ownership and runtime boundaries.
 <!-- RELEASE_ARCHITECTURE_ALIGNMENT:END -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows *Keep a Changelog*. Versions use semantic versioning with pre
 
 ## [Unreleased]
 
+## [v1.7.6] - 2026-09-12
+
 ### Why Upgrade
 
 - Keeps macOS editor text intact while scrolling long or wrapped documents.

--- a/Neon Vision Editor.xcodeproj/project.pbxproj
+++ b/Neon Vision Editor.xcodeproj/project.pbxproj
@@ -752,7 +752,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor App Clip/Neon Vision Editor App Clip.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_PREVIEWS = YES;
@@ -763,7 +763,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -791,7 +791,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_PREVIEWS = YES;
@@ -802,7 +802,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.6.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -903,7 +903,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -957,7 +957,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1139,7 +1139,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]" = "Neon Vision Editor/Neon Vision Editor iOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Neon Vision Editor/Neon Vision Editor macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1192,7 +1192,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1306,7 +1306,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1358,7 +1358,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor";
 				PRODUCT_NAME = "Neon Vision Editor";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1395,7 +1395,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -1409,7 +1409,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				REGISTER_APP_GROUPS = YES;
@@ -1435,7 +1435,7 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Share Extension/Neon Vision Editor Share Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
@@ -1460,7 +1460,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1490,7 +1490,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = CS727NF72U;
@@ -1516,7 +1516,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.ShareExtension";
 				PRODUCT_NAME = "Neon Vision Editor Share Extension";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1570,7 +1570,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1579,7 +1579,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1600,7 +1600,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1609,7 +1609,7 @@
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1630,7 +1630,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Watch App/Neon Pulse Watch App.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Neon Vision Editor Pulse";
@@ -1638,7 +1638,7 @@
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "h3p.Neon-Vision-Editor";
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = YES;
 				INFOPLIST_KEY_WKWatchKitApp = YES;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp";
 				PRODUCT_NAME = "Neon Pulse";
 				SDKROOT = watchos;
@@ -1658,7 +1658,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1666,7 +1666,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1686,7 +1686,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1694,7 +1694,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1714,7 +1714,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Pulse Widget/Neon Pulse Widget.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist.widget;
@@ -1722,7 +1722,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.watchkitapp.NeonPulseWidget";
 				PRODUCT_NAME = "Neon Pulse Widget";
 				SDKROOT = watchos;
@@ -1743,13 +1743,13 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				SDKROOT = macosx;
@@ -1768,14 +1768,14 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				SDKROOT = macosx;
@@ -1795,14 +1795,14 @@
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1044;
+				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = "Neon Vision Editor Quick Look/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 1.7.5;
+				MARKETING_VERSION = 1.7.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "h3p.Neon-Vision-Editor.QuickLook";
 				PRODUCT_NAME = "Neon Vision Editor Quick Look";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -2787,15 +2787,15 @@ struct WelcomeTourView: View {
 
     private let pages: [TourPage] = [
         TourPage(
-            title: "What’s New in v1.7.5",
-            subtitle: "Release highlights for v1.7.5.",
+            title: "What’s New in v1.7.6",
+            subtitle: "Release highlights for v1.7.6.",
             bullets: [
-                "Editor Improvements: Restores reliable drag-to-reorder behavior for native macOS document tabs.",
-                "Workflow Refinements: Makes large-document scrolling smoother by keeping ordinary scroll events on AppKit's composited path.",
-                "Performance Updates: Keeps the editor and minimap synchronized without repeating imperceptible viewport updates.",
-                "Usability Updates: Reuses prepared Core Text rows across fine-grained scrolling while retaining an ahead-of-viewport render window.",
-                "Editor Improvements: Prevents native tab items from being treated as draggable window background instead of receiving their own reorder gesture.",
-                "Workflow Refinements: Stops ordinary macOS editor scrolling from invalidating the complete canvas and rebuilding visual rows for subpoint movement."
+                "Editor Improvements: Keeps macOS editor text intact while scrolling long or wrapped documents.",
+                "Workflow Refinements: Restores reliable line rendering when scrolling with the Markdown preview and sidebars open.",
+                "Performance Updates: Preserves the virtual editor's bounded layout and redraw behavior while repairing ordinary scroll updates.",
+                "Usability Updates: Repaints only the visible Core Text canvas region during ordinary scrolling, preserving the fast virtualized layout path.",
+                "Editor Improvements: Prevents stale AppKit backing pixels from covering or clipping editor lines during macOS scrolling.",
+                "Workflow Refinements: Restores reliable drag-to-reorder behavior for native macOS document tabs."
             ],
             iconName: "sparkles.rectangle.stack",
             colors: [Color(red: 0.40, green: 0.28, blue: 0.90), Color(red: 0.96, green: 0.46, blue: 0.55)],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <p align="center"><a href="https://apps-h3p.com"><img alt="Docs on h3p apps" src="https://img.shields.io/badge/Docs-h3p%20apps-111827?style=for-the-badge"></a><a href="https://buymeacoffee.com/h3pdesign"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a-Coffee-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=111827"></a><a href="https://www.patreon.com/h3p"><img alt="Support on Patreon" src="https://img.shields.io/badge/Support%20on-Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white"></a><a href="https://www.paypal.com/paypalme/HilthartPedersen"><img alt="Support via PayPal" src="https://img.shields.io/badge/Support%20via-PayPal-0070BA?style=for-the-badge&logo=paypal&logoColor=white"></a></p>
 
+> Prepared release: **v1.7.6** — not published. See [candidate notes](CHANGELOG.md).
+
 <p align="center">
   <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases"><img alt="Latest Release" src="https://img.shields.io/badge/release-v1.7.5-0A84FF"></a>
   <a href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965"><img alt="Platforms" src="https://img.shields.io/badge/platforms-macOS%20%7C%20iOS%20%7C%20iPadOS%20%7C%20visionOS-0A84FF"></a>

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@
 
 > Status: **active release**  
 > Latest release: **v1.7.5**
-> Next release target: **v1.7.6**
+> Next release target: **v1.7.7**
 > Platform target: **macOS 26 (Tahoe)** compatible with **macOS Sequoia**
 > Apple Silicon: tested / Intel: not tested
-> Direct GitHub release: **v1.7.5** / App Store and TestFlight availability varies by platform and review status
-> Last updated (README): **2026-09-12** for latest release **v1.7.5**
+> Direct GitHub release: **v1.7.6** / App Store and TestFlight availability varies by platform and review status
+> Last updated (README): **2026-09-12** for latest release **v1.7.6**
 
 ## What's New in v1.7.4 and v1.7.5
 
@@ -221,11 +221,11 @@ The direct GitHub release is currently ahead of the iOS/iPadOS App Store version
 
 | Channel | Platform | Best For | Download | Release Track | Notes |
 |---|---|---|---|---|---|
-| **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.7.5** | Current direct download |
-| **Store** | iOS / iPadOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.7.1** | Current public App Store listing |
-| **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.7.5** | In Apple review |
+| **Stable** | macOS | Direct notarized builds and fastest stable updates | [GitHub Releases](https://github.com/h3pdesign/Neon-Vision-Editor/releases) | **v1.7.6** | Current direct download |
+| **Store** | iOS / iPadOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.7.2** | Current public App Store listing |
+| **Store Review** | macOS | Corrected App Store update | App Store Connect review | **v1.7.6** | In Apple review |
 | **Store** | visionOS | Apple-managed installs and updates | [Neon Vision Editor on the App Store](https://apps.apple.com/de/app/neon-vision-editor/id6758950965) | **v1.6.1** | Current recorded visionOS listing |
-| **Beta** | iOS / iPadOS / macOS | Testing upcoming changes before stable | [TestFlight Invite](https://testflight.apple.com/join/YWB2fGAP) | **v1.7.5** | Early access builds for feedback; availability may vary by review state |
+| **Beta** | iOS / iPadOS / macOS | Testing upcoming changes before stable | [TestFlight Invite](https://testflight.apple.com/join/YWB2fGAP) | **v1.7.6** | Early access builds for feedback; availability may vary by review state |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <p align="center"><a href="https://apps-h3p.com"><img alt="Docs on h3p apps" src="https://img.shields.io/badge/Docs-h3p%20apps-111827?style=for-the-badge"></a><a href="https://buymeacoffee.com/h3pdesign"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a-Coffee-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=111827"></a><a href="https://www.patreon.com/h3p"><img alt="Support on Patreon" src="https://img.shields.io/badge/Support%20on-Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white"></a><a href="https://www.paypal.com/paypalme/HilthartPedersen"><img alt="Support via PayPal" src="https://img.shields.io/badge/Support%20via-PayPal-0070BA?style=for-the-badge&logo=paypal&logoColor=white"></a></p>
 
-> Prepared release: **v1.7.6** — not published. See [candidate notes](CHANGELOG.md).
-
 <p align="center">
-  <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases"><img alt="Latest Release" src="https://img.shields.io/badge/release-v1.7.5-0A84FF"></a>
+  <a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases"><img alt="Latest Release" src="https://img.shields.io/badge/release-v1.7.6-0A84FF"></a>
   <a href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965"><img alt="Platforms" src="https://img.shields.io/badge/platforms-macOS%20%7C%20iOS%20%7C%20iPadOS%20%7C%20visionOS-0A84FF"></a>
   <a href="https://github.com/h3pdesign/Neon-Vision-Editor/actions/workflows/release-github-only.yml"><img alt="Primary Release" src="https://img.shields.io/github/actions/workflow/status/h3pdesign/Neon-Vision-Editor/release-github-only.yml?branch=main&label=Primary%20Release"></a>
   <a href="https://github.com/h3pdesign/Neon-Vision-Editor/blob/main/SECURITY.md"><img alt="Security Policy" src="https://img.shields.io/badge/security-policy-22C55E"></a>
@@ -54,16 +52,26 @@
 </p>
 
 > Status: **active release**  
-> Latest release: **v1.7.5**
+> Latest release: **v1.7.6**
 > Next release target: **v1.7.7**
 > Platform target: **macOS 26 (Tahoe)** compatible with **macOS Sequoia**
 > Apple Silicon: tested / Intel: not tested
 > Direct GitHub release: **v1.7.6** / App Store and TestFlight availability varies by platform and review status
 > Last updated (README): **2026-09-12** for latest release **v1.7.6**
 
-## What's New in v1.7.4 and v1.7.5
+## What's New in v1.7.5 and v1.7.6
 
 ### Why Upgrade
+
+- v1.7.6: Keeps macOS editor text intact while scrolling long or wrapped documents.
+- v1.7.6: Restores reliable line rendering when scrolling with the Markdown preview and sidebars open.
+- v1.7.6: Preserves the virtual editor's bounded layout and redraw behavior while repairing ordinary scroll updates.
+
+### v1.7.6 Highlights
+
+- Repaints only the visible Core Text canvas region during ordinary scrolling, preserving the fast virtualized layout path.
+
+### v1.7.5 Context
 
 - v1.7.5: Restores reliable drag-to-reorder behavior for native macOS document tabs.
 - v1.7.5: Makes large-document scrolling smoother by keeping ordinary scroll events on AppKit's composited path.
@@ -72,16 +80,6 @@
 ### v1.7.5 Highlights
 
 - Reuses prepared Core Text rows across fine-grained scrolling while retaining an ahead-of-viewport render window.
-
-### v1.7.4 Context
-
-- v1.7.4: Keeps Markdown and PDF project browsing responsive while large preview collections are prepared.
-- v1.7.4: Reduces avoidable SwiftUI panel invalidations as indexed project files finish loading.
-- v1.7.4: Preserves progressive preview feedback while publishing UI changes in bounded batches.
-
-### v1.7.4 Highlights
-
-- Updates project-preview cards and progress in bounded batches instead of invalidating the complete panel for every indexed file.
 
 ## Start Here
 
@@ -141,7 +139,7 @@
         <td><img alt="Stable" src="https://img.shields.io/badge/Stable-22C55E?style=flat-square"></td>
         <td>Direct notarized builds and fastest stable updates</td>
         <td><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases">GitHub Releases</a></td>
-        <td>v1.7.5 release docs current; v1.7.5 direct download current</td>
+        <td>v1.7.6 release docs current; v1.7.6 direct download current</td>
       </tr>
       <tr>
         <td><img alt="Store" src="https://img.shields.io/badge/Store-0A84FF?style=flat-square"></td>
@@ -360,7 +358,7 @@ Platform-specific availability is tracked in the [Platform Matrix](#platform-mat
 - **Languages and structured documents:** Swift 6-ready highlighting includes TeX/LaTeX and Typst/CeTZ-aware editing; CSV/TSV, property lists, Apple crash reports, and recognized logs can switch between structured and raw-text views, and plain text can be transformed into validated JSON through an explicit AI-assisted action.
 - **Project and preview workflows:** project-level Markdown/PDF cards reuse the project index for bounded excerpts and thumbnails, while Markdown, HTML, SVG, PDF, and PNG previews remain integrated with the editor.
 - **macOS integration:** the embedded Quick Look extension previews supported Markdown and source files in Finder, and detached Markdown previews can use the same glass treatment without changing editor content.
-- **Latest stable additions (v1.7.5):** Reuses prepared Core Text rows across fine-grained scrolling while retaining an ahead-of-viewport render window.
+- **Latest stable additions (v1.7.6):** Repaints only the visible Core Text canvas region during ordinary scrolling, preserving the fast virtualized layout path.
 <!-- FEATURE_COVERAGE:END -->
 
 ### Editing Core
@@ -630,7 +628,7 @@ More release integrity details: [Release Integrity](#release-integrity)
 
 | Track | Current Focus | Status |
 |---|---|---|
-| Stable direct download | `v1.7.5` notarized GitHub release | Current |
+| Stable direct download | `v1.7.6` notarized GitHub release | Current |
 | App Store rollout | Platform releases are published independently after App Review | Check the relevant App Store listing |
 | Post-1.4 stabilization | Crash triage, docs freshness, platform polish, App Store/Xcode Cloud release checks | Next patch train |
 | Larger workflow work | Remote workflow hardening, minimap polish, project navigation refinements | Later `v1.5+` work |
@@ -638,19 +636,19 @@ More release integrity details: [Release Integrity](#release-integrity)
 ## Roadmap (Near Term)
 
 <p align="center">
-  <img alt="Now" src="https://img.shields.io/badge/NOW-v1.7.5-22C55E?style=for-the-badge">
-  <img alt="Next" src="https://img.shields.io/badge/NEXT-v1.7.6-F59E0B?style=for-the-badge">
+  <img alt="Now" src="https://img.shields.io/badge/NOW-v1.7.6-22C55E?style=for-the-badge">
+  <img alt="Next" src="https://img.shields.io/badge/NEXT-v1.7.7-F59E0B?style=for-the-badge">
   <img alt="Later" src="https://img.shields.io/badge/LATER-v1.5%2B-0A84FF?style=for-the-badge">
 </p>
 
-### Now (v1.7.5)
+### Now (v1.7.6)
 
 - ![v1.4.0](https://img.shields.io/badge/v1.4.0-22C55E?style=flat-square) delivers file-backed large-document editing, bounded live viewport virtualization, reliable ordinary-file installation, and the release workflow hardening shipped alongside the release.
-  Tracking: [Release v1.7.5](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5)
+  Tracking: [Release v1.7.6](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6)
 
-### Next (v1.7.6)
+### Next (v1.7.7)
 
-- ![v1.7.6](https://img.shields.io/badge/v1.7.6-F59E0B?style=flat-square) targets the reviewed changes listed under Unreleased in CHANGELOG.md; scope is not final until release preparation.
+- ![v1.7.7](https://img.shields.io/badge/v1.7.7-F59E0B?style=flat-square) targets the reviewed changes listed under Unreleased in CHANGELOG.md; scope is not final until release preparation.
   Tracking: [Milestones](https://github.com/h3pdesign/Neon-Vision-Editor/milestones)
 
 ### Later (v1.5+)
@@ -740,7 +738,7 @@ Vim navigation is also available on iPad with a hardware keyboard after enabling
 
 ## Changelog
 
-Latest stable: **v1.7.5** (2026-09-11)
+Latest stable: **v1.7.6** (2026-09-12)
 
 ### Editor Evolution
 
@@ -748,8 +746,6 @@ Latest stable: **v1.7.5** (2026-09-11)
 ```mermaid
 timeline
     title Neon Vision Editor — recent release story
-    9 September 2026 : v1.7.1 · Safer document transitions
-                : Keeps native document tabs, sidebars, editor surfaces, and Settings visually consistent across macOS, iOS, and iPadOS window modes.
     9 September 2026 : v1.7.2 · A more deliberate workflow
                 : Keeps editor chrome responsive and visually consistent across macOS, iOS, and iPadOS.
     11 September 2026 : v1.7.3 · Windows that remember
@@ -758,6 +754,8 @@ timeline
                 : Keeps Markdown and PDF project browsing responsive while large preview collections are prepared.
     11 September 2026 : v1.7.5 · Windows that remember
                 : Restores reliable drag-to-reorder behavior for native macOS document tabs.
+    12 September 2026 : v1.7.6 · A more deliberate workflow
+                : Keeps macOS editor text intact while scrolling long or wrapped documents.
 ```
 <!-- RELEASE_TIMELINE:END -->
 
@@ -767,13 +765,13 @@ The recent release arc is about continuity: files that change outside the app, w
 
 | Release | The editor change | What it protects or enables |
 |---|---|---|
+| [`v1.7.6`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6) | **A more deliberate workflow** — Keeps macOS editor text intact while scrolling long or wrapped documents. | Prevents stale AppKit backing pixels from covering or clipping editor lines during macOS scrolling. |
 | [`v1.7.5`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5) | **Windows that remember** — Restores reliable drag-to-reorder behavior for native macOS document tabs. | Prevents native tab items from being treated as draggable window background instead of receiving their own reorder gesture. |
 | [`v1.7.4`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.4) | **A more deliberate workflow** — Keeps Markdown and PDF project browsing responsive while large preview collections are prepared. | Prevents per-file loading-status publications from triggering redundant SwiftUI project-preview refreshes. |
-| [`v1.7.3`](https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.3) | **Windows that remember** — Completes macOS 27 release readiness while keeping existing deployment targets and runtime availability checks for older systems. | Prevents a theme selection from publishing ten process-wide preference changes and removes unrelated full-window composition work from theme updates. |
 
 - Full release history: [`CHANGELOG.md`](CHANGELOG.md)
-- Latest release: **v1.7.5**
-- Compare recent changes: [v1.7.4...v1.7.5](https://github.com/h3pdesign/Neon-Vision-Editor/compare/v1.7.4...v1.7.5)
+- Latest release: **v1.7.6**
+- Compare recent changes: [v1.7.5...v1.7.6](https://github.com/h3pdesign/Neon-Vision-Editor/compare/v1.7.5...v1.7.6)
 
 ## Known Limitations
 
@@ -795,12 +793,12 @@ The recent release arc is about continuity: files that change outside the app, w
 
 ## Release Integrity
 
-- Tag: `v1.7.5`
+- Tag: `v1.7.6`
 - Tagged commit: release tag target
 - Verify local tag target:
 
 ```bash
-git rev-parse --verify v1.7.5
+git rev-parse --verify v1.7.6
 ```
 
 - Verify downloaded artifact checksum locally:

--- a/appcast.xml
+++ b/appcast.xml
@@ -3,12 +3,12 @@
     <channel>
         <title>Neon Vision Editor</title>
         <item>
-            <title>1.7.5</title>
-            <pubDate>Fri, 11 Sep 2026 13:38:41 +0000</pubDate>
-            <sparkle:version>1044</sparkle:version>
-            <sparkle:shortVersionString>1.7.5</sparkle:shortVersionString>
+            <title>1.7.6</title>
+            <pubDate>Sat, 12 Sep 2026 06:06:31 +0000</pubDate>
+            <sparkle:version>1045</sparkle:version>
+            <sparkle:shortVersionString>1.7.6</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.6</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.zip" length="12796423" type="application/octet-stream" sparkle:edSignature="WqzFSf/ujsk1wCnDI11ygtqYsn7VQp4Y4rorefal0s4qvg31dqIdKNn4vTtDlMr4bqtJ1bcE9tenP09uI5qnDA=="/>
+            <enclosure url="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.zip" length="12795944" type="application/octet-stream" sparkle:edSignature="edhu1xpMLDQ7qnZXiJB4z6sRq3oZgSWNeA66RIYjwS5M4aeDkD1ZtUT3Kox4/H1Z4i1OJIaIXwcuqdhrH2wOBA=="/>
         </item>
     </channel>
 </rss>

--- a/release/prepared-release.json
+++ b/release/prepared-release.json
@@ -5,7 +5,7 @@
   "build": 1045,
   "published_tag": "v1.7.5",
   "published_build": 1044,
-  "status": "prepared",
+  "status": "published",
   "cloud": {
     "product_id": "6BA578EC-8F26-47BC-81A9-94246EAF48E0",
     "max_number": 1044

--- a/release/prepared-release.json
+++ b/release/prepared-release.json
@@ -1,13 +1,13 @@
 {
-  "tag": "v1.7.5",
-  "source": "1caf1936e0db12af287363d05ce5359332af5e29",
-  "date": "2026-09-11",
-  "build": 1044,
-  "published_tag": "v1.7.4",
-  "published_build": 1043,
-  "status": "published",
+  "tag": "v1.7.6",
+  "source": "be8c5d433fce5941cf737d63daf3ab96772b5db6",
+  "date": "2026-09-12",
+  "build": 1045,
+  "published_tag": "v1.7.5",
+  "published_build": 1044,
+  "status": "prepared",
   "cloud": {
     "product_id": "6BA578EC-8F26-47BC-81A9-94246EAF48E0",
-    "max_number": 1042
+    "max_number": 1044
   }
 }

--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -3,12 +3,12 @@
     <channel>
         <title>Neon Vision Editor</title>
         <item>
-            <title>1.7.5</title>
-            <pubDate>Fri, 11 Sep 2026 13:38:41 +0000</pubDate>
-            <sparkle:version>1044</sparkle:version>
-            <sparkle:shortVersionString>1.7.5</sparkle:shortVersionString>
+            <title>1.7.6</title>
+            <pubDate>Sat, 12 Sep 2026 06:06:31 +0000</pubDate>
+            <sparkle:version>1045</sparkle:version>
+            <sparkle:shortVersionString>1.7.6</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.6</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.zip" length="12796423" type="application/octet-stream" sparkle:edSignature="WqzFSf/ujsk1wCnDI11ygtqYsn7VQp4Y4rorefal0s4qvg31dqIdKNn4vTtDlMr4bqtJ1bcE9tenP09uI5qnDA=="/>
+            <enclosure url="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.zip" length="12795944" type="application/octet-stream" sparkle:edSignature="edhu1xpMLDQ7qnZXiJB4z6sRq3oZgSWNeA66RIYjwS5M4aeDkD1ZtUT3Kox4/H1Z4i1OJIaIXwcuqdhrH2wOBA=="/>
         </item>
     </channel>
 </rss>

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -118,7 +118,15 @@
     <section class="timeline" aria-label="Neon Vision Editor changelog">
     <!-- CHANGELOG_ENTRIES:START -->
       <article class="release current">
-        <div class="release-header"><h2>v1.7.5</h2><span class="date">11 September 2026</span><span class="latest">Latest</span></div>
+        <div class="release-header"><h2>v1.7.6</h2><span class="date">12 September 2026</span><span class="latest">Latest</span></div>
+        <div class="items">
+          <div class="item"><span class="badge new">New</span><p>Repaints only the visible Core Text canvas region during ordinary scrolling, preserving the fast virtualized layout path.</p></div>
+          <div class="item"><span class="badge fixed">Fixed</span><p>Prevents stale AppKit backing pixels from covering or clipping editor lines during macOS scrolling.</p></div>
+          <div class="item"><span class="badge breaking">Breaking</span><p>None.</p></div>
+        </div>
+      </article>
+      <article class="release">
+        <div class="release-header"><h2>v1.7.5</h2><span class="date">11 September 2026</span></div>
         <div class="items">
           <div class="item"><span class="badge new">New</span><p>Reuses prepared Core Text rows across fine-grained scrolling while retaining an ahead-of-viewport render window.</p></div>
           <div class="item"><span class="badge fixed">Fixed</span><p>Prevents native tab items from being treated as draggable window background instead of receiving their own reorder gesture.</p></div>

--- a/site/da/index.html
+++ b/site/da/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="da" data-static-release-version="v1.7.5">
+<html lang="da" data-static-release-version="v1.7.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.7.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
+      "softwareVersion": "1.7.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1375,9 +1375,9 @@
         <h1 id="page-title">En sikrere arbejdsgang til tekst, Markdown og kode.</h1>
         <p class="lede">Til Markdown-forfattere og udviklere bevarer Neon Vision Editor fordelene ved en let editor: hurtige filer, tydelig kildekode, komplette forhåndsvisninger og delte dokumenter uden overraskelser.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">Hent til Mac <span class="sr-only">version </span><span data-latest-version>v1.7.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">Hent til Mac <span class="sr-only">version </span><span data-latest-version>v1.7.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Se i App Store</a>
-          <a class="hero-release-link" href="#release-timeline">Nyt i <span data-latest-version>v1.7.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">Nyt i <span data-latest-version>v1.7.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1430,15 +1430,15 @@
           <h3>Notariseret Mac-download</h3>
           <p>Det nyeste stabile direkte build, signeret og notariseret af Apple, med valgfri kommandolinjehjælper.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
-            <span>Build <strong data-latest-build>1044</strong></span>
+            <span data-latest-version>v1.7.6</span>
+            <span>Build <strong data-latest-build>1045</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">
             Hent DMG
           </a>
         </article>
@@ -1448,7 +1448,7 @@
           <h3>Homebrew</h3>
           <p>Installér samme stabile, notariserede macOS-release via det officielle Homebrew-cask.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
+            <span data-latest-version>v1.7.6</span>
             <span>macOS 15+</span>
             <span>Officielt cask</span>
           </div>
@@ -1487,14 +1487,14 @@
             <span>Udgivet gennem den verificerede macOS-releaseproces.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
-          <strong><span data-latest-version>v1.7.5</span> · Build <span data-latest-build>1044</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
+          <strong><span data-latest-version>v1.7.6</span> · Build <span data-latest-build>1045</span></strong>
           <span>Seneste stabile release</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/SHA256SUMS.txt">
           <strong>SHA-256-kontrolsummer</strong>
           <span>Bekræft både ZIP og DMG</span>
         </a>
@@ -1541,7 +1541,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Nyt i v1.4.0</p><h2 id="large-document-editor-title">Store dokumenter forbliver responsive uden at indlæse alt på én gang.</h2><p>Neons macOS-editor arbejder nu direkte med filen på disken og holder et afgrænset virtuelt udsnit omkring den del, du redigerer. Det undgår at genopbygge en komplet dokumentbuffer ved hver ændring og bevarer den normale redigeringsarbejdsgang.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.7.5</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 på macOS med linjenumre, faner og kompakte værktøjslinjer"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Nyt i v1.4.0</p><h2 id="large-document-editor-title">Store dokumenter forbliver responsive uden at indlæse alt på én gang.</h2><p>Neons macOS-editor arbejder nu direkte med filen på disken og holder et afgrænset virtuelt udsnit omkring den del, du redigerer. Det undgår at genopbygge en komplet dokumentbuffer ved hver ændring og bevarer den normale redigeringsarbejdsgang.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.7.6</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 på macOS med linjenumre, faner og kompakte værktøjslinjer"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Filbaseret editorarkitektur</p><h2>Redigér, scroll, vælg og gem uden at genopbygge hele dokumentet.</h2><p>Det virtuelle udsnit følger scrollpositionen og bevarer markør og markering, når det erstatter det aktive vindue. Syntaksarbejde og linjelayout begrænses til det synlige område.</p><p>Kodning, linjeskift, håndtering af eksterne ændringer og atomiske gemninger forbliver i samme filarbejdsgang. Filer på 100 MB eller mere åbnes som en tydeligt mærket skrivebeskyttet delvis forhåndsvisning.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funktioner til store dokumenter"><div class="markdown-feature-point"><strong>Afgrænset udsnit</strong><span>Kun det aktive redigeringsvindue forbliver aktivt i store filer.</span></div><div class="markdown-feature-point"><strong>Synligt arbejde først</strong><span>Linjelayout og syntaksfarvning fokuserer på indholdet på skærmen.</span></div><div class="markdown-feature-point"><strong>Sikker filarbejdsgang</strong><span>Markeringer, kodning, linjeskift, eksterne ændringer og atomiske gemninger bevares.</span></div><div class="markdown-feature-point"><strong>Delvis visning</strong><span>Filer på 100 MB eller mere kan undersøges uden en overdimensioneret editorbuffer.</span></div></div>
     </section>
@@ -1686,7 +1686,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Ny i v1.2.1</p><h2 id="release-1-2-1-title">En klarere værktøjslinje til enhver Apple-enhed.</h2><p>Version 1.2.1 tilføjer platformoptimerede værktøjslinjeforudindstillinger med kompakte symboler og ensartede kontroller på macOS, iPadOS og iOS. Vælg standard-, fokus-, udvikler-, review- eller komplette arbejdsgange fra Indstillinger, mens iOS bevarer sin gennemsigtige statuslinje.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.7.5</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Åbn skærmbilledet af værktøjslinjen i v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Værktøjslinjeforudindstillinger i Neon Vision Editor"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Ny i v1.2.1</p><h2 id="release-1-2-1-title">En klarere værktøjslinje til enhver Apple-enhed.</h2><p>Version 1.2.1 tilføjer platformoptimerede værktøjslinjeforudindstillinger med kompakte symboler og ensartede kontroller på macOS, iPadOS og iOS. Vælg standard-, fokus-, udvikler-, review- eller komplette arbejdsgange fra Indstillinger, mens iOS bevarer sin gennemsigtige statuslinje.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.7.6</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Åbn skærmbilledet af værktøjslinjen i v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Værktøjslinjeforudindstillinger i Neon Vision Editor"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Værktøjslinjeforudindstillinger og layoutstabilitet</p><h2>Vælg de værktøjer, du skal bruge, uden at miste dokumentet.</h2><p>Kompakte etiketter holder macOS- og iPadOS-værktøjslinjer læselige, mens iPhone bruger ikoner først, hvor pladsen er begrænset. Forudindstillinger gør det nemt at skifte mellem daglig redigering, fokuseret skrivning, udvikling, gennemgang og det komplette arbejdsområde.</p><p>Udgivelsen gendanner også den gennemsigtige iOS-statuslinje og navigationsflade uden at ændre det eksisterende editor- eller preview-layout.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funktioner i version 1.2.1"><div class="markdown-feature-point"><strong>Platformstilpassede værktøjslinjer</strong><span>Kompakte, ensartede kontroller til macOS, iPadOS og iOS.</span></div><div class="markdown-feature-point"><strong>Fem forudindstillinger</strong><span>Standard, fokuseret, udvikler, gennemgang og komplet.</span></div><div class="markdown-feature-point"><strong>Tydeligere tilpasning</strong><span>Konfigurer handlinger i værktøjslinje og projektpanel fra Indstillinger.</span></div><div class="markdown-feature-point"><strong>Stabile iOS-flader</strong><span>Bevar den gennemsigtige statuslinje og det eksisterende layout.</span></div></div>
     </section>
@@ -1696,7 +1696,7 @@
         <p class="eyebrow">Nyt i v1.2.0</p>
         <h2 id="release-1-2-title">PDF'er og projektfiler i den samme gennemgangsworkflow.</h2>
         <p>Version 1.2.0 udvider Neon ud over kildefiler og Markdown. PDF'er og PNG'er kan nu indgå i en responsiv projektoversigt, mens PDF-markeringer og tilknyttede Markdown-noter holder research knyttet til det dokument, du læser.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.7.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Hent v1.7.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1752,17 +1752,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.7.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.1">v1.7.1 — Mere stabile vinduer, markering og App Store-builds</a></h3>
-              <span class="release-date">9 September 2026</span>
-            </div>
-            <p>Retter flytning af vinduer, tekstmarkering på iPhone og iPad, velkomstturens udseende og iOS App Store-paketering.</p>
-            <div class="release-tags"><span>Vinduer</span><span>Markering</span><span>App Store</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1795,7 +1784,7 @@
             <div class="release-tags"><span>Forhåndsvisning</span><span>Ydeevne</span><span>Projekter</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1804,6 +1793,17 @@
             </div>
             <p>Holder fine rullebevægelser på den hurtige AppKit-sti, undgår overflødige minimap-opdateringer og gendanner flytning af native macOS-faner.</p>
             <div class="release-tags"><span>Editor</span><span>Ydeevne</span><span>Faner</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.7.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">v1.7.6 — Stabile editorlinjer under rulning</a></h3>
+              <span class="release-date">12 September 2026</span>
+            </div>
+            <p>Gentegner det synlige Core Text-område under rulning og forhindrer overlappende eller afskårne linjer i lange dokumenter med linjeombrydning.</p>
+            <div class="release-tags"><span>Editor</span><span>Rulning</span><span>macOS</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1939,7 +1939,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
           <strong>Release notes</strong>
           <span>Hvad er ændret i den seneste stabile version →</span>
         </a>
@@ -2013,7 +2013,7 @@
       <h2 id="closing-title">En let editor, der respekterer dit igangværende arbejde.</h2>
       <p>Hent den seneste direkte macOS-version, følg udviklingen på GitHub, eller prøv App Store- og TestFlight-versionerne på Apple-enheder.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">Seneste release</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">Seneste release</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/de/index.html
+++ b/site/de/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="de" data-static-release-version="v1.7.5">
+<html lang="de" data-static-release-version="v1.7.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -34,9 +34,9 @@
       "applicationCategory": "DeveloperApplication",
       "description": "Ein nativer Apple-Editor für Klartext, Markdown, HTML, SVG und Quellcode mit Live-Vorschauen, KI-Unterstützung und sicherer Dateisynchronisierung.",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.7.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
+      "softwareVersion": "1.7.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1376,9 +1376,9 @@
         <h1 id="page-title">Ein sicherer Workflow für Text, Markdown und Code.</h1>
         <p class="lede">Neon Vision Editor ist ein fokussierter Apple-Editor für Schreiben und Entwicklung: Markdown, Quellcode und Vorschauen bleiben in einem übersichtlichen Arbeitsbereich, während externe Dateiänderungen Ihre ungespeicherte Arbeit nicht überschreiben.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">Für Mac laden <span class="sr-only">Version </span><span data-latest-version>v1.7.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">Für Mac laden <span class="sr-only">Version </span><span data-latest-version>v1.7.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Im App Store ansehen</a>
-          <a class="hero-release-link" href="#release-timeline">Neu in <span data-latest-version>v1.7.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">Neu in <span data-latest-version>v1.7.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1431,15 +1431,15 @@
           <h3>Notarisierter Mac-Herunterladen</h3>
           <p>Der neueste stabile Direkt-Build, von Apple signiert und notarisiert, mit optionalem Kommandozeilenhelfer.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
-            <span>Build <strong data-latest-build>1044</strong></span>
+            <span data-latest-version>v1.7.6</span>
+            <span>Build <strong data-latest-build>1045</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">
             DMG laden
           </a>
         </article>
@@ -1449,7 +1449,7 @@
           <h3>Homebrew</h3>
           <p>Installieren Sie denselben stabilen, notarisierten macOS-Build über das offizielle Homebrew-Cask.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
+            <span data-latest-version>v1.7.6</span>
             <span>macOS 15+</span>
             <span>Offizielles Cask</span>
           </div>
@@ -1488,14 +1488,14 @@
             <span>Über den geprüften macOS-Release-Weg veröffentlicht.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
-          <strong><span data-latest-version>v1.7.5</span> · Build <span data-latest-build>1044</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
+          <strong><span data-latest-version>v1.7.6</span> · Build <span data-latest-build>1045</span></strong>
           <span>Neuester stabiler Release</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/SHA256SUMS.txt">
           <strong>SHA-256-Prüfsummen</strong>
           <span>ZIP und DMG prüfen</span>
         </a>
@@ -1542,7 +1542,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Neu in v1.4.0</p><h2 id="large-document-editor-title">Große Dokumente bleiben reaktionsschnell, ohne alles auf einmal zu laden.</h2><p>Der macOS-Editor von Neon arbeitet direkt mit der Datei auf dem Datenträger und hält einen begrenzten virtuellen Bereich um die gerade bearbeitete Stelle aktiv. So wird nicht bei jeder Änderung ein vollständiger Dokumentpuffer neu aufgebaut, während der normale Bearbeitungsablauf erhalten bleibt.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.5 herunterladen</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 auf macOS mit Zeilennummern, Tabs und kompakten Symbolleisten"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Neu in v1.4.0</p><h2 id="large-document-editor-title">Große Dokumente bleiben reaktionsschnell, ohne alles auf einmal zu laden.</h2><p>Der macOS-Editor von Neon arbeitet direkt mit der Datei auf dem Datenträger und hält einen begrenzten virtuellen Bereich um die gerade bearbeitete Stelle aktiv. So wird nicht bei jeder Änderung ein vollständiger Dokumentpuffer neu aufgebaut, während der normale Bearbeitungsablauf erhalten bleibt.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.6 herunterladen</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 auf macOS mit Zeilennummern, Tabs und kompakten Symbolleisten"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Dateibasierte Editorarchitektur</p><h2>Bearbeiten, scrollen, auswählen und sichern — ohne das ganze Dokument neu aufzubauen.</h2><p>Der virtuelle Bereich folgt der Scrollposition und bewahrt Cursor und Auswahl, wenn er das aktive Fenster ersetzt. Syntaxarbeit und Zeilenlayout bleiben auf den sichtbaren Bereich begrenzt.</p><p>Kodierung, Zeilenenden, externe Änderungen und atomisches Sichern bleiben Teil desselben Dateiablaufs. Dateien ab 100 MB öffnen als klar gekennzeichnete schreibgeschützte Teilvorschau zur sicheren Prüfung.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funktionen für große Dokumente"><div class="markdown-feature-point"><strong>Begrenzter Bereich</strong><span>Nur das aktive Bearbeitungsfenster bleibt beim Navigieren durch große Dateien aktiv.</span></div><div class="markdown-feature-point"><strong>Sichtbares zuerst</strong><span>Zeilenlayout und Syntaxfärbung konzentrieren sich auf den sichtbaren Inhalt.</span></div><div class="markdown-feature-point"><strong>Sicherer Dateiablauf</strong><span>Auswahl, Kodierung, Zeilenenden, externe Änderungen und atomisches Sichern bleiben erhalten.</span></div><div class="markdown-feature-point"><strong>Schutz bei Teilansicht</strong><span>Dateien ab 100 MB bleiben prüfbar, ohne einen übergroßen Editorpuffer zu riskieren.</span></div></div>
     </section>
@@ -1687,7 +1687,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Neu in v1.2.1</p><h2 id="release-1-2-1-title">Eine klarere Symbolleiste für jedes Apple-Gerät.</h2><p>Version 1.2.1 bringt plattformoptimierte Symbolleisten-Voreinstellungen mit kompakten Symbolen und einheitlichen Steuerelementen für macOS, iPadOS und iOS. In den Einstellungen können Sie Standard-, Fokus-, Entwickler-, Review- oder vollständige Workflows konfigurieren; iOS behält dabei seine transparente Statusleiste.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.5 herunterladen</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="v1.4.1-Symbolleisten-Screenshot öffnen"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Symbolleisten-Voreinstellungen in Neon Vision Editor"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Neu in v1.2.1</p><h2 id="release-1-2-1-title">Eine klarere Symbolleiste für jedes Apple-Gerät.</h2><p>Version 1.2.1 bringt plattformoptimierte Symbolleisten-Voreinstellungen mit kompakten Symbolen und einheitlichen Steuerelementen für macOS, iPadOS und iOS. In den Einstellungen können Sie Standard-, Fokus-, Entwickler-, Review- oder vollständige Workflows konfigurieren; iOS behält dabei seine transparente Statusleiste.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.6 herunterladen</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="v1.4.1-Symbolleisten-Screenshot öffnen"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Symbolleisten-Voreinstellungen in Neon Vision Editor"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Symbolleisten-Voreinstellungen und Layoutstabilität</p><h2>Die benötigten Werkzeuge wählen, ohne das Dokument zu verlieren.</h2><p>Kompakte Beschriftungen halten Symbolleisten auf macOS und iPadOS lesbar; auf dem iPhone bleiben sie platzsparend symbolorientiert. Voreinstellungen erleichtern den Wechsel zwischen täglicher Bearbeitung, fokussiertem Schreiben, Entwicklung, Review und dem vollständigen Arbeitsbereich.</p><p>Außerdem stellt das Release die transparente iOS-Statusleiste und Navigationsfläche wieder her, ohne das bestehende Editor- oder Vorschau-Layout zu ändern.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funktionen von Version 1.2.1"><div class="markdown-feature-point"><strong>Plattformoptimierte Symbolleisten</strong><span>Kompakte, einheitliche Steuerelemente für macOS, iPadOS und iOS.</span></div><div class="markdown-feature-point"><strong>Fünf Arbeitsbereichs-Voreinstellungen</strong><span>Standard, Fokus, Entwickler, Review und vollständig.</span></div><div class="markdown-feature-point"><strong>Klarere Anpassung</strong><span>Symbolleisten- und Projektleistenaktionen in den Einstellungen konfigurieren.</span></div><div class="markdown-feature-point"><strong>Stabile iOS-Flächen</strong><span>Transparente Statusleiste und bestehendes Layout beibehalten.</span></div></div>
     </section>
@@ -1697,7 +1697,7 @@
         <p class="eyebrow">Neu in v1.2.0</p>
         <h2 id="release-1-2-title">PDFs und Projektdateien in denselben Review-Workflow integrieren.</h2>
         <p>Version 1.2.0 erweitert Neon über Quelltext und Markdown hinaus. PDFs und PNGs werden Teil einer responsiven Projektübersicht, während PDF-Markierungen und verknüpfte Markdown-Notizen den Kontext beim Lesen erhalten.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.5 herunterladen</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.6 herunterladen</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1757,17 +1757,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.7.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.1">v1.7.1 — Stabilere Fenster, Auswahl und App-Store-Builds</a></h3>
-              <span class="release-date">9 September 2026</span>
-            </div>
-            <p>Behebt das Verschieben von Fenstern, die Textauswahl auf iPhone und iPad, die Darstellung der Willkommenstour und die iOS-App-Store-Paketierung.</p>
-            <div class="release-tags"><span>Fenster</span><span>Auswahl</span><span>App Store</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1800,7 +1789,7 @@
             <div class="release-tags"><span>Vorschau</span><span>Leistung</span><span>Projekte</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1809,6 +1798,17 @@
             </div>
             <p>Hält feine Scrollbewegungen auf dem schnellen AppKit-Pfad, vermeidet redundante Minimap-Aktualisierungen und stellt das Verschieben nativer macOS-Tabs wieder her.</p>
             <div class="release-tags"><span>Editor</span><span>Leistung</span><span>Tabs</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.7.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">v1.7.6 — Stabile Editorzeilen beim Scrollen</a></h3>
+              <span class="release-date">12 September 2026</span>
+            </div>
+            <p>Zeichnet beim Scrollen den sichtbaren Core-Text-Bereich neu und verhindert überlagerte oder abgeschnittene Zeilen in langen und umbrochenen Dokumenten.</p>
+            <div class="release-tags"><span>Editor</span><span>Scrollen</span><span>macOS</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1944,7 +1944,7 @@
           <strong>Kommandozeilenhelfer</strong>
           <span>Optionalen <code>nve</code> Befehl installieren und verwenden →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
           <strong>Versionshinweise</strong>
           <span>Änderungen im neuesten stabilen Build →</span>
         </a>
@@ -2018,7 +2018,7 @@
       <h2 id="closing-title">Ein leichter Editor, der Ihre laufende Arbeit respektiert.</h2>
       <p>Laden Sie den neuesten direkten macOS-Build, verfolgen Sie die Entwicklung auf GitHub oder testen Sie die App-Store- und TestFlight-Versionen auf Apple-Geräten.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">Neuester Release</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">Neuester Release</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/es/index.html
+++ b/site/es/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es" data-static-release-version="v1.7.5">
+<html lang="es" data-static-release-version="v1.7.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.7.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
+      "softwareVersion": "1.7.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1375,9 +1375,9 @@
         <h1 id="page-title">Un flujo de trabajo más seguro para texto, Markdown y código.</h1>
         <p class="lede">Para escritores de Markdown y desarrolladores, Neon Vision Editor conserva lo mejor de un editor ligero: archivos rápidos, código claro, vistas completas y documentos compartidos sin sorpresas.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">Descargar para Mac <span class="sr-only">versión </span><span data-latest-version>v1.7.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">Descargar para Mac <span class="sr-only">versión </span><span data-latest-version>v1.7.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">View in App Store</a>
-          <a class="hero-release-link" href="#release-timeline">Novedades de <span data-latest-version>v1.7.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">Novedades de <span data-latest-version>v1.7.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1430,15 +1430,15 @@
           <h3>Descarga de Mac notarizada</h3>
           <p>La última versión estable directa, firmada y notarizada por Apple, con el asistente opcional de línea de comandos.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
-            <span>Build <strong data-latest-build>1044</strong></span>
+            <span data-latest-version>v1.7.6</span>
+            <span>Build <strong data-latest-build>1045</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">
             Descargar DMG
           </a>
         </article>
@@ -1448,7 +1448,7 @@
           <h3>Homebrew</h3>
           <p>Instala la misma versión estable y notarizada de macOS mediante el Cask oficial de Homebrew.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
+            <span data-latest-version>v1.7.6</span>
             <span>macOS 15+</span>
             <span>Cask oficial</span>
           </div>
@@ -1487,14 +1487,14 @@
             <span>Publicada mediante el proceso de release de macOS verificado.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
-          <strong><span data-latest-version>v1.7.5</span> · Build <span data-latest-build>1044</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
+          <strong><span data-latest-version>v1.7.6</span> · Build <span data-latest-build>1045</span></strong>
           <span>Última versión estable</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/SHA256SUMS.txt">
           <strong>SHA-256 checksums</strong>
           <span>Verifica ZIP y DMG</span>
         </a>
@@ -1541,7 +1541,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Novedades de v1.4.0</p><h2 id="large-document-editor-title">Los documentos grandes siguen siendo ágiles sin cargarlo todo a la vez.</h2><p>El editor de macOS de Neon trabaja ahora directamente con el archivo en disco y mantiene una ventana virtual limitada alrededor de la parte que estás editando. Así evita reconstruir un búfer completo en cada cambio y conserva el flujo de edición habitual.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.7.5</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 en macOS con números de línea, pestañas y controles compactos"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Novedades de v1.4.0</p><h2 id="large-document-editor-title">Los documentos grandes siguen siendo ágiles sin cargarlo todo a la vez.</h2><p>El editor de macOS de Neon trabaja ahora directamente con el archivo en disco y mantiene una ventana virtual limitada alrededor de la parte que estás editando. Así evita reconstruir un búfer completo en cada cambio y conserva el flujo de edición habitual.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.7.6</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 en macOS con números de línea, pestañas y controles compactos"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Arquitectura de editor basada en archivos</p><h2>Edita, desplázate, selecciona y guarda sin reconstruir todo el documento.</h2><p>La ventana virtual sigue la posición de desplazamiento y conserva el cursor y la selección al sustituir la ventana activa. El trabajo de sintaxis y el diseño de líneas se limitan al rango visible.</p><p>La codificación, los finales de línea, los cambios externos y los guardados atómicos siguen formando parte del mismo flujo de archivo. Los archivos de 100 MB o más se abren como una vista parcial de solo lectura claramente identificada.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funciones para documentos grandes"><div class="markdown-feature-point"><strong>Ventana limitada</strong><span>Solo la ventana de edición activa permanece cargada al recorrer archivos grandes.</span></div><div class="markdown-feature-point"><strong>Primero lo visible</strong><span>El diseño de líneas y el coloreado de sintaxis se concentran en el contenido en pantalla.</span></div><div class="markdown-feature-point"><strong>Flujo de archivo seguro</strong><span>Se conservan selección, codificación, finales de línea, cambios externos y guardados atómicos.</span></div><div class="markdown-feature-point"><strong>Protección de vista parcial</strong><span>Los archivos de 100 MB o más se pueden inspeccionar sin un búfer sobredimensionado.</span></div></div>
     </section>
@@ -1686,7 +1686,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Novedades de v1.2.1</p><h2 id="release-1-2-1-title">Una barra de herramientas más clara para cada dispositivo Apple.</h2><p>La versión 1.2.1 añade ajustes de barra de herramientas optimizados para cada plataforma, con símbolos compactos y controles coherentes en macOS, iPadOS e iOS. Configura los flujos estándar, centrado, desarrollo, revisión o completo desde Ajustes, mientras iOS conserva su barra de estado transparente.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.7.5</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Abrir la captura de ajustes de barra de herramientas v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Ajustes de barra de herramientas en Neon Vision Editor"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Novedades de v1.2.1</p><h2 id="release-1-2-1-title">Una barra de herramientas más clara para cada dispositivo Apple.</h2><p>La versión 1.2.1 añade ajustes de barra de herramientas optimizados para cada plataforma, con símbolos compactos y controles coherentes en macOS, iPadOS e iOS. Configura los flujos estándar, centrado, desarrollo, revisión o completo desde Ajustes, mientras iOS conserva su barra de estado transparente.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.7.6</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Abrir la captura de ajustes de barra de herramientas v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Ajustes de barra de herramientas en Neon Vision Editor"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Ajustes de barra de herramientas y estabilidad del diseño</p><h2>Elige las herramientas que necesitas sin perder el documento.</h2><p>Las etiquetas compactas mantienen legibles las barras de macOS y iPadOS, mientras que el iPhone prioriza los iconos cuando el espacio es limitado. Los ajustes facilitan cambiar entre edición diaria, escritura enfocada, desarrollo, revisión y el espacio completo.</p><p>La versión también restaura la composición transparente de la barra de estado y la superficie de navegación de iOS sin cambiar el diseño existente.</p></div></div>
       <div class="markdown-feature-points" aria-label="Funciones de la versión 1.2.1"><div class="markdown-feature-point"><strong>Barras optimizadas por plataforma</strong><span>Controles compactos y coherentes para macOS, iPadOS e iOS.</span></div><div class="markdown-feature-point"><strong>Cinco ajustes preestablecidos</strong><span>Estándar, enfocado, desarrollador, revisión y completo.</span></div><div class="markdown-feature-point"><strong>Personalización más clara</strong><span>Configura acciones de la barra y del proyecto desde Ajustes.</span></div><div class="markdown-feature-point"><strong>Superficies estables en iOS</strong><span>Conserva la barra de estado transparente y el diseño existente.</span></div></div>
     </section>
@@ -1696,7 +1696,7 @@
         <p class="eyebrow">Novedades de v1.2.0</p>
         <h2 id="release-1-2-title">Integra PDF y archivos de proyecto en el mismo flujo de revisión.</h2>
         <p>La versión 1.2.0 amplía Neon más allá de los archivos de código y Markdown. Los PDF y PNG pueden formar parte de una vista de proyecto adaptable, mientras que los resaltados PDF y las notas Markdown vinculadas conservan el contexto del documento.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.7.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Descargar v1.7.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1752,17 +1752,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.7.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.1">v1.7.1 — Ventanas, selección y builds del App Store más estables</a></h3>
-              <span class="release-date">9 September 2026</span>
-            </div>
-            <p>Corrige el movimiento de ventanas, la selección de texto en iPhone y iPad, la apariencia de la bienvenida y el empaquetado iOS para el App Store.</p>
-            <div class="release-tags"><span>Ventanas</span><span>Selección</span><span>App Store</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1795,7 +1784,7 @@
             <div class="release-tags"><span>Vista previa</span><span>Rendimiento</span><span>Proyectos</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1804,6 +1793,17 @@
             </div>
             <p>Mantiene los pequeños desplazamientos en la ruta rápida de AppKit, evita actualizaciones redundantes del minimapa y restaura el movimiento de pestañas nativas de macOS.</p>
             <div class="release-tags"><span>Editor</span><span>Rendimiento</span><span>Pestañas</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.7.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">v1.7.6 — Líneas estables al desplazarse</a></h3>
+              <span class="release-date">12 September 2026</span>
+            </div>
+            <p>Redibuja la región visible de Core Text durante el desplazamiento y evita líneas superpuestas o recortadas en documentos largos con ajuste de línea.</p>
+            <div class="release-tags"><span>Editor</span><span>Desplazamiento</span><span>macOS</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1939,7 +1939,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
           <strong>Release notes</strong>
           <span>Cambios de la última versión estable →</span>
         </a>
@@ -2013,7 +2013,7 @@
       <h2 id="closing-title">Un editor ligero que respeta el trabajo en curso.</h2>
       <p>Get the latest direct macOS build, follow development on GitHub, or try the App Store and TestFlight versións across Apple devices.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">Última versión</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">Última versión</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr" data-static-release-version="v1.7.5">
+<html lang="fr" data-static-release-version="v1.7.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.7.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
+      "softwareVersion": "1.7.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1375,9 +1375,9 @@
         <h1 id="page-title">Un workflow plus sûr pour le texte, Markdown et le code.</h1>
         <p class="lede">Pour les auteurs Markdown et les développeurs, Neon Vision Editor conserve les atouts d’un éditeur léger : fichiers rapides, source claire, aperçus complets et documents partagés sans surprise.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">Télécharger pour Mac <span class="sr-only">version </span><span data-latest-version>v1.7.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">Télécharger pour Mac <span class="sr-only">version </span><span data-latest-version>v1.7.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">Voir dans l’App Store</a>
-          <a class="hero-release-link" href="#release-timeline">Nouveautés de <span data-latest-version>v1.7.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">Nouveautés de <span data-latest-version>v1.7.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1430,15 +1430,15 @@
           <h3>Téléchargement Mac notarisé</h3>
           <p>Le dernier build direct stable, signé et notarisé par Apple, avec l’assistant en ligne de commande facultatif.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
-            <span>Build <strong data-latest-build>1044</strong></span>
+            <span data-latest-version>v1.7.6</span>
+            <span>Build <strong data-latest-build>1045</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">
             Télécharger DMG
           </a>
         </article>
@@ -1448,7 +1448,7 @@
           <h3>Homebrew</h3>
           <p>Installez le même build macOS stable et notarisé via le cask Homebrew officiel.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
+            <span data-latest-version>v1.7.6</span>
             <span>macOS 15+</span>
             <span>Cask officiel</span>
           </div>
@@ -1487,14 +1487,14 @@
             <span>Publié via le chemin de release macOS vérifié.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
-          <strong><span data-latest-version>v1.7.5</span> · Build <span data-latest-build>1044</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
+          <strong><span data-latest-version>v1.7.6</span> · Build <span data-latest-build>1045</span></strong>
           <span>Dernière version stable</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/SHA256SUMS.txt">
           <strong>Sommes SHA-256</strong>
           <span>Vérifiez le ZIP et le DMG</span>
         </a>
@@ -1541,7 +1541,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Nouveautés de v1.4.0</p><h2 id="large-document-editor-title">Les documents volumineux restent réactifs sans tout charger d’un coup.</h2><p>L’éditeur macOS de Neon travaille désormais à partir du fichier sur le disque et maintient une fenêtre virtuelle limitée autour de la zone en cours d’édition. Il évite ainsi de reconstruire tout le tampon du document à chaque modification tout en conservant le flux d’édition habituel.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.7.5</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 sur macOS avec numéros de ligne, onglets et commandes compactes"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">Nouveautés de v1.4.0</p><h2 id="large-document-editor-title">Les documents volumineux restent réactifs sans tout charger d’un coup.</h2><p>L’éditeur macOS de Neon travaille désormais à partir du fichier sur le disque et maintient une fenêtre virtuelle limitée autour de la zone en cours d’édition. Il évite ainsi de reconstruire tout le tampon du document à chaque modification tout en conservant le flux d’édition habituel.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.7.6</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 sur macOS avec numéros de ligne, onglets et commandes compactes"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Architecture d’éditeur basée sur les fichiers</p><h2>Modifiez, faites défiler, sélectionnez et enregistrez sans reconstruire tout le document.</h2><p>La fenêtre virtuelle suit le défilement et préserve le curseur et la sélection lorsqu’elle remplace la fenêtre active. Le travail de syntaxe et la mise en page des lignes restent limités à la zone visible.</p><p>Encodage, fins de ligne, gestion des modifications externes et enregistrements atomiques restent dans le même flux de fichier. Les fichiers de 100 Mo ou plus s’ouvrent en aperçu partiel clairement signalé, en lecture seule.</p></div></div>
       <div class="markdown-feature-points" aria-label="Fonctionnalités pour documents volumineux"><div class="markdown-feature-point"><strong>Fenêtre limitée</strong><span>Seule la fenêtre d’édition active reste chargée dans les grands fichiers.</span></div><div class="markdown-feature-point"><strong>Priorité au visible</strong><span>La mise en page et la coloration syntaxique se concentrent sur le contenu affiché.</span></div><div class="markdown-feature-point"><strong>Flux de fichier sûr</strong><span>Sélections, encodage, fins de ligne, modifications externes et enregistrements atomiques sont préservés.</span></div><div class="markdown-feature-point"><strong>Protection d’aperçu</strong><span>Les fichiers de 100 Mo ou plus restent inspectables sans tampon surdimensionné.</span></div></div>
     </section>
@@ -1686,7 +1686,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Nouveautés de v1.2.1</p><h2 id="release-1-2-1-title">Une barre d’outils plus claire pour chaque appareil Apple.</h2><p>La version 1.2.1 ajoute des préréglages de barre d’outils optimisés pour chaque plateforme, avec des symboles compacts et des commandes cohérentes sur macOS, iPadOS et iOS. Configurez les flux standard, concentré, développement, révision ou complet depuis Réglages, tandis qu’iOS conserve sa barre d’état transparente.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.7.5</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Ouvrir la capture des préréglages de barre d’outils v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Préréglages de barre d’outils dans Neon Vision Editor"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">Nouveautés de v1.2.1</p><h2 id="release-1-2-1-title">Une barre d’outils plus claire pour chaque appareil Apple.</h2><p>La version 1.2.1 ajoute des préréglages de barre d’outils optimisés pour chaque plateforme, avec des symboles compacts et des commandes cohérentes sur macOS, iPadOS et iOS. Configurez les flux standard, concentré, développement, révision ou complet depuis Réglages, tandis qu’iOS conserve sa barre d’état transparente.</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.7.6</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Ouvrir la capture des préréglages de barre d’outils v1.4.1"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Préréglages de barre d’outils dans Neon Vision Editor"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">Préréglages de barre d’outils et stabilité de la mise en page</p><h2>Choisissez vos outils sans perdre le document.</h2><p>Les libellés compacts gardent les barres d’outils macOS et iPadOS lisibles, tandis que l’iPhone privilégie les icônes lorsque l’espace est limité. Les préréglages facilitent le passage entre édition quotidienne, écriture concentrée, développement, révision et espace complet.</p><p>La version restaure également la composition transparente de la barre d’état et de la surface de navigation iOS sans modifier la mise en page existante.</p></div></div>
       <div class="markdown-feature-points" aria-label="Fonctionnalités de la version 1.2.1"><div class="markdown-feature-point"><strong>Barres d’outils optimisées</strong><span>Des contrôles compacts et cohérents sur macOS, iPadOS et iOS.</span></div><div class="markdown-feature-point"><strong>Cinq préréglages</strong><span>Standard, concentré, développeur, révision et complet.</span></div><div class="markdown-feature-point"><strong>Personnalisation plus claire</strong><span>Configurez les actions de la barre d’outils et du projet depuis les réglages.</span></div><div class="markdown-feature-point"><strong>Surfaces iOS stables</strong><span>Conservez la barre d’état transparente et la mise en page existante.</span></div></div>
     </section>
@@ -1696,7 +1696,7 @@
         <p class="eyebrow">Nouveautés de v1.2.0</p>
         <h2 id="release-1-2-title">Intégrez les PDF et les fichiers de projet au même flux de révision.</h2>
         <p>La version 1.2.0 étend Neon au-delà des fichiers source et du Markdown. Les PDF et les PNG peuvent désormais faire partie d’un aperçu de projet réactif, tandis que les surlignages PDF et les notes Markdown associées conservent le contexte de lecture.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.7.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Télécharger v1.7.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1752,17 +1752,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.7.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.1">v1.7.1 — Fenêtres, sélection et builds App Store plus stables</a></h3>
-              <span class="release-date">9 September 2026</span>
-            </div>
-            <p>Corrige le déplacement des fenêtres, la sélection de texte sur iPhone et iPad, l’apparence de l’accueil et le paquet iOS pour l’App Store.</p>
-            <div class="release-tags"><span>Fenêtres</span><span>Sélection</span><span>App Store</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1795,7 +1784,7 @@
             <div class="release-tags"><span>Aperçu</span><span>Performances</span><span>Projets</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1804,6 +1793,17 @@
             </div>
             <p>Conserve les petits défilements sur le chemin AppKit rapide, évite les mises à jour redondantes de la minicarte et rétablit le déplacement des onglets natifs macOS.</p>
             <div class="release-tags"><span>Éditeur</span><span>Performances</span><span>Onglets</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.7.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">v1.7.6 — Lignes stables pendant le défilement</a></h3>
+              <span class="release-date">12 September 2026</span>
+            </div>
+            <p>Redessine la zone Core Text visible pendant le défilement et évite les lignes superposées ou tronquées dans les documents longs avec retour à la ligne.</p>
+            <div class="release-tags"><span>Éditeur</span><span>Défilement</span><span>macOS</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1939,7 +1939,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
           <strong>Release notes</strong>
           <span>Modifications de la dernière version stable →</span>
         </a>
@@ -2013,7 +2013,7 @@
       <h2 id="closing-title">Un éditeur léger qui respecte votre travail en cours.</h2>
       <p>Téléchargez le dernier build macOS direct, suivez le projet sur GitHub ou essayez les versions App Store et TestFlight sur vos appareils Apple.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">Dernière version</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">Dernière version</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-static-release-version="v1.7.5">
+<html lang="en" data-static-release-version="v1.7.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.7.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
+      "softwareVersion": "1.7.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1420,9 +1420,9 @@
         <h1 id="page-title">A safer workflow for text, Markdown, and code.</h1>
         <p class="lede">For Markdown writers and developers, Neon Vision Editor keeps the useful parts of a lightweight editor: fast files, clear source, full previews, and shared documents that do not surprise you.</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">Download for Mac <span class="sr-only">version </span><span data-latest-version>v1.7.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">Download for Mac <span class="sr-only">version </span><span data-latest-version>v1.7.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">View in App Store</a>
-          <a class="hero-release-link" href="#release-timeline">What’s new in <span data-latest-version>v1.7.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">What’s new in <span data-latest-version>v1.7.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1475,15 +1475,15 @@
           <h3>Notarized Mac download</h3>
           <p>The latest stable direct build, signed and notarized by Apple, with the optional command-line helper.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
-            <span>Build <strong data-latest-build>1044</strong></span>
+            <span data-latest-version>v1.7.6</span>
+            <span>Build <strong data-latest-build>1045</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">
             Download DMG
           </a>
         </article>
@@ -1493,7 +1493,7 @@
           <h3>Homebrew</h3>
           <p>Install the same stable, notarized macOS release through the official Homebrew Cask.</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
+            <span data-latest-version>v1.7.6</span>
             <span>macOS 15+</span>
             <span>Official cask</span>
           </div>
@@ -1532,14 +1532,14 @@
             <span>Published through the verified macOS release path.</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
-          <strong><span data-latest-version>v1.7.5</span> · Build <span data-latest-build>1044</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
+          <strong><span data-latest-version>v1.7.6</span> · Build <span data-latest-build>1045</span></strong>
           <span>Latest stable release</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/SHA256SUMS.txt">
           <strong>SHA-256 checksums</strong>
           <span>Verify both ZIP and DMG</span>
         </a>
@@ -1591,7 +1591,7 @@
           <p class="eyebrow">New in v1.4.0</p>
           <h2 id="large-document-editor-title">Large documents stay responsive without loading everything at once.</h2>
           <p>Neon’s macOS editor now works from the file on disk and keeps a bounded virtual viewport around the part you are editing. That avoids rebuilding a complete document buffer for each edit while preserving the normal editing workflow.</p>
-          <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.7.5</a></p>
+          <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.7.6</a></p>
         </div>
         <figure class="media-card editor-core-shot">
           <img src="docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="Neon Vision Editor v1.4.1 macOS editor with line numbers, tabs, and compact toolbar controls">
@@ -1644,7 +1644,7 @@
           <p class="eyebrow">New in v1.2.1</p>
           <h2 id="release-1-2-1-title">A clearer toolbar for every Apple device.</h2>
           <p>Version 1.2.1 adds platform-optimized toolbar presets with compact symbols and consistent controls across macOS, iPadOS, and iOS. Configure standard, focused, developer, review, or complete workflows from Settings, while iOS keeps its transparent status-bar composition.</p>
-          <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.7.5</a></p>
+          <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.7.6</a></p>
         </div>
         <figure class="media-card">
           <a class="screenshot-link" href="docs/images/release-v1-4-1-toolbar-presets.png" aria-label="Open the v1.4.1 toolbar presets screenshot">
@@ -1673,7 +1673,7 @@
         <p class="eyebrow">New in v1.2.0</p>
         <h2 id="release-1-2-title">Bring PDFs and project files into the same review workflow.</h2>
         <p>Version 1.2.0 expands Neon beyond source files and Markdown. PDFs and PNGs can now become part of a responsive project overview, while PDF highlights and attached Markdown notes keep research connected to the document you are reading.</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.7.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">Download v1.7.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1857,17 +1857,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.7.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.1">v1.7.1 — Safer document transitions</a></h3>
-              <span class="release-date">9 September 2026</span>
-            </div>
-            <p>Keeps native document tabs, sidebars, editor surfaces, and Settings visually consistent across macOS, iOS, and iPadOS window modes.</p>
-            <div class="release-tags"><span>Welcome Tour</span><span>Windows</span><span>Layout stability</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1900,7 +1889,7 @@
             <div class="release-tags"><span>Markdown</span><span>Preview</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1909,6 +1898,17 @@
             </div>
             <p>Restores reliable drag-to-reorder behavior for native macOS document tabs.</p>
             <div class="release-tags"><span>Windows</span><span>AppKit stability</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.7.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">v1.7.6 — A more deliberate workflow</a></h3>
+              <span class="release-date">12 September 2026</span>
+            </div>
+            <p>Keeps macOS editor text intact while scrolling long or wrapped documents.</p>
+            <div class="release-tags"><span>Markdown</span><span>Preview</span><span>AppKit stability</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -2046,7 +2046,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
           <strong>Release notes</strong>
           <span>What changed in the latest stable build →</span>
         </a>
@@ -2120,7 +2120,7 @@
       <h2 id="closing-title">A lightweight editor that respects the work already in progress.</h2>
       <p>Get the latest direct macOS build, follow development on GitHub, or try the App Store and TestFlight versions across Apple devices.</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">Latest release</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">Latest release</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -1461,7 +1461,7 @@
           <h3>App Store</h3>
           <p>Apple-managed installation across the supported Apple platforms. Store releases can trail the direct channel during review.</p>
           <div class="channel-meta">
-            <span data-app-store-version>iOS / iPadOS · v1.7.1</span>
+            <span data-app-store-version>iOS / iPadOS · v1.7.2</span>
             <span>macOS · v1.5.4 (review)</span>
             <span>visionOS · v0.8.8</span>
             <span>Last verified · 28 August 2026</span>

--- a/site/ja/index.html
+++ b/site/ja/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ja" data-static-release-version="v1.7.5">
+<html lang="ja" data-static-release-version="v1.7.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.7.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
+      "softwareVersion": "1.7.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1375,9 +1375,9 @@
         <h1 id="page-title">テキスト、Markdown、コードのための安全なワークフロー。</h1>
         <p class="lede">Markdownを書く人や開発者のために、Neon Vision Editorは軽量エディタの便利な部分を保ちます。高速なファイル、明快なソース、完全なプレビュー、予期せぬ変更をしない共有ドキュメント。</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">Mac版をダウンロード <span class="sr-only">バージョン </span><span data-latest-version>v1.7.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">Mac版をダウンロード <span class="sr-only">バージョン </span><span data-latest-version>v1.7.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Storeで見る</a>
-          <a class="hero-release-link" href="#release-timeline">新機能 <span data-latest-version>v1.7.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">新機能 <span data-latest-version>v1.7.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1430,15 +1430,15 @@
           <h3>公証済みMacダウンロード</h3>
           <p>Appleが署名・公証した最新の安定版と、任意のコマンドラインヘルパー。</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
-            <span>Build <strong data-latest-build>1044</strong></span>
+            <span data-latest-version>v1.7.6</span>
+            <span>Build <strong data-latest-build>1045</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">
             ダウンロード DMG
           </a>
         </article>
@@ -1448,7 +1448,7 @@
           <h3>Homebrew</h3>
           <p>公式Homebrew Caskから同じ安定した公証済みmacOSリリースをインストールします。</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
+            <span data-latest-version>v1.7.6</span>
             <span>macOS 15+</span>
             <span>公式Cask</span>
           </div>
@@ -1487,14 +1487,14 @@
             <span>確認済みのmacOSリリース経路で公開。</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
-          <strong><span data-latest-version>v1.7.5</span> · Build <span data-latest-build>1044</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
+          <strong><span data-latest-version>v1.7.6</span> · Build <span data-latest-build>1045</span></strong>
           <span>最新の安定版</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/SHA256SUMS.txt">
           <strong>SHA-256 checksums</strong>
           <span>ZIPとDMGを確認</span>
         </a>
@@ -1541,7 +1541,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">v1.4.0 の新機能</p><h2 id="large-document-editor-title">大きな文書も、すべてを一度に読み込まず軽快に操作できます。</h2><p>Neon の macOS エディタはディスク上のファイルを直接扱い、編集中の箇所の周囲だけに限定した仮想ビューポートを維持します。編集のたびに文書全体のバッファを再構築せず、通常の編集ワークフローを保ちます。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.5 をダウンロード</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="行番号、タブ、コンパクトなツールバーを備えた macOS 版 Neon Vision Editor v1.4.1"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">v1.4.0 の新機能</p><h2 id="large-document-editor-title">大きな文書も、すべてを一度に読み込まず軽快に操作できます。</h2><p>Neon の macOS エディタはディスク上のファイルを直接扱い、編集中の箇所の周囲だけに限定した仮想ビューポートを維持します。編集のたびに文書全体のバッファを再構築せず、通常の編集ワークフローを保ちます。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.6 をダウンロード</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="行番号、タブ、コンパクトなツールバーを備えた macOS 版 Neon Vision Editor v1.4.1"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">ファイルベースのエディタアーキテクチャ</p><h2>文書全体を作り直さずに、編集、スクロール、選択、保存。</h2><p>仮想ビューポートはスクロール位置を追い、アクティブなウィンドウを置き換える際にもカーソルと選択を保ちます。構文処理と行レイアウトは表示範囲に限定されます。</p><p>エンコーディング、改行、外部変更の処理、アトミック保存は同じファイルワークフローに残ります。100 MB 以上のファイルは、安全に確認できる明確な読み取り専用の部分プレビューとして開きます。</p></div></div>
       <div class="markdown-feature-points" aria-label="大きな文書の編集機能"><div class="markdown-feature-point"><strong>限定された表示範囲</strong><span>大きなファイルでも、操作中の編集ウィンドウだけを維持します。</span></div><div class="markdown-feature-point"><strong>見えている作業を優先</strong><span>行レイアウトと構文色分けは画面上の内容に集中します。</span></div><div class="markdown-feature-point"><strong>安全なファイル処理</strong><span>選択、エンコーディング、改行、外部変更、アトミック保存を保持します。</span></div><div class="markdown-feature-point"><strong>部分表示の保護</strong><span>100 MB 以上のファイルも過大なバッファを作らずに確認できます。</span></div></div>
     </section>
@@ -1686,7 +1686,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">v1.2.1 の新機能</p><h2 id="release-1-2-1-title">すべての Apple デバイスに、より明快なツールバーを。</h2><p>バージョン 1.2.1 では、macOS、iPadOS、iOS で一貫したコンパクトな操作を提供する、プラットフォームに最適化されたツールバープリセットを追加しました。設定から標準、集中、開発、レビュー、完全なワークフローを選択でき、iOS は透明なステータスバー構成を維持します。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.5 をダウンロード</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="v1.4.1 のツールバープリセット画面を開く"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Neon Vision Editor のツールバープリセット"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">v1.2.1 の新機能</p><h2 id="release-1-2-1-title">すべての Apple デバイスに、より明快なツールバーを。</h2><p>バージョン 1.2.1 では、macOS、iPadOS、iOS で一貫したコンパクトな操作を提供する、プラットフォームに最適化されたツールバープリセットを追加しました。設定から標準、集中、開発、レビュー、完全なワークフローを選択でき、iOS は透明なステータスバー構成を維持します。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.6 をダウンロード</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="v1.4.1 のツールバープリセット画面を開く"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Neon Vision Editor のツールバープリセット"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">ツールバープリセットとレイアウトの安定性</p><h2>必要なツールを選びながら、文書を見失わない。</h2><p>macOS と iPadOS ではコンパクトなラベルでツールバーを読みやすくし、iPhone では限られた空間に合わせてアイコンを優先します。日常の編集、集中した執筆、開発、レビュー、完全なワークスペースを簡単に切り替えられます。</p><p>iOS の透明なステータスバーとナビゲーション面も、既存のエディタやプレビューのレイアウトを変えずに復元しました。</p></div></div>
       <div class="markdown-feature-points" aria-label="v1.2.1 の機能"><div class="markdown-feature-point"><strong>プラットフォーム最適化ツールバー</strong><span>macOS、iPadOS、iOS でコンパクトかつ一貫した操作。</span></div><div class="markdown-feature-point"><strong>5つのワークスペースプリセット</strong><span>標準、集中、開発者、レビュー、完全。</span></div><div class="markdown-feature-point"><strong>分かりやすいカスタマイズ</strong><span>設定からツールバーとプロジェクト操作を構成できます。</span></div><div class="markdown-feature-point"><strong>安定した iOS サーフェス</strong><span>透明なステータスバーと既存のレイアウトを維持します。</span></div></div>
     </section>
@@ -1696,7 +1696,7 @@
         <p class="eyebrow">v1.2.0 の新機能</p>
         <h2 id="release-1-2-title">PDF とプロジェクトファイルを同じレビュー ワークフローに。</h2>
         <p>v1.2.0 では、Neon の対象がソースファイルと Markdown だけでなくなりました。PDF と PNG をレスポンシブなプロジェクト概要に含め、PDF のハイライトと関連付けた Markdown ノートで、読んでいる文書のコンテキストを保てます。</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.5 をダウンロード</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">v1.7.6 をダウンロード</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1752,17 +1752,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.7.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.1">v1.7.1 — ウインドウ、選択、App Store ビルドを安定化</a></h3>
-              <span class="release-date">9 September 2026</span>
-            </div>
-            <p>ウインドウ移動、iPhone と iPad のテキスト選択、ウェルカムツアーの外観、iOS App Store パッケージを修正します。</p>
-            <div class="release-tags"><span>ウインドウ</span><span>選択</span><span>App Store</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1795,7 +1784,7 @@
             <div class="release-tags"><span>プレビュー</span><span>パフォーマンス</span><span>プロジェクト</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1804,6 +1793,17 @@
             </div>
             <p>細かなスクロールを高速な AppKit 経路で処理し、不要なミニマップ更新を避け、macOS のネイティブタブ移動を復元します。</p>
             <div class="release-tags"><span>エディタ</span><span>パフォーマンス</span><span>タブ</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.7.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">v1.7.6 — スクロール中も安定したエディタ行</a></h3>
+              <span class="release-date">12 September 2026</span>
+            </div>
+            <p>スクロール時に表示中の Core Text 領域だけを再描画し、長い折り返し文書で行が重なったり欠けたりする問題を防ぎます。</p>
+            <div class="release-tags"><span>エディタ</span><span>スクロール</span><span>macOS</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1939,7 +1939,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
           <strong>Release notes</strong>
           <span>What changed in the latest stable build →</span>
         </a>
@@ -2013,7 +2013,7 @@
       <h2 id="closing-title">進行中の作業を尊重する軽量エディタ。</h2>
       <p>最新のmacOS直接配布版を入手し、GitHubで開発を追い、Appleデバイス向けApp StoreとTestFlight版を試せます。</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">最新リリース</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">最新リリース</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>

--- a/site/zh-Hans/index.html
+++ b/site/zh-Hans/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-Hans" data-static-release-version="v1.7.5">
+<html lang="zh-Hans" data-static-release-version="v1.7.6">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,9 +33,9 @@
       "name": "Neon Vision Editor",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS 15+, iOS 18.6+, iPadOS 18.6+, visionOS 26.5+",
-      "softwareVersion": "1.7.5",
-      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
-      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5",
+      "softwareVersion": "1.7.6",
+      "downloadUrl": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
+      "releaseNotes": "https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6",
       "license": "https://www.apache.org/licenses/LICENSE-2.0",
       "image": "https://h3pdesign.github.io/Neon-Vision-Editor/docs/media/neon-social-card.jpg",
       "sameAs": [
@@ -1375,9 +1375,9 @@
         <h1 id="page-title">更安全的文本、Markdown 和代码工作流。</h1>
         <p class="lede">面向 Markdown 作者和开发者，Neon Vision Editor 保留轻量编辑器的实用部分：快速文件、清晰源码、完整预览，以及不会带来意外的共享文档。</p>
         <div class="hero-actions">
-          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">下载 Mac 版 <span class="sr-only">版本 </span><span data-latest-version>v1.7.5</span></a>
+          <a class="button release-download-button" data-release-asset="Neon.Vision.Editor.app.dmg" href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">下载 Mac 版 <span class="sr-only">版本 </span><span data-latest-version>v1.7.6</span></a>
           <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">在 App Store 中查看</a>
-          <a class="hero-release-link" href="#release-timeline">新功能 <span data-latest-version>v1.7.5</span><span aria-hidden="true">→</span></a>
+          <a class="hero-release-link" href="#release-timeline">新功能 <span data-latest-version>v1.7.6</span><span aria-hidden="true">→</span></a>
         </div>
       </div>
       <div class="hero-art">
@@ -1430,15 +1430,15 @@
           <h3>已公证的 Mac 下载</h3>
           <p>最新稳定的直接版本，由 Apple 签名并公证，包含可选的命令行助手。</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
-            <span>Build <strong data-latest-build>1044</strong></span>
+            <span data-latest-version>v1.7.6</span>
+            <span>Build <strong data-latest-build>1045</strong></span>
             <span>macOS 15+</span>
             <span>Apple Silicon · Intel</span>
           </div>
           <a
             class="button"
             data-release-asset="Neon.Vision.Editor.app.dmg"
-            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/Neon.Vision.Editor.app.dmg">
+            href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/Neon.Vision.Editor.app.dmg">
             下载 DMG
           </a>
         </article>
@@ -1448,7 +1448,7 @@
           <h3>Homebrew</h3>
           <p>通过官方 Homebrew Cask 安装同一稳定且已公证的 macOS 版本。</p>
           <div class="channel-meta">
-            <span data-latest-version>v1.7.5</span>
+            <span data-latest-version>v1.7.6</span>
             <span>macOS 15+</span>
             <span>官方 Cask</span>
           </div>
@@ -1487,14 +1487,14 @@
             <span>通过经过验证的 macOS 发布流程发布。</span>
           </div>
         </div>
-        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
-          <strong><span data-latest-version>v1.7.5</span> · Build <span data-latest-build>1044</span></strong>
+        <a class="trust-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
+          <strong><span data-latest-version>v1.7.6</span> · Build <span data-latest-build>1045</span></strong>
           <span>最新稳定版</span>
         </a>
         <a
           class="trust-link"
           data-release-asset="SHA256SUMS.txt"
-          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.5/SHA256SUMS.txt">
+          href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/download/v1.7.6/SHA256SUMS.txt">
           <strong>SHA-256 checksums</strong>
           <span>验证 ZIP 和 DMG</span>
         </a>
@@ -1541,7 +1541,7 @@
     </section>
 
     <section class="feature-band" id="large-document-editor" aria-labelledby="large-document-editor-title">
-      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">v1.4.0 新功能</p><h2 id="large-document-editor-title">大型文档无需一次性加载全部内容，也能保持流畅响应。</h2><p>Neon 的 macOS 编辑器现在直接基于磁盘中的文件工作，并在正在编辑的位置周围保留一个有界的虚拟视口。这样无需在每次编辑时重建完整文档缓冲区，同时保留正常的编辑流程。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.7.5</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="带行号、标签页和紧凑工具栏控件的 macOS 版 Neon Vision Editor v1.4.1"></figure></div>
+      <div class="editor-core-hero"><div class="section-title"><p class="eyebrow">v1.4.0 新功能</p><h2 id="large-document-editor-title">大型文档无需一次性加载全部内容，也能保持流畅响应。</h2><p>Neon 的 macOS 编辑器现在直接基于磁盘中的文件工作，并在正在编辑的位置周围保留一个有界的虚拟视口。这样无需在每次编辑时重建完整文档缓冲区，同时保留正常的编辑流程。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.7.6</a></p></div><figure class="media-card editor-core-shot"><img src="../docs/images/release-v1-4-1-editor-core.png" width="1499" height="1215" loading="lazy" decoding="async" alt="带行号、标签页和紧凑工具栏控件的 macOS 版 Neon Vision Editor v1.4.1"></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">基于文件的编辑器架构</p><h2>无需重建整篇文档，也能编辑、滚动、选择和保存。</h2><p>虚拟视口会跟随滚动位置，并在替换活动窗口时保留光标和选区。语法处理和行布局仅限于可见范围。</p><p>编码、换行符、外部更改处理和原子保存仍属于同一文件工作流。100 MB 及以上的文件会作为清晰标记的只读部分预览打开，便于安全检查。</p></div></div>
       <div class="markdown-feature-points" aria-label="大型文档编辑功能"><div class="markdown-feature-point"><strong>有界视口</strong><span>浏览大型文件时，只有当前编辑窗口保持活动。</span></div><div class="markdown-feature-point"><strong>优先处理可见内容</strong><span>行布局和语法着色聚焦于屏幕上的内容。</span></div><div class="markdown-feature-point"><strong>安全文件工作流</strong><span>保留选区、编码、换行符、外部更改和原子保存。</span></div><div class="markdown-feature-point"><strong>部分预览保护</strong><span>100 MB 及以上的文件可安全检查，无需超大编辑器缓冲区。</span></div></div>
     </section>
@@ -1686,7 +1686,7 @@
     </section>
 
     <section class="feature-band" id="release-1-2-1" aria-labelledby="release-1-2-1-title">
-      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">v1.2.1 新功能</p><h2 id="release-1-2-1-title">为每台 Apple 设备提供更清晰的工具栏。</h2><p>1.2.1 版为 macOS、iPadOS 和 iOS 加入了针对平台优化的工具栏预设，提供紧凑的图标和一致的控制项。你可在“设置”中配置标准、专注、开发、审阅或完整工作流，同时 iOS 保留透明状态栏布局。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.7.5</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="打开 v1.4.1 工具栏预设截图"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Neon Vision Editor 中的工具栏预设"></a></figure></div>
+      <div class="toolbar-presets-hero"><div class="section-title"><p class="eyebrow">v1.2.1 新功能</p><h2 id="release-1-2-1-title">为每台 Apple 设备提供更清晰的工具栏。</h2><p>1.2.1 版为 macOS、iPadOS 和 iOS 加入了针对平台优化的工具栏预设，提供紧凑的图标和一致的控制项。你可在“设置”中配置标准、专注、开发、审阅或完整工作流，同时 iOS 保留透明状态栏布局。</p><p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.7.6</a></p></div><figure class="media-card"><a class="screenshot-link" href="../docs/images/release-v1-4-1-toolbar-presets.png" aria-label="打开 v1.4.1 工具栏预设截图"><img src="../docs/images/release-v1-4-1-toolbar-presets.png" width="2024" height="1874" loading="lazy" decoding="async" alt="Neon Vision Editor 中的工具栏预设"></a></figure></div>
       <div class="story"><div class="story-copy"><p class="story-tag">工具栏预设与布局稳定性</p><h2>选择需要的工具，同时保留当前文档。</h2><p>紧凑标签让 macOS 和 iPadOS 工具栏更易阅读；在空间有限的 iPhone 上，工具栏优先使用图标。预设让你可以在日常编辑、专注写作、开发、审阅和完整工作区之间快速切换。</p><p>此版本还恢复了 iOS 透明的状态栏和导航表面组合，同时不改变现有的编辑器和预览布局。</p></div></div>
       <div class="markdown-feature-points" aria-label="v1.2.1 功能"><div class="markdown-feature-point"><strong>平台优化工具栏</strong><span>为 macOS、iPadOS 和 iOS 提供紧凑且一致的控件。</span></div><div class="markdown-feature-point"><strong>五种工作区预设</strong><span>标准、专注、开发者、审阅和完整。</span></div><div class="markdown-feature-point"><strong>更清晰的自定义</strong><span>在设置中配置工具栏和项目侧栏操作。</span></div><div class="markdown-feature-point"><strong>稳定的 iOS 表面</strong><span>保留透明状态栏组合和现有布局。</span></div></div>
     </section>
@@ -1696,7 +1696,7 @@
         <p class="eyebrow">v1.2.0 新功能</p>
         <h2 id="release-1-2-title">将 PDF 与项目文件纳入同一套审阅工作流。</h2>
         <p>v1.2.0 将 Neon 的范围从源文件和 Markdown 扩展到更多项目内容。PDF 和 PNG 现在可以加入响应式项目概览，PDF 高亮与关联的 Markdown 笔记则让研究内容始终连接到正在阅读的文档。</p>
-        <p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.7.5</a></p>
+        <p class="markdown-feature-cta"><a class="button" href="#get-neon">下载 v1.7.6</a></p>
       </div>
       <div class="story">
         <div class="story-copy">
@@ -1752,17 +1752,6 @@
       <div class="release-timeline" aria-label="Recent Neon Vision Editor release timeline">
         <!-- RELEASE_TIMELINE:START -->
         <article class="release-entry">
-          <div class="release-marker" aria-hidden="true">1.7.1</div>
-          <div class="release-card">
-            <div class="release-card-header">
-              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.1">v1.7.1 — 更稳定的窗口、文本选择与 App Store 构建</a></h3>
-              <span class="release-date">9 September 2026</span>
-            </div>
-            <p>修复窗口移动、iPhone 和 iPad 文本选择、欢迎导览外观以及 iOS App Store 打包问题。</p>
-            <div class="release-tags"><span>窗口</span><span>选择</span><span>App Store</span></div>
-          </div>
-        </article>
-        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.2</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1795,7 +1784,7 @@
             <div class="release-tags"><span>预览</span><span>性能</span><span>项目</span></div>
           </div>
         </article>
-        <article class="release-entry current">
+        <article class="release-entry">
           <div class="release-marker" aria-hidden="true">1.7.5</div>
           <div class="release-card">
             <div class="release-card-header">
@@ -1804,6 +1793,17 @@
             </div>
             <p>让细微滚动保持在快速的 AppKit 路径上，避免重复更新小地图，并恢复 macOS 原生标签页拖动排序。</p>
             <div class="release-tags"><span>编辑器</span><span>性能</span><span>标签页</span></div>
+          </div>
+        </article>
+        <article class="release-entry current">
+          <div class="release-marker" aria-hidden="true">1.7.6</div>
+          <div class="release-card">
+            <div class="release-card-header">
+              <h3><a href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">v1.7.6 — 滚动时保持编辑器行稳定</a></h3>
+              <span class="release-date">12 September 2026</span>
+            </div>
+            <p>滚动时仅重绘可见的 Core Text 区域，避免长文档和自动换行文档中的文本行重叠或被裁切。</p>
+            <div class="release-tags"><span>编辑器</span><span>滚动</span><span>macOS</span></div>
           </div>
         </article>
         <!-- RELEASE_TIMELINE:END -->
@@ -1939,7 +1939,7 @@
           <strong>Command-line helper</strong>
           <span>Install and use the optional <code>nve</code> command →</span>
         </a>
-        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">
+        <a class="help-link" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">
           <strong>Release notes</strong>
           <span>What changed in the latest stable build →</span>
         </a>
@@ -2013,7 +2013,7 @@
       <h2 id="closing-title">尊重现有工作的轻量编辑器。</h2>
       <p>获取最新的 macOS 直接版本，在 GitHub 关注开发，或在 Apple 设备上试用 App Store 和 TestFlight 版本。</p>
       <div class="cta-row">
-        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.5">最新版本</a>
+        <a class="button" data-latest-release-url href="https://github.com/h3pdesign/Neon-Vision-Editor/releases/tag/v1.7.6">最新版本</a>
         <a class="button secondary" href="https://apps.apple.com/de/app/neon-vision-editor/id6758950965">App Store</a>
         <a class="button secondary" href="https://testflight.apple.com/join/YWB2fGAP">TestFlight</a>
       </div>


### PR DESCRIPTION
## Summary
- sync the protected v1.7.6 release commit back into develop
- include the signed Sparkle appcast and verified post-release documentation updates
- preserve the complete release history after publication

## Validation
- primary v1.7.6 hosted release workflow completed successfully
- notarization, app payload, ZIP, DMG, checksum, uploaded-asset, and signed-appcast checks passed
- live Sparkle feed reports v1.7.6 build 1045

## Risk
Low: history-only protected branch synchronization of already published and verified release commits.

## Summary by Sourcery

Sync the verified v1.7.6 release into develop and update product, distribution, and documentation metadata to reflect the new stable build.

New Features:
- Publish the v1.7.6 release with improved macOS editor scrolling that keeps long and wrapped document lines visible and intact.
- Expose v1.7.6 build 1045 through the signed Sparkle appcast and current release download channels.

Bug Fixes:
- Prevent stale AppKit rendering from overlapping or clipping editor lines during macOS scrolling.

Enhancements:
- Update architecture notes, release metadata, welcome-tour content, README, localized site pages, and release timelines for v1.7.6 while advancing the next release target to v1.7.7.

Build:
- Synchronize project and prepared-release metadata with the v1.7.6 release.

Deployment:
- Update the published release feeds and download references to the verified v1.7.6 artifacts.

Documentation:
- Refresh user-facing release documentation and localized website content to identify v1.7.6 as the latest stable release.

Tests:
- Record the completed release validation for notarization, packaged artifacts, checksums, uploaded assets, and signed appcast.

Chores:
- Synchronize the verified v1.7.6 release history back into the development branch.