### PR TITLE
Fix local Developer ID archives with App Groups

### DIFF
--- a/Neon Vision Editor.xcodeproj/project.pbxproj
+++ b/Neon Vision Editor.xcodeproj/project.pbxproj
@@ -1272,6 +1272,9 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				NVE_APP_PROFILE_NAME = "Neon Vision Editor Developer ID G2 App 20260609003243";
+				NVE_DEVELOPER_ID_IDENTITY = 62FF5D2240E836ABBA9571C2C370C94C3A789EFF;
+				NVE_SHARE_EXTENSION_PROFILE_NAME = "Neon Vision Editor Developer ID G2 Share Extension 20260609003246";
 				ONLY_ACTIVE_ARCH = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = USE_FOUNDATION_MODELS;
@@ -1303,7 +1306,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=iphonesimulator*]" = "Neon Vision Editor/Neon Vision Editor iOS.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Neon Vision Editor/Neon Vision Editor macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "$(NVE_DEVELOPER_ID_IDENTITY)";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
 				CURRENT_PROJECT_VERSION = 1045;
@@ -1487,7 +1490,7 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Share Extension/Neon Vision Editor Share Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "$(NVE_DEVELOPER_ID_IDENTITY)";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
 				CURRENT_PROJECT_VERSION = 1045;
@@ -1794,7 +1797,9 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = "Neon Vision Editor Quick Look/Neon Vision Editor Quick Look.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "$(NVE_DEVELOPER_ID_IDENTITY)";
 				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_STYLE[sdk=macosx*]" = Manual;
 				CURRENT_PROJECT_VERSION = 1045;
 				DEVELOPMENT_TEAM = CS727NF72U;
 				ENABLE_APP_SANDBOX = YES;

--- a/scripts/ci/test_release_workflow.py
+++ b/scripts/ci/test_release_workflow.py
@@ -49,6 +49,31 @@ def fixture(root):
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
+    def test_release_github_has_local_developer_id_signing_defaults(self):
+        project = (ROOT / prep.PROJECT).read_text()
+        self.assertIn(
+            'NVE_APP_PROFILE_NAME = "Neon Vision Editor Developer ID G2 App 20260609003243";',
+            project,
+        )
+        self.assertIn(
+            'NVE_SHARE_EXTENSION_PROFILE_NAME = "Neon Vision Editor Developer ID G2 Share Extension 20260609003246";',
+            project,
+        )
+        self.assertIn(
+            "NVE_DEVELOPER_ID_IDENTITY = 62FF5D2240E836ABBA9571C2C370C94C3A789EFF;",
+            project,
+        )
+        self.assertEqual(
+            project.count(
+                '\"CODE_SIGN_IDENTITY[sdk=macosx*]\" = \"$(NVE_DEVELOPER_ID_IDENTITY)\";'
+            ),
+            3,
+        )
+        self.assertEqual(
+            project.count('\"CODE_SIGN_STYLE[sdk=macosx*]\" = Manual;'),
+            3,
+        )
+
     def test_all_notarized_archives_force_developer_id_signing(self):
         workflows = (
             ".github/workflows/release-github-only.yml",


### PR DESCRIPTION
## Summary
- provide Release-GitHub defaults for the existing Developer ID App Group profiles
- pin the matching Developer ID certificate for the app, Share extension, and Quick Look extension
- add a regression test for the local signing defaults while retaining GitHub workflow overrides

## Verification
- Xcode Release-GitHub archive succeeded without command-line signing overrides
- Developer ID export succeeded with the matching certificate
- `codesign --verify --deep --strict` passed for the exported app and both extensions
- 41 release-workflow tests passed
- macOS, iOS Simulator, iPad Simulator, and visionOS matrix passed

## Summary by Sourcery

Fix Developer ID signing defaults so local App Group archives use the intended profiles and certificate.

Bug Fixes:
- Ensure local Developer ID archives use the correct App Group profiles and matching certificate for the app and extensions.

Tests:
- Add regression coverage for local Developer ID signing defaults while preserving GitHub workflow overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Updated macOS release builds to use configurable Developer ID signing settings.
  - Applied consistent signing configuration across the main app, Share Extension, and Quick Look components.
  - Added manual signing support for the Quick Look component to improve release build reliability.

- **Quality Assurance**
  - Added automated checks to verify the required Developer ID signing configuration for GitHub release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->