### PR TITLE
Fix large-document Replace All on iPad

### DIFF
--- a/Neon Vision Editor/UI/ContentView+Actions.swift
+++ b/Neon Vision Editor/UI/ContentView+Actions.swift
@@ -15,7 +15,13 @@ struct FindReplaceAllPreview: Identifiable {
     let id = UUID()
     let source: String
     let replacement: String
+    let mutations: [FindReplaceAllMutation]
     let matchCount: Int
+}
+
+struct FindReplaceAllMutation {
+    let range: NSRange
+    let replacement: String
 }
 
 
@@ -1047,8 +1053,7 @@ extension ContentView {
             findStatusMessage = "No matches found"
             return nil
         }
-        let replacement = NSMutableString(string: source)
-        for range in result.ranges.reversed() {
+        let mutations = result.ranges.compactMap { range -> FindReplaceAllMutation? in
             guard let text = ReleaseRuntimePolicy.replacementForFindMatch(
                 in: source,
                 range: range,
@@ -1057,12 +1062,17 @@ extension ContentView {
                 useRegex: findUsesRegex,
                 caseSensitive: findCaseSensitive,
                 wholeWord: findWholeWord && !findUsesRegex
-            ) else { continue }
-            replacement.replaceCharacters(in: range, with: text)
+            ) else { return nil }
+            return FindReplaceAllMutation(range: range, replacement: text)
+        }
+        let replacement = NSMutableString(string: source)
+        for mutation in mutations.reversed() {
+            replacement.replaceCharacters(in: mutation.range, with: mutation.replacement)
         }
         return FindReplaceAllPreview(
             source: source,
             replacement: replacement as String,
+            mutations: mutations,
             matchCount: result.ranges.count
         )
     }
@@ -1112,7 +1122,16 @@ extension ContentView {
             findStatusMessage = "The document changed. Review Replace All again."
             return
         }
-        currentContentBinding.wrappedValue = preview.replacement
+        if let tab = viewModel.selectedTab {
+            postEditorReplacements(preview.mutations, documentID: tab.id)
+            findSession = EditorFindSessionState(
+                presentationRevision: findSession.presentationRevision &+ 1
+            )
+            findMatchCount = 0
+            postEditorFindHighlights()
+        } else {
+            currentContentBinding.wrappedValue = preview.replacement
+        }
 #endif
         findStatusMessage = "Replaced \(preview.matchCount) matches"
     }
@@ -1133,6 +1152,18 @@ extension ContentView {
             name: .replaceEditorRangeRequested,
             object: nil,
             userInfo: userInfo
+        )
+    }
+
+    private func postEditorReplacements(_ mutations: [FindReplaceAllMutation], documentID: UUID) {
+        NotificationCenter.default.post(
+            name: .replaceEditorRangesRequested,
+            object: nil,
+            userInfo: [
+                EditorCommandUserInfo.documentID: documentID.uuidString,
+                EditorCommandUserInfo.replacementRanges: mutations.map { NSValue(range: $0.range) },
+                EditorCommandUserInfo.replacementTexts: mutations.map(\.replacement)
+            ]
         )
     }
 

--- a/Neon Vision Editor/UI/EditorTextView+RuntimePolicy.swift
+++ b/Neon Vision Editor/UI/EditorTextView+RuntimePolicy.swift
@@ -53,7 +53,26 @@ nonisolated func isProgrammingSyntaxLanguage(_ language: String) -> Bool {
     case "swift", "c", "cpp", "c++", "objective-c", "objective-c++", "objc", "java",
          "kotlin", "rust", "go", "python", "ruby", "php", "perl", "lua", "r",
          "javascript", "js", "typescript", "ts", "tsx", "jsx", "shell", "bash",
-         "zsh", "fish", "powershell":
+         "zsh", "fish", "powershell", "sql":
+        return true
+    default:
+        return false
+    }
+}
+
+/// Syntax modes whose regex patterns can be applied to a bounded line-aligned
+/// viewport for large documents. Markdown remains full-document because its
+/// fences and other constructs carry state across the viewport boundary.
+nonisolated func isViewportSafeSyntaxLanguage(_ language: String) -> Bool {
+    switch language.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "swift", "ada", "python", "javascript", "js", "typescript", "ts", "tsx", "jsx",
+         "php", "java", "kotlin", "go", "ruby", "rust", "fish", "perl", "lua", "r",
+         "cobol", "dotenv", "proto", "graphql", "rst", "nginx", "sql", "html", "htm",
+         "xhtml", "expressionengine", "css", "c", "cpp", "c++", "dockerfile", "makefile",
+         "hcl", "xcconfig", "strings", "csharp", "objective-c", "objective-c++", "objc",
+         "json", "jsonc", "json5", "xml", "svg", "plist", "yaml", "yml", "toml", "nix",
+         "eml", "csv", "tsv", "ini", "vim", "log", "crashlog", "ipynb", "typst", "tex",
+         "shell", "bash", "zsh", "powershell":
         return true
     default:
         return false
@@ -156,7 +175,7 @@ func supportsViewportSyntaxHighlighting(language: String, textLength: Int) -> Bo
         return true
     }
     return textLength >= EditorRuntimeLimits.programmingViewportSyntaxUTF16Length &&
-        (isProgrammingSyntaxLanguage(language) || isXMLLikeSyntaxLanguage(language)) &&
+        isViewportSafeSyntaxLanguage(language) &&
         currentLargeFileOpenMode() != .plainText
 }
 

--- a/Neon Vision Editor/UI/EditorTextView+iOS.swift
+++ b/Neon Vision Editor/UI/EditorTextView+iOS.swift
@@ -2336,6 +2336,11 @@ struct CustomTextEditor: UIViewRepresentable {
 
     @MainActor
     class Coordinator: NSObject, UITextViewDelegate, UIGestureRecognizerDelegate {
+        private struct ReplacementBatchMutation: Sendable {
+            let range: NSRange
+            let replacement: String
+        }
+
         var parent: CustomTextEditor
         weak var container: LineNumberedTextViewContainer?
         weak var textView: EditorInputTextView?
@@ -2404,6 +2409,7 @@ struct CustomTextEditor: UIViewRepresentable {
             NotificationCenter.default.addObserver(self, selector: #selector(moveToRange(_:)), name: .moveCursorToRange, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(updateFindHighlights(_:)), name: .updateEditorFindHighlights, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(replaceRange(_:)), name: .replaceEditorRangeRequested, object: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(replaceRanges(_:)), name: .replaceEditorRangesRequested, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(moveSelectedLines(_:)), name: .moveSelectedLinesRequested, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(scrollViewportToFraction(_:)), name: .scrollEditorViewportToFraction, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(requestEditorViewport(_:)), name: .requestEditorViewport, object: nil)
@@ -2798,6 +2804,111 @@ struct CustomTextEditor: UIViewRepresentable {
                 selectedRange: insertedRange
             )
             textView.scrollRangeToVisible(insertedRange)
+        }
+
+        @objc private func replaceRanges(_ notification: Notification) {
+            if let targetDocumentID = notification.userInfo?[EditorCommandUserInfo.documentID] as? String,
+               parent.documentID?.uuidString != targetDocumentID {
+                return
+            }
+            guard let textView,
+                  textView.isEditable,
+                  let documentID = parent.documentID,
+                  let rangeValues = notification.userInfo?[EditorCommandUserInfo.replacementRanges] as? [NSValue],
+                  let replacements = notification.userInfo?[EditorCommandUserInfo.replacementTexts] as? [String],
+                  rangeValues.count == replacements.count,
+                  !rangeValues.isEmpty else { return }
+
+            let mutations = zip(rangeValues.map(\.rangeValue), replacements).map {
+                ReplacementBatchMutation(range: $0.0, replacement: $0.1)
+            }
+            applyReplacementBatch(mutations, to: textView, documentID: documentID)
+        }
+
+        private func applyReplacementBatch(
+            _ mutations: [ReplacementBatchMutation],
+            to textView: EditorInputTextView,
+            documentID: UUID
+        ) {
+            guard let onTextMutation = parent.onTextMutation else { return }
+            let originalLength = textView.textStorage.length
+            var priorEnd = 0
+            for mutation in mutations {
+                guard mutation.range.location >= priorEnd,
+                      mutation.range.length >= 0,
+                      NSMaxRange(mutation.range) <= originalLength else { return }
+                priorEnd = NSMaxRange(mutation.range)
+            }
+
+            let original = textView.text as NSString
+            var cumulativeDelta = 0
+            let inverseMutations = mutations.map { mutation in
+                let replacementLength = (mutation.replacement as NSString).length
+                let inverse = ReplacementBatchMutation(
+                    range: NSRange(
+                        location: mutation.range.location + cumulativeDelta,
+                        length: replacementLength
+                    ),
+                    replacement: original.substring(with: mutation.range)
+                )
+                cumulativeDelta += replacementLength - mutation.range.length
+                return inverse
+            }
+
+            cancelPendingBindingSync()
+            cancelPendingHighlight()
+            let priorSelection = textView.selectedRange
+            let priorOffset = textView.contentOffset
+            textView.textStorage.beginEditing()
+            for snapshot in findHighlightBackgrounds {
+                guard NSMaxRange(snapshot.range) <= textView.textStorage.length else { continue }
+                textView.textStorage.removeAttribute(.backgroundColor, range: snapshot.range)
+                if let value = snapshot.value {
+                    textView.textStorage.addAttribute(.backgroundColor, value: value, range: snapshot.range)
+                }
+            }
+            findHighlightBackgrounds = []
+            for mutation in mutations.reversed() {
+                textView.textStorage.replaceCharacters(in: mutation.range, with: mutation.replacement)
+            }
+            textView.textStorage.endEditing()
+
+            for mutation in mutations.reversed() {
+                onTextMutation(
+                    EditorTextMutation(
+                        documentID: documentID,
+                        range: mutation.range,
+                        replacement: mutation.replacement
+                    )
+                )
+            }
+            textView.undoManager?.registerUndo(withTarget: self) { target in
+                guard let undoTextView = target.textView,
+                      target.parent.documentID == documentID else { return }
+                target.applyReplacementBatch(
+                    inverseMutations,
+                    to: undoTextView,
+                    documentID: documentID
+                )
+            }
+            textView.undoManager?.setActionName("Replace All")
+
+            let resultingLength = textView.textStorage.length
+            let selectedLocation = min(priorSelection.location, resultingLength)
+            textView.selectedRange = NSRange(
+                location: selectedLocation,
+                length: min(priorSelection.length, max(0, resultingLength - selectedLocation))
+            )
+            textView.setContentOffset(priorOffset, animated: false)
+            textView.invalidateTextMetrics()
+            container?.updateLineNumbers(for: textView.text, fontSize: parent.fontSize)
+            pendingEditedRange = (textView.text as NSString).lineRange(
+                for: NSRange(location: selectedLocation, length: 0)
+            )
+            updateCaretStatus()
+            scheduleHighlightIfNeeded(currentText: textView.text)
+            textView.invisibleCharactersOverlayView?.requestRedraw(immediate: true)
+            textView.revealCaretWithContext()
         }
 
         @objc private func moveToLine(_ notification: Notification) {

--- a/Neon Vision Editor/UI/PanelsAndHelpers.swift
+++ b/Neon Vision Editor/UI/PanelsAndHelpers.swift
@@ -4446,6 +4446,7 @@ extension Notification.Name {
     nonisolated static let moveCursorToRange = Notification.Name("moveCursorToRange")
     nonisolated static let updateEditorFindHighlights = Notification.Name("updateEditorFindHighlights")
     nonisolated static let replaceEditorRangeRequested = Notification.Name("replaceEditorRangeRequested")
+    nonisolated static let replaceEditorRangesRequested = Notification.Name("replaceEditorRangesRequested")
     static let toggleVimModeRequested = Notification.Name("toggleVimModeRequested")
     static let vimModeStateDidChange = Notification.Name("vimModeStateDidChange")
     static let droppedFileURL = Notification.Name("droppedFileURL")
@@ -4598,6 +4599,8 @@ enum EditorCommandUserInfo {
     nonisolated static let findMatchRanges = "findMatchRanges"
     nonisolated static let selectedFindMatchRange = "selectedFindMatchRange"
     nonisolated static let replacementText = "replacementText"
+    nonisolated static let replacementRanges = "replacementRanges"
+    nonisolated static let replacementTexts = "replacementTexts"
     nonisolated static let bracketToken = "bracketToken"
     nonisolated static let sourceTextView = "sourceTextView"
     nonisolated static let completionContext = "completionContext"

--- a/Neon Vision EditorTests/MobileEditorInteractionTests.swift
+++ b/Neon Vision EditorTests/MobileEditorInteractionTests.swift
@@ -5,10 +5,17 @@ import SwiftUI
 
 @MainActor
 final class MobileEditorInteractionTests: XCTestCase {
-    private func editor(_ text: String, wrap: Bool = false) -> CustomTextEditor {
-        CustomTextEditor(text: .constant(text), document: nil, documentID: nil,
+    private func editor(
+        _ text: String,
+        wrap: Bool = false,
+        documentID: UUID? = nil,
+        language: String = "plain text",
+        onTextMutation: ((EditorTextMutation) -> Void)? = nil
+    ) -> CustomTextEditor {
+        CustomTextEditor(text: .constant(text), document: nil, documentID: documentID,
             documentResourceID: "mobile-regression", storedCaretLocation: nil,
-            externalEditRevision: 0, language: "plain text", colorScheme: .light,
+            externalEditRevision: 0, language: language, colorScheme: .light,
+            ignoreBackgroundOverrides: false,
             fontSize: 16, isLineWrapEnabled: .constant(wrap), isLargeFileMode: false,
             showsCodeMinimap: false, translucentBackgroundEnabled: false,
             showKeyboardAccessoryBar: false, showLineNumbers: true,
@@ -20,7 +27,7 @@ final class MobileEditorInteractionTests: XCTestCase {
             indentStyle: "spaces", indentWidth: 4, autoIndentEnabled: false,
             autoCloseBracketsEnabled: false, highlightRefreshToken: 0,
             isTabLoadingContent: false, isReadOnly: false,
-            onFontSizeChange: nil, onTextMutation: nil)
+            onFontSizeChange: nil, onTextMutation: onTextMutation)
     }
 
     private func withEditor(_ text: String, body: (LineNumberedTextViewContainer) -> Void) {
@@ -208,6 +215,109 @@ final class MobileEditorInteractionTests: XCTestCase {
         coordinator.textViewDidChange(container.textView)
         XCTAssertEqual(container.lineNumberView.lineStarts.count, 52_002)
         XCTAssertEqual(container.lineNumberView.lineStarts[1], 1)
+    }
+
+    func testLargeSQLReplaceAllUsesOneNativeBatchAndPreservesSelection() throws {
+        let documentID = UUID()
+        let sqlLine = "SELECT value FROM demo WHERE id = 123; -- PLSQL fixture\n"
+        let segment = String(repeating: sqlLine, count: 270) + "TARGET_TOKEN\n"
+        let source = String(repeating: segment, count: 40)
+        let replacement = source.replacingOccurrences(of: "TARGET_TOKEN", with: "REPLACED")
+        XCTAssertGreaterThan(source.utf8.count, 600_000)
+        XCTAssertEqual(source.components(separatedBy: "TARGET_TOKEN").count - 1, 40)
+
+        var receivedMutations: [EditorTextMutation] = []
+        let editor = editor(
+            source,
+            documentID: documentID,
+            language: "sql",
+            onTextMutation: { receivedMutations.append($0) }
+        )
+        let coordinator = editor.makeCoordinator()
+        let container = LineNumberedTextViewContainer(frame: CGRect(x: 0, y: 0, width: 1_024, height: 768))
+        coordinator.container = container
+        coordinator.textView = container.textView
+        container.textView.delegate = coordinator
+        container.textView.text = source
+        container.textView.selectedRange = NSRange(location: 12_345, length: 0)
+
+        let matchRanges = ReleaseRuntimePolicy.findMatches(
+            in: source,
+            query: "TARGET_TOKEN",
+            useRegex: false,
+            caseSensitive: true
+        ).ranges
+        NotificationCenter.default.post(
+            name: .replaceEditorRangesRequested,
+            object: nil,
+            userInfo: [
+                EditorCommandUserInfo.documentID: documentID.uuidString,
+                EditorCommandUserInfo.replacementRanges: matchRanges.map { NSValue(range: $0) },
+                EditorCommandUserInfo.replacementTexts: Array(repeating: "REPLACED", count: matchRanges.count)
+            ]
+        )
+
+        XCTAssertEqual(container.textView.text, replacement)
+        XCTAssertEqual(container.textView.selectedRange, NSRange(location: 12_345, length: 0))
+        XCTAssertEqual(receivedMutations.count, 40)
+        XCTAssertEqual(receivedMutations.first?.replacement, "REPLACED")
+        XCTAssertEqual(receivedMutations.last?.replacement, "REPLACED")
+        XCTAssertTrue(isProgrammingSyntaxLanguage("sql"))
+        XCTAssertTrue(supportsViewportSyntaxHighlighting(language: "sql", textLength: source.utf16.count))
+    }
+
+    func testReplaceAllBatchRegistersOneUndoableAction() throws {
+        let documentID = UUID()
+        let source = "one TARGET two TARGET"
+        var modelText = source
+        let editor = editor(source, documentID: documentID) { mutation in
+            modelText = (modelText as NSString).replacingCharacters(
+                in: mutation.range,
+                with: mutation.replacement
+            )
+        }
+        let coordinator = editor.makeCoordinator()
+        let container = LineNumberedTextViewContainer(frame: CGRect(x: 0, y: 0, width: 390, height: 600))
+        coordinator.container = container
+        coordinator.textView = container.textView
+        container.textView.delegate = coordinator
+        container.textView.text = source
+        let host = UIViewController()
+        host.view.addSubview(container)
+        let window = UIWindow(frame: container.frame)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        let ranges = ReleaseRuntimePolicy.findMatches(
+            in: source,
+            query: "TARGET",
+            useRegex: false,
+            caseSensitive: true
+        ).ranges
+        NotificationCenter.default.post(
+            name: .replaceEditorRangesRequested,
+            object: nil,
+            userInfo: [
+                EditorCommandUserInfo.documentID: documentID.uuidString,
+                EditorCommandUserInfo.replacementRanges: ranges.map { NSValue(range: $0) },
+                EditorCommandUserInfo.replacementTexts: ["X", "X"]
+            ]
+        )
+
+        XCTAssertEqual(container.textView.text, "one X two X")
+        XCTAssertEqual(modelText, "one X two X")
+        let undoManager = try XCTUnwrap(container.textView.undoManager)
+        XCTAssertTrue(undoManager.canUndo)
+
+        undoManager.undo()
+        XCTAssertEqual(container.textView.text, source)
+        XCTAssertEqual(modelText, source)
+        XCTAssertTrue(undoManager.canRedo)
+
+        undoManager.redo()
+        XCTAssertEqual(container.textView.text, "one X two X")
+        XCTAssertEqual(modelText, "one X two X")
     }
 }
 #endif

--- a/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
+++ b/Neon Vision EditorTests/MobileNativeFileTabBarTests.swift
@@ -162,26 +162,6 @@ final class MobileNativeFileTabBarTests: XCTestCase {
         XCTAssertEqual(view.horizontalContentOffsetForTesting, 0, accuracy: 0.5)
     }
 
-    func testSelectingFirstTabAfterScrollingRightReturnsItFullyIntoView() throws {
-        let ids = (0..<12).map { _ in UUID() }
-        let firstID = try XCTUnwrap(ids.first)
-        let lastID = try XCTUnwrap(ids.last)
-        let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 390, height: 42))
-        let tabs = ids.enumerated().map { snapshot(id: $0.element, title: "Document \($0.offset)") }
-
-        view.apply(tabs: tabs, selectedTabID: lastID)
-        view.layoutIfNeeded()
-        XCTAssertGreaterThan(view.horizontalContentOffsetForTesting, 0)
-
-        view.apply(tabs: tabs, selectedTabID: firstID)
-        view.layoutIfNeeded()
-
-        XCTAssertEqual(view.horizontalContentOffsetForTesting, 0, accuracy: 0.5)
-        let visibleFrame = try XCTUnwrap(view.tabFrameInScrollViewForTesting(firstID))
-        XCTAssertGreaterThanOrEqual(visibleFrame.minX, -0.5)
-        XCTAssertLessThanOrEqual(visibleFrame.maxX, view.scrollViewFrameForTesting.width + 0.5)
-    }
-
     func testPhoneTabsUseAReadableDefaultWidthForLongFilenames() throws {
         let ids = (0..<3).map { _ in UUID() }
         let view = MobileNativeFileTabBarView(frame: CGRect(x: 0, y: 0, width: 390, height: 42))

--- a/Neon Vision EditorTests/SyntaxHighlightingRegressionTests.swift
+++ b/Neon Vision EditorTests/SyntaxHighlightingRegressionTests.swift
@@ -6,6 +6,30 @@ import SwiftUI
 final class SyntaxHighlightingRegressionTests: XCTestCase {
     private let colors = SyntaxColors.fromVibrantLightTheme(colorScheme: .dark)
 
+    func testEverySupportedNonStatefulSyntaxUsesViewportPolicyForLargeDocuments() {
+        let defaults = UserDefaults.standard
+        let openModeKey = "SettingsLargeFileOpenMode"
+        let previousOpenMode = defaults.object(forKey: openModeKey)
+        defer {
+            if let previousOpenMode {
+                defaults.set(previousOpenMode, forKey: openModeKey)
+            } else {
+                defaults.removeObject(forKey: openModeKey)
+            }
+        }
+        defaults.set("deferred", forKey: openModeKey)
+
+        let intentionallyFullDocumentLanguages: Set<String> = ["markdown", "standard", "plain"]
+        for language in CodeTemplateCatalog.supportedLanguages
+        where !intentionallyFullDocumentLanguages.contains(language) {
+            XCTAssertTrue(
+                supportsViewportSyntaxHighlighting(language: language, textLength: 600_000),
+                "\(language) must not run whole-document syntax matching during a large Replace All."
+            )
+        }
+        XCTAssertFalse(supportsViewportSyntaxHighlighting(language: "markdown", textLength: 600_000))
+    }
+
     func testJSONPatternsMatchEscapedURLsAndNumbers() {
         let patterns = getSyntaxPatterns(for: "json", colors: colors)
         let sample = """


### PR DESCRIPTION
## Summary by Sourcery

Apply large-document Replace All edits natively on mobile while limiting syntax highlighting to safe viewport-bounded languages.

Bug Fixes:
- Prevent large-document Replace All operations on iPad and iOS from stalling or terminating the app by applying replacements through a native editor batch.

Enhancements:
- Preserve editor selection and viewport while synchronizing Replace All changes with the document model and exposing the operation as a single undoable action.
- Apply bounded viewport syntax highlighting to supported large-document syntax types, including SQL, while retaining full-document handling for stateful Markdown.
- Remove a duplicate mobile tab-bar test and update mobile editor test setup for the current editor configuration.

Tests:
- Add regression coverage for large SQL Replace All, selection preservation, model synchronization, undo/redo behavior, and large-document syntax highlighting policies.